### PR TITLE
Added sanity check to avoid making 0x0 window (resulting in Segementation Fault)

### DIFF
--- a/src/x11.cc
+++ b/src/x11.cc
@@ -643,6 +643,11 @@ static void init_window(lua::state &l __attribute__((unused)), bool own)
 
 		int b = border_inner_margin.get(l) + border_width.get(l)
 			+ border_outer_margin.get(l);
+			
+		/* Sanity check to avoid making an invalid 0x0 window */
+		if (b == 0) {
+			b = 1;
+		}
 
 		if (own_window_type.get(l) == TYPE_OVERRIDE) {
 


### PR DESCRIPTION
This fixes the bug explained in: https://github.com/brndnmtthws/conky/issues/12 as far as i know the 1x1 instead of 0x0 window has no side effects and thus fixing the issue.

With properly formatted code. (see https://github.com/brndnmtthws/conky/pull/124)