### PR TITLE
Close file only if it was successfully opened

### DIFF
--- a/src/linux.cc
+++ b/src/linux.cc
@@ -643,8 +643,8 @@ int update_net_stats(void)
 			}
 			lastv6->next = NULL;
 		}
+		fclose(file);
 	}
-	fclose(file);
 #endif /* BUILD_IPV6 */
 
 	first = 0;


### PR DESCRIPTION
If BUILD_IPV6=ON (default), but the user has disabled ipv6 support
in the kernel using the parameter ipv6.disable=1, then conky fails
to open /proc/net/if_inet6. This leads to a segfault since conky
calls fclose(file) regardless. This fix simply moves the fclose call
into the preceding if statement. See #105.