### PR TITLE
Specify diskio by device label

### DIFF
--- a/doc/variables.xml
+++ b/doc/variables.xml
@@ -881,8 +881,9 @@
             <option>(device)</option>
         </term>
         <listitem>Displays current disk IO. Device is optional, and
-        takes the form of sda for /dev/sda. Individual partitions
-        are allowed. 
+       takes the form of sda for /dev/sda. A block device label can
+       be specified with label:foo. Individual partitions are also
+       allowed.
         <para /></listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
This might be helpful for someone. Block device labels are provided in /dev/disk/by-label/, and can be more reliable than specifying the actual device name.