### PR TITLE
Make diskio work with /dev/disk/*/* paths

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -98,9 +98,14 @@ const char *dev_name(const char *path)
 
 #define DEV_NAME(x) \
   x != NULL && strlen(x) > 5 && strncmp(x, "/dev/", 5) == 0 ? x + 5 : x
-	if ((buflen = readlink(path, buf, 254)) == -1)
+	// realpath is POSIX.1-2008 and does what we need here.
+	char *actualpath = realpath(path, 0);
+	if (actualpath == 0) {
 		return DEV_NAME(path);
-	buf[buflen] = '\0';
+	}
+	strncpy(buf, actualpath, 254);
+	free(actualpath);
+	buf[254] = '\0';
 	return DEV_NAME(buf);
 #undef DEV_NAME
 }

--- a/src/diskio.c
+++ b/src/diskio.c
@@ -105,7 +105,7 @@ struct diskio_stat *prepare_diskio_stat(const char *s)
 
 void parse_diskio_arg(struct text_object *obj, const char *arg)
 {
-	obj->data.opaque = prepare_diskio_stat(arg);
+	obj->data.opaque = prepare_diskio_stat(dev_name(arg));
 }
 
 /* dir indicates the direction:


### PR DESCRIPTION
This uses the POSIX.1-2008 function realpath; if it does not comply with
the standard, bad things will happen (unspecified behaviour). Linux does
it right from the beginning.
