### PR TITLE
Enable X11 backing store

### DIFF
--- a/src/x11.cc
+++ b/src/x11.cc
@@ -618,7 +618,7 @@ static void init_window(lua::state &l __attribute__((unused)), bool own)
 
 #ifdef OWN_WINDOW
 	if (own) {
-		int depth = 0, flags = CWOverrideRedirect;
+		int depth = 0, flags = CWOverrideRedirect | CWBackingStore;
 		Visual *visual = NULL;
 		
 		if (!find_desktop_window(&window.root, &window.desktop)) {


### PR DESCRIPTION
Currently, the X11 backing store is disabled when conky creates a window, even though we specify 'Always' in the xsetwindowattributes structure. This is because we don't give CWBackingStore in the values mask that specifies which members of our attribute structure are set. Without the x11 backing store, if you obscure part of the conky window then unobscure it, the unobscured part is blank until conky gets around to updating it (which can be a significant amount of time, if we're blocked on the network or a dns lookup or something). This can also be tested easily by sending conky a TSTP or similar signal (and CONTing it to draw again).

I'm not 100% sure that this is a mistake; it's possible the backing store was turned off because it uses more memory or something (but I would imagine not a whole lot for conky). And it really seems like a mistake since we set 'Always' but not the appropriate mask. So I assume this should just always be turned on, but I could imagine maybe someone would rather have it as an option or something. In any case, it fixes that really annoying behavior for me.
