### PR TITLE
Support for graph output on console/shell

### DIFF
--- a/doc/config_settings.xml
+++ b/doc/config_settings.xml
@@ -75,6 +75,17 @@
     <varlistentry>
         <term>
             <command>
+                <option>console_graph_ticks</option>
+            </command>
+        </term>
+        <listitem>A comma-separated list of strings to use as the bars of a graph output
+        to console/shell. The first list item is used for the minimum bar height and the
+        last item is used for the maximum. Example: " ,_,▁,▂,▃,▄,▅,▆,▇,█".
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
                 <option>cpu_avg_samples</option>
             </command>
         </term>


### PR DESCRIPTION
This patch adds support for `cpugraph`, `memgraph`, etc to `out_to_console` and `out_to_ncurses`. This is particularly useful when used in conjunction with a text-only status bar common on tiling window managers (e.g. i3bar, dzen2, xmobar).
