### PR TITLE
Fix unknown short battery status

### DIFF
--- a/src/linux.cc
+++ b/src/linux.cc
@@ -2088,7 +2088,7 @@ void get_battery_short_status(char *buffer, unsigned int n, const char *bat)
 		memmove(buffer + 1, buffer + 5, n - 5);
 	} else if (0 != strncmp("AC", buffer, 2)) {
 		buffer[0] = 'U';
-		memmove(buffer + 1, buffer + 11, n - 11);
+		memmove(buffer + 1, buffer + 2, n - 2);
 	}
 }
 


### PR DESCRIPTION
Before, in the case of an unknown battery status (which often happens on my Sony VAIO laptop after waking from sleep), the buffer would be unterminated.

(Although, this memmove trick is a bit odd. It would probably be better to remove the memmove's and put a single buffer[1] = '\0'; at the end of the function).
