### PR TITLE
Set uninitialized inotify_fd to -1, not 0

### DIFF
--- a/src/conky.c
+++ b/src/conky.c
@@ -3558,7 +3558,7 @@ static void update_text(void)
 }
 
 #ifdef HAVE_SYS_INOTIFY_H
-int inotify_fd;
+int inotify_fd = -1;
 #endif
 
 static void main_loop(void)
@@ -4021,7 +4021,7 @@ static void main_loop(void)
 		} else if (disable_auto_reload && inotify_fd != -1) {
 			inotify_rm_watch(inotify_fd, inotify_config_wd);
 			close(inotify_fd);
-			inotify_fd = inotify_config_wd = 0;
+			inotify_fd = inotify_config_wd = -1;
 		}
 #endif /* HAVE_SYS_INOTIFY_H */
 
@@ -4036,7 +4036,7 @@ static void main_loop(void)
 	if (inotify_fd != -1) {
 		inotify_rm_watch(inotify_fd, inotify_config_wd);
 		close(inotify_fd);
-		inotify_fd = inotify_config_wd = 0;
+		inotify_fd = inotify_config_wd = -1;
 	}
 #endif /* HAVE_SYS_INOTIFY_H */
 }


### PR DESCRIPTION
Set uninitialized inotify_fd to -1, not 0

Currently we set inotify_fd to the value 0 when inotify_fd hasn't been
created yet, or after we close it. But 0 is a valid fd, and we check
for the value -1 to see if it's been initialized. So, if inotify
support is compiled in, but we disable_auto_reload, we can end up
closing fd 0. This can screw up various other things in weird ways,
including that exec'd processes appear to have an invalid stdin.

So, set inotify_fd to -1 to clear all of this up.
(cherry picked from commit f670e70d7c0ffcc602f40aa1856fe085e5800455)
