### PR TITLE
Finalized nvidia module

### DIFF
--- a/doc/variables.xml
+++ b/doc/variables.xml
@@ -2715,45 +2715,119 @@
             <command>
                 <option>nvidia</option>
             </command>
-            <option>threshold</option>
-            <option>temp</option>
-            <option>ambient</option>
-            <option>gpufreq</option>
-            <option>memfreq</option>
-            <option>imagequality</option>
+            <option>metric</option>
         </term>
-        <listitem>Nvidia graficcard support for the XNVCtrl
-        library. Each option can be shortened to the least
-        significant part. Temperatures are printed as float, all
-        other values as integer. 
+        <listitem>Displays metrics for NVIDIA graphics cards using the
+        XNVCtrl library. Please use nvidia-settings to determine metric
+        units (e.g. MHz, °C/°F). Valid metrics are:
         <simplelist>
             <member>
-		<command>threshold</command>
-		<option>The thresholdtemperature at
-			which the gpu slows down</option>
+                <command>gputemp</command>
+                <option>Current GPU temperature</option>
             </member>
             <member>
-		<command>temp</command>
-		<option>Gives the gpu current
-			temperature</option>
+                <command>gputempthreshold</command>
+                <option>Temperature threshold at which the GPU slows down to prevent damage</option>
             </member>
             <member>
-                <command>ambient</command>
-                <option>Gives current air temperature near GPU
-                case</option>
+                <command>ambienttemp</command>
+                <option>Current air temperature near the GPU</option>
             </member>
             <member>
-                <command>gpufreq</command>
-                <option>Gives the current gpu frequency</option>
+                <command>gpufreq, gpufreqcur</command>
+                <option>Current GPU clock</option>
             </member>
             <member>
-                <command>memfreq</command>
-                <option>Gives the current mem frequency</option>
+                <command>gpufreqmin</command>
+                <option>Lowest possible GPU clock</option>
+            </member>
+            <member>
+                <command>gpufreqmax</command>
+                <option>Highest possible GPU clock</option>
+            </member>
+            <member>
+                <command>memfreq, memfreqcur</command>
+                <option>Current memory clock</option>
+            </member>
+            <member>
+                <command>memfreqmin</command>
+                <option>Lowest possible memory clock</option>
+            </member>
+            <member>
+                <command>memfreqmax</command>
+                <option>Highest possible memory clock</option>
+            </member>
+            <member>
+                <command>mtrfreq, mtrfreqcur</command>
+                <option>Current memory transfer rate</option>
+            </member>
+            <member>
+                <command>mtrfreqmin</command>
+                <option>Lowest possible memory transfer rate</option>
+            </member>
+            <member>
+                <command>mtrfreqmax</command>
+                <option>Highest possible memory transfer rate</option>
+            </member>
+            <member>
+                <command>perflevel, perflevelcur</command>
+                <option>Current performance level</option>
+            </member>
+            <member>
+                <command>perflevelmin</command>
+                <option>Lowest possible performance level</option>
+            </member>
+            <member>
+                <command>perflevelmax</command>
+                <option>Highest possible performance level</option>
+            </member>
+            <member>
+                <command>perfmode</command>
+                <option>Current performance mode</option>
+            </member>
+            <member>
+                <command>gpuutil</command>
+                <option>Current GPU utilization</option>
+            </member>
+            <member>
+                <command>membwutil</command>
+                <option>Current memory bandwidth utilization</option>
+            </member>
+            <member>
+                <command>videoutil</command>
+                <option>Current video engine utilization</option>
+            </member>
+            <member>
+                <command>pcieutil</command>
+                <option>Current PCIe bandwidth utilization</option>
+            </member>
+            <member>
+                <command>mem, memused</command>
+                <option>Amount of memory in use</option>
+            </member>
+            <member>
+                <command>memfree, memavail</command>
+                <option>Amount of free memory</option>
+            </member>
+            <member>
+                <command>memmax, memtotal</command>
+                <option>Total amount of memory</option>
+            </member>
+            <member>
+                <command>memutil, memperc</command>
+                <option>Current memory utilization</option>
+            </member>
+            <member>
+                <command>fanspeed</command>
+                <option>Current fan/cooler speed</option>
+            </member>
+            <member>
+                <command>fanlevel, fanutil</command>
+                <option>Current fan/cooler level (as in utilization)</option>
             </member>
             <member>
                 <command>imagequality</command>
-                <option>Which imagequality should be chosen by
-                OpenGL applications</option>
+                <option>Current image quality setting for OpenGL applications</option>
             </member>
         </simplelist>
         <para /></listitem>

--- a/src/core.cc
+++ b/src/core.cc
@@ -1788,7 +1788,7 @@ struct text_object *construct_text_object(char *s, const char *arg,
 		obj->callbacks.free = &free_combine;
 #ifdef BUILD_NVIDIA
 	END OBJ_ARG(nvidia, 0, "nvidia needs an argument")
-		if (set_nvidia_type(obj, arg)) {
+		if (set_nvidia_query(obj, arg)) {
 			CRIT_ERR(obj, free_at_crash, "nvidia: invalid argument"
 				 " specified: '%s'\n", arg);
 		}
@@ -2084,4 +2084,3 @@ void free_text_objects(struct text_object *root)
 		}
 	}
 }
-

--- a/src/nvidia.h
+++ b/src/nvidia.h
@@ -32,7 +32,7 @@
 #ifndef NVIDIA_CONKY_H
 #define NVIDIA_CONKY_H
 
-int set_nvidia_type(struct text_object *, const char *);
+int set_nvidia_query(struct text_object *, const char *);
 void print_nvidia_value(struct text_object *, char *, int);
 void free_nvidia(struct text_object *);
 


### PR DESCRIPTION
I finalized the nvidia module including code cleanup and documentation (variables.xml).

Changes to previous revision:
- Implemented `nvs->pmode` to allow control over how values are printed (int, float, temperature...)
- Moved decoding of GPU/MEM frequencies to `print_nvidia_value()` using QUERY_SPECIAL -> cleaner quirks handling
- Revised `print_nvidia_value()` -> cleaner string and memory allocation handling
- Renamed `set_nvidia_type()` to `set_nvidia_query()` -> required change in core.cc
- General code cleanup (comments, spacing)

Please note that:
- The module partially breaks compatibility to the previous (old) nvidia module since shortcuts (e.g. 'g' for 'gpufreq') are no longer supported. However, I was able to maintain compatibility for full argument strings (temp, threshold, ambient, gpufreq, memfreq)
- I decided against multiple GPUs/fans/... support. I don't feel it's worth the effort since users most likely have a single card or only want to monitor their primary card
- I decided against static metrics (e.g. min/max values which are only queried once to save CPU time) since this is a feature I'd like to propose in general for conky
- There are features (PRINT_FLOAT, QUERY_STRING) that are currently unused, but might come in handy in the future. I designed the whole module with easy further enhancement in mind.