### PR TITLE
Add top_name_verbose option

### DIFF
--- a/doc/config_settings.xml
+++ b/doc/config_settings.xml
@@ -962,6 +962,17 @@
     <varlistentry>
         <term>
             <command>
+                <option>top_name_verbose</option>
+            </command>
+        </term>
+        <listitem>If true, top name shows the full command line of each
+        process, including arguments (whenever possible). Otherwise,
+        only the basename is displayed. Default value is false.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
                 <option>top_name_width</option>
             </command>
         </term>

--- a/src/top.cc
+++ b/src/top.cc
@@ -32,6 +32,7 @@
 #include "prioqueue.h"
 #include "top.h"
 #include "logging.h"
+#include <string>
 
 /* hash table size - always a power of 2 */
 #define HTABSIZE 256
@@ -480,6 +481,7 @@ struct top_data {
 
 static conky::range_config_setting<unsigned int> top_name_width("top_name_width", 0,
 										std::numeric_limits<unsigned int>::max(), 15, true);
+static conky::simple_config_setting<bool> top_name_verbose("top_name_verbose", false, false);
 
 static void print_top_name(struct text_object *obj, char *p, int p_max_size)
 {
@@ -489,8 +491,13 @@ static void print_top_name(struct text_object *obj, char *p, int p_max_size)
 	if (!td || !td->list || !td->list[td->num])
 		return;
 
+	std::string top_name = td->list[td->num]->name;
+	if (!top_name_verbose.get(*state)) {
+		top_name = top_name.substr(0, top_name.find_first_of(' '));
+	}
+
 	width = MIN(p_max_size, (int)top_name_width.get(*state) + 1);
-	snprintf(p, width + 1, "%-*s", width, td->list[td->num]->name);
+	snprintf(p, width + 1, "%-*s", width, top_name.c_str());
 }
 
 static void print_top_mem(struct text_object *obj, char *p, int p_max_size)


### PR DESCRIPTION
Since commit 749083a, the output of `${top name <num>}` contains the full command line of each process, including arguments. While this feature can be very useful, it changes the default behavior of Conky.

The present commit adds a new `top_name_verbose` option that allows the user to toggle between basenames with no arguments (the old behavior) and full command lines with arguments. To remain consistent with past versions of Conky, the default value of `top_name_verbose` is `false`.

Now, I used the string class, rather than C str* functions. This is a personal preference, but I can change it if necessary. Also, I chose to set the default behavior back to what it was prior to version 1.10.0, which might annoy some people (again). I'm open to input.

Thanks for your consideration of this request.

Fixes #113.