### PR TITLE
lock mpd result before modifying it

### DIFF
--- a/src/mpd.cc
+++ b/src/mpd.cc
@@ -298,6 +298,7 @@ if (b) a=b; else a="";
 			   conn = 0;
 			   } */
 		} while (0);
+		std::lock_guard<std::mutex> lock(Base::result_mutex);
 		result = mpd_info; // don't forget to save results!
 	}
 


### PR DESCRIPTION
Add a lock to the mpd work callback to prevent another thread from reading the struct while we're writing to it.  This might, maybe, possibly resolve #103.  I've been running it for a couple days without any crashes.