### PR TITLE
Fix BUILD_MATH flag not working, partial #128

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -281,7 +281,7 @@ static void print_version(void)
 #endif /* BUILD_MYSQL */
 #ifdef BUILD_WEATHER_METAR
                 << _("  * Weather (METAR)\n")
-#endif /* BUILD_WEATHER_METAR */                
+#endif /* BUILD_WEATHER_METAR */
 #ifdef BUILD_WEATHER_XOAP
                 << _("  * Weather (XOAP)\n")
 #endif /* BUILD_WEATHER_XOAP */
@@ -1690,9 +1690,8 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied)
 						char *tmp_str;
 						cur_x += font_ascent() / 2;
 						cur_y += font_h / 2;
-						tmp_str = (char *)
-							calloc(log10(floor(current->scale)) + 4,
-									sizeof(char));
+						const int tmp_str_len = 64;
+						tmp_str = (char *) calloc(tmp_str_len, sizeof(char));
 						sprintf(tmp_str, "%.1f", current->scale);
 						draw_string(tmp_str);
 						free(tmp_str);
@@ -2007,7 +2006,7 @@ static void clear_text(int exposures)
 		/* there is some extra space for borders and outlines */
 		int border_total = get_border_total();
 
-		XClearArea(display, window.window, text_start_x - border_total, 
+		XClearArea(display, window.window, text_start_x - border_total,
 			text_start_y - border_total, text_width + 2*border_total,
 			text_height + 2*border_total, exposures ? True : 0);
 	}
@@ -2142,7 +2141,7 @@ static void main_loop(void)
 							XFreePixmap(display, window.back_buffer);
 							window.back_buffer = XCreatePixmap(display,
 								window.window, window.width, window.height, DefaultDepth(display, screen));
-						
+
 							if (window.back_buffer != None) {
 								window.drawable = window.back_buffer;
 							} else {
@@ -2721,7 +2720,7 @@ void load_config_file()
 	l.replace(-2);
 	if(l.type(-1) != lua::TSTRING)
 		throw conky::error(_("missing text block in configuration"));
-	
+
 	/* Remove \\-\n. */
 	l.gsub(l.tocstring(-1), "\\\n", "");
 	l.replace(-2);

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1501,10 +1501,10 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied)
 				{
 					int h, by = 0;
 					unsigned long last_colour = current_color;
-#ifdef MATH
+#ifdef BUILD_MATH
 					float angle, px, py;
 					double usage, scale;
-#endif /* MATH */
+#endif /* BUILD_MATH */
 
 					if (cur_x - text_start_x > mw && mw > 0) {
 						break;
@@ -1530,7 +1530,7 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied)
 					XDrawArc(display, window.drawable, window.gc,
 							cur_x, by, w, h * 2, 0, 180*64);
 
-#ifdef MATH
+#ifdef BUILD_MATH
 					usage = current->arg;
 					scale = current->scale;
 					angle = M_PI * usage / scale;
@@ -1539,7 +1539,7 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied)
 
 					XDrawLine(display, window.drawable, window.gc,
 							cur_x + (w/2.), by+(h), (int)(px), (int)(py));
-#endif /* MATH */
+#endif /* BUILD_MATH */
 
 					if (h > cur_y_add
 							&& h > font_h) {
@@ -1683,7 +1683,7 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied)
 						cur_x = tmp_x;
 						cur_y = tmp_y;
 					}
