### PR TITLE
Wrapper for drawing images with imlib2 and cairo

### DIFF
--- a/lua/CMakeLists.txt
+++ b/lua/CMakeLists.txt
@@ -63,6 +63,17 @@ if(BUILD_LUA_RSVG)
 	set(lua_libs ${lua_libs} conky-rsvg)
 endif(BUILD_LUA_RSVG)
 
+if(BUILD_LUA_CAIRO AND BUILD_LUA_IMLIB2)
+	include_directories(${luacairo_includes} ${luaimlib2_includes} ${CMAKE_CURRENT_SOURCE_DIR})
+	wrap_tolua(luacairo_imlib2_helper_src cairo_imlib2_helper.pkg)
+
+	add_library(conky-cairo_imlib2_helper SHARED ${luacairo_imlib2_helper_src})
+	set_target_properties(conky-cairo_imlib2_helper PROPERTIES OUTPUT_NAME "cairo_imlib2_helper")
+
+	target_link_libraries(conky-cairo_imlib2_helper ${luacairo_libs} ${luaimlib2_libs} ${TOLUA_LIBS})
+	set(lua_libs ${lua_libs} conky-cairo_imlib2_helper)
+endif(BUILD_LUA_CAIRO AND BUILD_LUA_IMLIB2)
+
 install(TARGETS
 	${lua_libs}
 	LIBRARY DESTINATION lib/conky

--- a/lua/cairo_imlib2_helper.pkg
+++ b/lua/cairo_imlib2_helper.pkg
@@ -1,0 +1,5 @@
+$#include <cairo.h>
+$#include <libcairo_imlib2_helper.h>
+
+void cairo_draw_image(const char *, cairo_surface_t *, int, int, double, double,
+                      double * return_scale_w, double * return_scale_h);

--- a/lua/libcairo_imlib2_helper.h
+++ b/lua/libcairo_imlib2_helper.h
@@ -1,0 +1,79 @@
+/* -*- mode: c; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: t -*-
+ *
+ * Conky, a system monitor, based on torsmo
+ *
+ * Please see COPYING for details
+ *
+ * Copyright (c) 2005-2012 Brenden Matthews, Philip Kovacs, et. al.
+ *	(see AUTHORS)
+ * All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef _LIBCAIRO_IMAGE_HELPER_H_
+#define _LIBCAIRO_IMAGE_HELPER_H_
+
+#include <cairo.h>
+#include <Imlib2.h>
+
+void
+cairo_draw_image(const char * file, cairo_surface_t * cs, int x, int y,
+                 double scale_x, double scale_y,
+                 double * return_scale_w, double * return_scale_h)
+{
+  Imlib_Image * image = imlib_load_image(file);
+  if (! image) { return; }
+
+  imlib_context_set_image(image);
+  int w = imlib_image_get_width(), h = imlib_image_get_height();
+
+  double scaled_w = *return_scale_w = scale_x * (double)w
+       , scaled_h = *return_scale_h = scale_y * (double)h;
+
+  /* create temporary image */
+  Imlib_Image premul = imlib_create_image(scaled_w, scaled_h);
+  /* FIXME: add error handling */
+
+  /* fill with opaque black */
+  imlib_context_set_image(premul);
+  imlib_context_set_color(0, 0, 0, 255);
+  imlib_image_fill_rectangle(0, 0, scaled_w, scaled_h);
+
+  /* blend source image on top -
+   * in effect this multiplies the rgb values by alpha */
+  imlib_blend_image_onto_image(image, 0, 0, 0, w, h, 0, 0, scaled_w, scaled_h);
+
+  /* and use the alpha channel of the source image */
+  imlib_image_copy_alpha_to_image(image, 0, 0);
+
+  /* now pass the result to cairo */
+  cairo_surface_t * result = cairo_image_surface_create_for_data(
+    (void *) imlib_image_get_data_for_reading_only(),
+    CAIRO_FORMAT_ARGB32, scaled_w, scaled_h, sizeof(DATA32) * scaled_w);
+
+  cairo_t * cr = cairo_create(cs);
+  cairo_set_source_surface(cr, result, x, y);
+  cairo_paint(cr);
+
+  imlib_context_set_image(image);
+  imlib_free_image();
+  imlib_context_set_image(premul);
+  imlib_free_image();
+
+  cairo_destroy(cr);
+  cairo_surface_destroy(result);
+}
+
+#endif /* _LIBCAIRO_IMAGE_HELPER_H_ */


### PR DESCRIPTION
One problem is, that tolua/lua does not handle plain data pointers
properly. Therefore something like

local surface = cairo_image_surface_create_for_data(
    imlib_image_get_data_for_reading_only(), ..

will fail using the lua bindings. Hence this wrapper, which adds
a function which be used to draw an imlib image to a cairo surface.

This also addresses another issue, drawing images with a transparent
background (e.g. gifs or pngs) to the cairo surface properly. Apparently
the image format of imlib is incompatible to cairos which uses
pre-multiplied data. This is also explained in the cairo documentation.
A fix for this issue is to blend the image with another alpha mask to
get the correct values. The code and explanation for this was taken from

  http://lists.cairographics.org/archives/cairo/2008-March/013492.html

Executive Summary: This wrapper function can load (transparent) images
(e.g. gif or png) from a file by using imlib and draw them on a cairo
surface.
