### PR TITLE
Fix convert.lua : Splitting fails

### DIFF
--- a/extras/convert.lua
+++ b/extras/convert.lua
@@ -133,7 +133,7 @@ end;
 local config = input:read('*a');
 input:close();
 
-local settings, text = config:match('^(.-)TEXT\n(.*)$');
+local settings, text = config:match('^(.-)TEXT(.*)\n(.*)$');
 
 local converted = 'conky.config = {\n' .. settings:gsub('.-\n', convert) .. '};\n\nconky.text = ' ..
                 quote(text) .. ';\n';


### PR DESCRIPTION
Fixed bug when script try to split settings and "text". If there is any characters (like space) after "TEXT" token, the script fails to split and return an error on settings local variable usage. Now accept any characters between "TEXT" and '\n'.
