### PR TITLE
Fixed Curl segmentation fault

### DIFF
--- a/src/ccurl_thread.cc
+++ b/src/ccurl_thread.cc
@@ -119,9 +119,7 @@ namespace priv {
 			headers.h = curl_slist_append(headers.h, ("If-None-Match: " + etag).c_str());
 			etag.clear();
 		}
-		if (headers.h) {
-			curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers.h);
-		}
+		curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers.h);
 
 		res = curl_easy_perform(curl);
 		if (res == CURLE_OK) {


### PR DESCRIPTION
This is a pull request form the patch mentioned in #109 the original patch is contributed by Jay: https://github.com/bagder/curl/issues/342#issuecomment-120579447

Important note from the original author: This may not be the correct solution, it depends on the author's intention. Maybe he wanted to keep the headers from the previous call (in other words if there are no new headers use the old ones) and didn't realize they weren't copied in the handle, in which case he'll have to save the headers instead of above.

This patch has been used in the arch packages for a while now and seems to fix the problem so I've made a pull request for it.