### PR TITLE
Freetype include path

### DIFF
--- a/cmake/ConkyPlatformChecks.cmake
+++ b/cmake/ConkyPlatformChecks.cmake
@@ -214,6 +214,7 @@ if(BUILD_X11)
 		if(BUILD_XFT)
 			find_path(freetype_INCLUDE_PATH config/ftconfig.h ${INCLUDE_SEARCH_PATH}
 				/usr/include/freetype2
+				/usr/include/freetype2/freetype
 				/usr/local/include/freetype2
 				/usr/pkg/include/freetype2)
 			if(freetype_INCLUDE_PATH)

--- a/cmake/ConkyPlatformChecks.cmake
+++ b/cmake/ConkyPlatformChecks.cmake
@@ -212,7 +212,7 @@ if(BUILD_X11)
 
 		# check for Xft
 		if(BUILD_XFT)
-			find_path(freetype_INCLUDE_PATH freetype/config/ftconfig.h ${INCLUDE_SEARCH_PATH}
+			find_path(freetype_INCLUDE_PATH config/ftconfig.h ${INCLUDE_SEARCH_PATH}
 				/usr/include/freetype2
 				/usr/local/include/freetype2
 				/usr/pkg/include/freetype2)

--- a/cmake/ConkyPlatformChecks.cmake
+++ b/cmake/ConkyPlatformChecks.cmake
@@ -214,14 +214,22 @@ if(BUILD_X11)
 		if(BUILD_XFT)
 			find_path(freetype_INCLUDE_PATH config/ftconfig.h ${INCLUDE_SEARCH_PATH}
 				/usr/include/freetype2
-				/usr/include/freetype2/freetype
 				/usr/local/include/freetype2
 				/usr/pkg/include/freetype2)
 			if(freetype_INCLUDE_PATH)
 				set(freetype_FOUND true)
 				set(conky_includes ${conky_includes} ${freetype_INCLUDE_PATH})
 			else(freetype_INCLUDE_PATH)
-				message(FATAL_ERROR "Unable to find freetype library")
+				find_path(freetype_INCLUDE_PATH freetype/config/ftconfig.h ${INCLUDE_SEARCH_PATH}
+					/usr/include/freetype2
+					/usr/local/include/freetype2
+					/usr/pkg/include/freetype2)
+				if(freetype_INCLUDE_PATH)
+					set(freetype_FOUND true)
+					set(conky_includes ${conky_includes} ${freetype_INCLUDE_PATH})
+				else(freetype_INCLUDE_PATH)
+					message(FATAL_ERROR "Unable to find freetype library")
+				endif(freetype_INCLUDE_PATH)
 			endif(freetype_INCLUDE_PATH)
 			if(NOT X11_Xft_FOUND)
 				message(FATAL_ERROR "Unable to find Xft library")


### PR DESCRIPTION
According to comments in /usr/share/cmake-3.1/Modules/FindFreetype.cmake, recent versions of FreeType use some #include trickery that complicate finding headers. The proper way to do this is to use the `freetype-config` application or a recent version of upstream CMake's FindFreetype.cmake module, but this patch worked on all the distros I tested it on (Gentoo, Archlinux, Ubuntu 14.04, Ubuntu 12.04, Fedora 20).
