### PR TITLE
Fix regression regarding $eval

### DIFF
--- a/src/conky.c
+++ b/src/conky.c
@@ -1108,9 +1108,8 @@ void generate_text_internal(char *p, int p_max_size,
 #endif /* IMLIB2 */
 			OBJ(eval) {
 				char p2[p_max_size];
-				evaluate(obj->data.s, p, p_max_size);
+				evaluate(obj->data.s, p2, p_max_size);
 				// Parse the output again
-				strncpy(p2, p, p_max_size);
 				evaluate(p2, p, p_max_size);
 			}
 			OBJ(cat) {


### PR DESCRIPTION
In order to be useful $eval needs to evaluate the given string twice,
for example: `${eval $${downspeedf ${gw_iface}}}` should first yield
e.g. '${downspeedf eth0}', then the second evaluation yields the desired
result.
Commit 2fa5f97edbc2c77833bdef3ba0ac5663d5eb25d6 refactored some parsing bits
into the evaluate function, but this caused $eval to call
parse_conky_vars only once.