-#ifdef MATH
+#ifdef BUILD_MATH
 					if (show_graph_scale.get(*state) && (current->show_scale == 1)) {
 						int tmp_x = cur_x;
 						int tmp_y = cur_y;

--- a/src/net_stat.cc
+++ b/src/net_stat.cc
@@ -272,8 +272,19 @@ void print_v6addrs(struct text_object *obj, char *p, int p_max_size)
 #endif /* __linux__ */
 
 #ifdef BUILD_X11
+
+/**
+ * This function is called periodically to update the download and upload graphs
+ *
+ * - evaluates argument strings like 'eth0 50,120 #FFFFFF #FF0000 0 -l'
+ * - sets the obj->data.opaque pointer to the interface specified
+ *
+ * @param[out] obj  struct which will hold evaluated arguments
+ * @param[in]  arg  argument string to evaluate
+ **/
 void parse_net_stat_graph_arg(struct text_object *obj, const char *arg, void *free_at_crash)
 {
+	/* scan arguments and get interface name back */
 	char *buf = 0;
 	buf = scan_graph(obj, arg, 0);
 
@@ -286,6 +297,12 @@ void parse_net_stat_graph_arg(struct text_object *obj, const char *arg, void *fr
 	obj->data.opaque = get_net_stat(DEFAULTNETDEV, obj, free_at_crash);
 }
 
+/**
+ * returns the download speed in kiB/s for the interface referenced by obj
+ *
+ * @param[in] obj struct containting a member data, which is a struct
+ *                containing a void * to a net_stat struct
+ **/
 double downspeedgraphval(struct text_object *obj)
 {
 	struct net_stat *ns = (struct net_stat *)obj->data.opaque;

--- a/src/specials.cc
+++ b/src/specials.cc
@@ -289,8 +289,6 @@ char *scan_graph(struct text_object *obj, const char *args, double defscale)
 			buf[_size] = 0;
 		}
 
-#undef g
-
 		return strndup(buf, text_buffer_size.get(*state));
 	}
 
@@ -417,6 +415,9 @@ void new_font(struct text_object *obj, char *p, int p_max_size)
 	}
 }
 
+/**
+ * Adds value f to graph possibly truncating and scaling the graph
+ **/
 static void graph_append(struct special_t *graph, double f, char showaslog)
 {
 	int i;
@@ -497,7 +498,7 @@ void new_graph(struct text_object *obj, char *buf, int buf_max_size, double val)
 
 	s = new_special(buf, GRAPH);
 
-    /* set graph (special) width to width in obj */
+	/* set graph (special) width to width in obj */
 	s->width = g->width;
 	if (s->width) s->graph_width = s->width;
 
@@ -537,7 +538,7 @@ void new_graph(struct text_object *obj, char *buf, int buf_max_size, double val)
 		s->scale = log10(s->scale + 1);
 	}
 #endif
-	graph_append(s, val, g->flags & SF_SHOWLOG);
+	graph_append(s, val, g->flags);
 
 	if (not out_to_x.get(*state))
 		new_graph_in_shell(s, buf, buf_max_size);

--- a/src/weather.cc
+++ b/src/weather.cc
@@ -159,11 +159,11 @@ int rel_humidity(int dew_point, int air) {
 	const float b = 237.7f;
 
 	float diff = a*(dew_point/(b+dew_point)-air/(b+air));
-#ifdef MATH
+#ifdef BUILD_MATH
 	return (int)(100.f*expf(diff));
 #else
 	return (int)(16.666667163372f*(6.f+diff*(6.f+diff*(3.f+diff))));
-#endif /* MATH */
+#endif /* BUILD_MATH */
 }
 
 #ifdef BUILD_WEATHER_XOAP


### PR DESCRIPTION
changed MATH to BUILD_MATH + 2 smaller changes which didn't work out of the box after that change

Fixes:
 - cpugauge not working
 - logarithmic scales not working in all graphs
-  graph scale not showing, even if 'show_graph_scale yes' specified
 - ...

Also added documentation as much as needed to find these problems

This fixes partially Issue #128 , but there is a more fundamental problem: In the range of 0 to 1.0 a as used for the cpugraph usage, the 'logarithmic' scale (which isn't strictly true) calculates log10(f+1), meaning f=0 will result in 0 and f=1.0 will result in log10(2)=0.3. f=0.5 will result in 0.176 

All this means, that the logarithmic version is only very very slightly different than the linear version. It's visible, but you have to look for it, in contrast to the downspeedgraph, where the logarithmic scale has it's use.

The solution would be to scale ab the cpugraph values plotted e.g. by factor of 100 to range from 0 to 100. The resulting logscale: 100->2.0, 50->1.7, 0->0 would be clearly visible.
But then the scale shown if 'show_scale yes' would show 100 instead of 1.0 which is basically incorrect, because the percent sign after the 100 would be missing. But this is just ideology, I'm not sure if I should implement this
???
