### PR TITLE
Reverts a change from check_include_file to files

### DIFF
--- a/cmake/ConkyPlatformChecks.cmake
+++ b/cmake/ConkyPlatformChecks.cmake
@@ -141,7 +141,7 @@ if(BUILD_MYSQL)
 endif(BUILD_MYSQL)
 
 if(BUILD_WLAN)
-	check_include_files(iwlib.h IWLIB_H -D_GNU_SOURCE)
+	check_include_file(iwlib.h IWLIB_H -D_GNU_SOURCE)
 	if(NOT IWLIB_H)
 		message(FATAL_ERROR "Unable to find iwlib.h")
 	endif(NOT IWLIB_H)


### PR DESCRIPTION
One of the check_include_file checks in ConkyPlatformChecks should
not have been changed to check_include_files because the latter
takes 2 arguments and this call gives 3 (and doens't work right
without the third).