### PR TITLE
Ensure getglobal pushes only one value onto stack

### DIFF
--- a/src/luamm.cc
+++ b/src/luamm.cc
@@ -357,6 +357,7 @@ namespace lua {
 		pushinteger(LUA_RIDX_GLOBALS);
 		gettable(REGISTRYINDEX);
 		getfield(-1, name);
+		replace(-2);
 #else
 		getfield(LUA_GLOBALSINDEX, name);
 #endif


### PR DESCRIPTION
Currently, `state::getglobal` pushes two values onto the stack: the global environment and the requested global. For example, if you call `getglobal("conky")`, the stack ends up with the following:

```
| ... global, conky |
```

The function `config_setting_base::lua_set` in `setting.cc:108` does not take this behavior into account, resulting in #97. To correct this, we call `replace(-2)` at the end of `state::getglobal` where `LUA_VERSION_NUM >= 502`.

I checked every call to `getglobal` (to the best of my abilities) to be sure there are no regressions. I used the incredibly useful [inspect.lua](https://github.com/kikito/inspect.lua) to dump the top entries of the stack after each stack-changing line in `lua_set` to confirm the fix. I'd be happy to provide before/after stack dumps, or the code I used to generate them.

**Edit:** added some details on how I debugged this.