### PR TITLE
Fix compile error with Lua 5.3

### DIFF
--- a/src/luamm.cc
+++ b/src/luamm.cc
@@ -171,6 +171,14 @@ namespace lua {
 			return nresults;
 		}
 
+		// Overloaded for Lua 5.3+ as lua_gettable and others return an int
+		template<int (*misc)(lua_State *, int), int nresults>
+		int safe_misc_trampoline(lua_State *l)
+		{
+			misc(l, 1);
+			return nresults;
+		}
+
 		int safe_next_trampoline(lua_State *l)
 		{
 			int r = lua_next(l, 1);


### PR DESCRIPTION
`lua_gettable` returns an int instead of void in Lua 5.3, so provide a backwards-compatible overload of `safe_misc_trampoline` to account for this. Tested with Lua 5.2 and 5.3.

This change does not address other compilation issues related to Lua bindings for cairo, imlib2, and rsvg.

Fixes #90 and part of #100. I proposed another fix in #136, but this is much cleaner.