### PR TITLE
Fixed db2x_manxml failure on non-ascii chars

### DIFF
--- a/doc/config_settings.xml
+++ b/doc/config_settings.xml
@@ -80,7 +80,7 @@
         </term>
         <listitem>A comma-separated list of strings to use as the bars of a graph output
         to console/shell. The first list item is used for the minimum bar height and the
-        last item is used for the maximum. Example: " ,_,▁,▂,▃,▄,▅,▆,▇,█".
+        last item is used for the maximum. Example: " ,|,||,|||,||||,|||||,||||||".
         <para /></listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
This is just a pull request with the patch mentioned in #91, i see no reason not to add it to Conky. It was also mentioned here: #100

The original author of the commit never responded to the question how he did manage to compile the documentation with the non ascii characters. Reference: https://github.com/brndnmtthws/conky/pull/48