### PR TITLE
Set uninitialized inotify_fd to -1, not 0

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -2017,7 +2017,7 @@ static void update_text(void)
 }
 
 #ifdef HAVE_SYS_INOTIFY_H
-int inotify_fd;
+int inotify_fd = -1;
 #endif
 
 static void main_loop(void)
@@ -2484,7 +2484,7 @@ static void main_loop(void)
 		} else if (disable_auto_reload.get(*state) && inotify_fd != -1) {
 			inotify_rm_watch(inotify_fd, inotify_config_wd);
 			close(inotify_fd);
-			inotify_fd = inotify_config_wd = 0;
+			inotify_fd = inotify_config_wd = -1;
 		}
 #endif /* HAVE_SYS_INOTIFY_H */
 
@@ -2497,7 +2497,7 @@ static void main_loop(void)
 	if (inotify_fd != -1) {
 		inotify_rm_watch(inotify_fd, inotify_config_wd);
 		close(inotify_fd);
-		inotify_fd = inotify_config_wd = 0;
+		inotify_fd = inotify_config_wd = -1;
 	}
 #endif /* HAVE_SYS_INOTIFY_H */
 }


### PR DESCRIPTION
Currently we set inotify_fd to the value 0 when inotify_fd hasn't been
created yet, or after we close it. But 0 is a valid fd, and we check
for the value -1 to see if it's been initialized. So, if inotify
support is compiled in, but we disable_auto_reload, we can end up
closing fd 0. This can screw up various other things in weird ways,
including that exec'd processes appear to have an invalid stdin.

So, set inotify_fd to -1 to clear all of this up.
