### PR TITLE
Don't blend image onto drawable when using ARGB visuals fixes #51

### DIFF
--- a/src/imlib2.cc
+++ b/src/imlib2.cc
@@ -254,8 +254,9 @@ void cimlib_render(int x, int y, int width, int height)
 	/* clear our buffer */
 	imlib_context_set_image(buffer);
 	imlib_image_clear();
-	/* we can blend stuff now */
-	imlib_context_set_blend(1);
+	/* we should only blend if not using argb visuals to prevent incorrect
+	 * image opacity being drawn */
+	imlib_context_set_blend(!use_argb_visual.get(*state));
 	/* turn alpha channel on */
 	imlib_image_set_has_alpha(1);
 


### PR DESCRIPTION
This is a fix for the issue described in https://sourceforge.net/p/conky/bugs/317/ as well as issue #51 

Blending makes sense when using fake transparency, but with ARGB visuals it causes strange results - dark colors in images end up with partial opacity causing images to appear washed out or parts of them to be missing altogether.

The difference between this fix and the one in #52 is that images still can have transparent regions, they're just not incorrectly drawn with opacity where it's not intended.