### PR TITLE
add support for $ibm_thinklight

### DIFF
--- a/doc/variables.xml
+++ b/doc/variables.xml
@@ -1679,6 +1679,16 @@
     <varlistentry>
         <term>
             <command>
+                <option>ibm_thinklight</option>
+            </command>
+        </term>
+        <listitem>If running the IBM ACPI, displays the status of your
+            ThinkLight™. Value is either 'on', 'off' or 'unknown'.
+            <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
                 <option>ibm_volume</option>
             </command>
         </term>

--- a/src/core.cc
+++ b/src/core.cc
@@ -509,6 +509,8 @@ struct text_object *construct_text_object(char *s, const char *arg,
 		obj->callbacks.print = &get_ibm_acpi_volume;
 	END OBJ(ibm_brightness, 0)
 		obj->callbacks.print = &get_ibm_acpi_brightness;
+	END OBJ(ibm_thinklight, 0)
+		obj->callbacks.print = &get_ibm_acpi_thinklight;
 #endif
 	/* information from sony_laptop kernel module
 	 * /sys/devices/platform/sony-laptop */

--- a/src/ibm.h
+++ b/src/ibm.h
@@ -30,6 +30,7 @@ void get_ibm_acpi_fan(struct text_object *, char *, int);
 int get_ibm_acpi_temps(void);
 void get_ibm_acpi_volume(struct text_object *, char *, int);
 void get_ibm_acpi_brightness(struct text_object *, char *, int);
+void get_ibm_acpi_thinklight(struct text_object *, char *, int);
 
 void parse_ibm_temps_arg(struct text_object *, const char *);
 void print_ibm_temps(struct text_object *, char *, int);


### PR DESCRIPTION
Some IBM/Lenovo models come with a light on the top edge of the
display to illuminate the keyboard. This either reports 'on', 'off'
or 'unknown'.
