### PR TITLE
Refactor the exec callback system

### DIFF
--- a/doc/config_settings.xml
+++ b/doc/config_settings.xml
@@ -99,8 +99,8 @@
                 <option>default_bar_height</option>
             </command>
         </term>
-        <listitem>Specify a default height for bars.  This is particularly useful for execbar and
-        execibar as they do not take size arguments. 
+        <listitem>Specify a default height for bars. If not specified,
+        the default value is 6.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -109,8 +109,13 @@
                 <option>default_bar_width</option>
             </command>
         </term>
-        <listitem>Specify a default width for bars.  This is particularly useful for execbar and
-        execibar as they do not take size arguments. 
+        <listitem>Specify a default width for bars. If not specified,
+        the default value is 0, which causes the bar to expand to
+        fit the width of your Conky window. If you set
+        out_to_console = true, the text version of the bar will
+        actually have no width and you will need to set a
+        sensible default or set the height and width of each bar
+        individually.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -128,8 +133,8 @@
                 <option>default_gauge_height</option>
             </command>
         </term>
-        <listitem>Specify a default height for gauges.  This is particularly useful for execgauge
-        and execigauge as they do not take size arguments 
+        <listitem>Specify a default height for gauges. If not specified,
+        the default value is 25.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -138,8 +143,8 @@
                 <option>default_gauge_width</option>
             </command>
         </term>
-        <listitem>Specify a default width for gauges.  This is particularly useful for execgauge
-        and execigauge as they do not take size arguments 
+        <listitem>Specify a default width for gauges. If not specified,
+        the default value is 40.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -148,8 +153,8 @@
                 <option>default_graph_height</option>
             </command>
         </term>
-        <listitem>Specify a default height for graphs.  This is particularly useful for execgraph
-        and execigraph as they do not take size arguments 
+        <listitem>Specify a default height for graphs. If not specified,
+        the default value is 25.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -158,8 +163,13 @@
                 <option>default_graph_width</option>
             </command>
         </term>
-        <listitem>Specify a default width for graphs.  This is particularly useful for execgraph
-        and execigraph as they do not take size arguments 
+        <listitem>Specify a default width for graphs. If not specified,
+        the default value is 0, which causes the graph to expand to
+        fit the width of your Conky window. If you set
+        out_to_console = true, the text version of the graph will
+        actually have no width and you will need to set a
+        sensible default or set the height and width of each graph
+        individually.
         <para /></listitem>
     </varlistentry>
     <varlistentry>

--- a/doc/variables.xml
+++ b/doc/variables.xml
@@ -1118,9 +1118,9 @@
             <option>command</option>
         </term>
         <listitem>Executes a shell command and displays the output
-        in conky. warning: this takes a lot more resources than
-        other variables. I'd recommend coding wanted behaviour in C
-        and posting a patch. 
+        in conky. Warning: this takes a lot more resources than
+        other variables. I'd recommend coding wanted behaviour in C/C++
+        and posting a patch.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1128,12 +1128,14 @@
             <command>
                 <option>execbar</option>
             </command>
+            <option>(height),(width)</option>
             <option>command</option>
         </term>
-        <listitem>Same as exec, except if the first value return is
-        a value between 0-100, it will use that number for a bar.
-        The size for bars can be controlled via the
-        default_bar_size config setting. 
+        <listitem>Same as exec, except if the first value returned is
+        a value between 0-100, it will use that number to draw a
+        horizontal bar. The height and width parameters are optional,
+        and default to the default_bar_height and default_bar_width
+        config settings, respectively.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1141,12 +1143,15 @@
             <command>
                 <option>execgauge</option>
             </command>
+            <option>(height),(width)</option>
             <option>command</option>
         </term>
-        <listitem>Same as exec, except if the first value returned
-        is a value between 0-100, it will use that number for a
-        gauge. The size for gauges can be controlled via the
-        default_gauge_size config setting. 
+        <listitem>Same as exec, except if the first value returned is
+        a value between 0-100, it will use that number to draw a
+        round gauge (much like a vehicle speedometer). The height and
+        width parameters are optional, and default to the
+        default_gauge_height and default_gauge_width config settings,
+        respectively.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1154,33 +1159,61 @@
             <command>
                 <option>execgraph</option>
             </command>
-            <option>(-t) (-l) command</option>
+            <option>command</option>
+            <option>(height),(width)</option>
+            <option>(gradient color 1)</option>
+            <option>(gradient color 2)</option>
+            <option>(scale)</option>
+            <option>(-t)</option>
+            <option>(-l)</option>
         </term>
-        <listitem>Same as execbar, but graphs values. Uses a
-        logaritmic scale when the log option (-l switch) is given
-        (to see small numbers). Values still have to be between 0
-        and 100. The size for graphs can be controlled via the
-        default_graph_size config setting. Takes the switch '-t' to
-        use a temperature gradient, which makes the gradient values
-        change depending on the amplitude of a particular graph
-        value (try it and see). If -t or -l is your first argument,
-        you may need to preceed it by a space (' ').  You may also use
-        double-quotes around the exec argument should you need to execute a
-        command with spaces.  For example, ${execgraph "date +'%S'"} to execute
-        `date +'%S'` and graph the result.  Without quotes, it would simply
-        print the result of `date`.
-        <para /></listitem>
+        <listitem>
+        <para>Draws a horizontally scrolling graph with values
+        from 0-100 plotted on the vertical axis. All parameters
+        following the command are optional. Gradient colors can
+        be specified as hexadecimal values with no 0x or #
+        prefix. Use the -t switch to enable a temperature
+        gradient, so that small values are "cold" with color 1
+        and large values are "hot" with color 2. Without the -t
+        switch, the colors produce a horizontal gradient
+        spanning the width of the graph. The scale parameter
+        defines the maximum value of the graph. Use the -l
+        switch to enable a logarithmic scale, which helps to see
+        small values. The default size for graphs can be
+        controlled via the default_graph_height and
+        default_graph_width config settings.</para>
+
+        <para>If you need to execute a command with spaces, you
+        have a couple options: 1) put your command into a
+        separate file, such as ~/bin/myscript.sh, and use that
+        as your execgraph command. Remember to make your script
+        executable! 2) Wrap your command in double-quotes. If
+        you go for this option, do not try to pass the extra
+        parameters for height, width, etc., as the results may
+        be unexpected.</para>
+
+        <para>Option 1 is preferred. In the following example, we
+        set up execgraph to display seconds (0-59) on a graph that
+        is 50px high and 200px wide, using a temperature gradient
+        with colors ranging from red for small values (FF0000) to
+        yellow for large values (FFFF00). We set the scale to
+        60.</para>
+
+        <para><command>${execgraph ~/seconds.sh 50,200 FF0000
+        FFFF00 60 -t}</command></para>
+        </listitem>
     </varlistentry>
     <varlistentry>
         <term>
             <command>
                 <option>execi</option>
             </command>
-            <option>interval command</option>
+            <option>interval</option>
+            <option>command</option>
         </term>
-        <listitem>Same as exec but with specific interval. Interval
-        can't be less than update_interval in configuration. See
-        also $texeci
+        <listitem>Same as exec, but with a specific interval in
+        seconds. The interval can't be less than the update_interval
+        in your configuration. See also $texeci.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1188,9 +1221,11 @@
             <command>
                 <option>execibar</option>
             </command>
-            <option>interval command</option>
+            <option>interval</option>
+            <option>(height),(width)</option>
+            <option>command</option>
         </term>
-        <listitem>Same as execbar, except with an interval 
+        <listitem>Same as execbar, but with an interval.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1198,10 +1233,11 @@
             <command>
                 <option>execigauge</option>
             </command>
-            <option>interval command</option>
+            <option>interval</option>
+            <option>(height),(width)</option>
+            <option>command</option>
         </term>
-        <listitem>Same as execgauge, but takes an interval arg and
-        gauges values. 
+        <listitem>Same as execgauge, but with an interval.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1209,11 +1245,16 @@
             <command>
                 <option>execigraph</option>
             </command>
-            <option>interval (-t) (-l) command</option>
+            <option>interval</option>
+            <option>command</option>
+            <option>(height),(width)</option>
+            <option>(gradient color 1)</option>
+            <option>(gradient color 2)</option>
+            <option>(scale)</option>
+            <option>(-t)</option>
+            <option>(-l)</option>
         </term>
-        <listitem>Same as execgraph, but takes an interval arg and
-        graphs values. If -t or -l is your first argument, you may
-        need to preceed it by a space (' '). 
+        <listitem>Same as execgraph, but with an interval.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1224,8 +1265,8 @@
             <option>command</option>
         </term>
         <listitem>Executes a shell command and displays the output
-        in conky. warning: this takes a lot more resources than
-        other variables. I'd recommend coding wanted behaviour in C
+        in conky. Warning: this takes a lot more resources than
+        other variables. I'd recommend coding wanted behaviour in C/C++
         and posting a patch. This differs from $exec in that it
         parses the output of the command, so you can insert things
         like ${color red}hi!${color} in your script and have it
@@ -1235,7 +1276,7 @@
         like $execi within an $execp statement, it will
         functionally run at the same interval that the $execp
         statement runs, as it is created and destroyed at every
-        interval. 
+        interval.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1243,12 +1284,12 @@
             <command>
                 <option>execpi</option>
             </command>
-            <option>interval command</option>
+            <option>interval</option>
+            <option>command</option>
         </term>
-        <listitem>Same as execp but with specific interval.
-        Interval can't be less than update_interval in
-        configuration. Note that the output from the $execpi
-        command is still parsed and evaluated at every interval. 
+        <listitem>Same as execp, but with an interval. Note that
+        the output from the $execpi command is still parsed
+        and evaluated at every interval.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3769,19 +3810,20 @@
             <command>
                 <option>texeci</option>
             </command>
-            <option>interval command</option>
+            <option>interval</option>
+            <option>command</option>
         </term>
         <listitem>Runs a command at an interval inside a thread and
         displays the output. Same as $execi, except the command is
         run inside a thread. Use this if you have a slow script to
         keep Conky updating. You should make the interval slightly
-        longer then the time it takes your script to execute. For
+        longer than the time it takes your script to execute. For
         example, if you have a script that take 5 seconds to
         execute, you should make the interval at least 6 seconds.
         See also $execi. This object will clean up the thread when
         it is destroyed, so it can safely be used in a nested
         fashion, though it may not produce the desired behaviour if
-        used this way. 
+        used this way.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3789,7 +3831,8 @@
             <command>
                 <option>texecpi</option>
             </command>
-            <option>interval command</option>
+            <option>interval</option>
+            <option>command</option>
         </term>
         <listitem>Same as execpi, except the command is run inside
         a thread.

--- a/src/common.cc
+++ b/src/common.cc
@@ -275,15 +275,13 @@ conky::simple_config_setting<bool> no_buffers("no_buffers", true, true);
 
 void update_stuff(void)
 {
-	int i;
-
 	/* clear speeds, addresses and up status in case device was removed and
 	 *  doesn't get updated */
 
 	#ifdef HAVE_OPENMP
 	#pragma omp parallel for schedule(dynamic,10)
 	#endif /* HAVE_OPENMP */
-	for (i = 0; i < MAX_NET_INTERFACES; i++) {
+	for (int i = 0; i < MAX_NET_INTERFACES; ++i) {
 		if (netstats[i].dev) {
 			netstats[i].up = 0;
 			netstats[i].recv_speed = 0.0;
@@ -295,8 +293,10 @@ void update_stuff(void)
 		}
 	}
 
+	/* this is a stub on all platforms except solaris */
 	prepare_update();
 
+	/* if you registered a callback with conky::register_cb, this will run it */
 	conky::run_all_callbacks();
 
 	/* XXX: move the following into the update_meminfo() functions? */

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -909,19 +909,17 @@ static void generate_text(void)
 {
 	char *p;
 	unsigned int i, j, k;
-
 	special_count = 0;
-
-	/* update info */
 
 	current_update_time = get_time();
 
+	/* clears netstats info, calls conky::run_all_callbacks(), and changes
+	 * some info.mem entries */
 	update_stuff();
 
-	/* add things to the buffer */
-
-	/* generate text */
-
+	/* populate the text buffer; generate_text_internal() iterates through
+	 * global_root_object (an instance of the text_object struct) and calls
+	 * any callbacks that were set on startup by construct_text_object(). */
 	p = text_buffer;
 
 	generate_text_internal(p, max_user_text.get(*state), global_root_object);

--- a/src/core.cc
+++ b/src/core.cc
@@ -742,69 +742,79 @@ struct text_object *construct_text_object(char *s, const char *arg,
 		scan_no_update(obj, arg);
 		obj->callbacks.print = &print_no_update;
 		obj->callbacks.free = &free_no_update;
-	END OBJ(exec, 0)
-		scan_exec_arg(obj, arg);
+	END OBJ_ARG(exec, 0, "exec needs arguments: <command>")
+		scan_exec_arg(obj, arg, EF_EXEC);
 		obj->parse = false;
 		obj->thread = false;
+		register_exec(obj);
 		obj->callbacks.print = &print_exec;
 		obj->callbacks.free = &free_exec;
-	END OBJ(execp, 0)
-		scan_exec_arg(obj, arg);
+	END OBJ_ARG(execi, 0, "execi needs arguments: <interval> <command>")
+		scan_exec_arg(obj, arg, EF_EXECI);
+		obj->parse = false;
+		obj->thread = false;
+		register_execi(obj);
+		obj->callbacks.print = &print_exec;
+		obj->callbacks.free = &free_execi;
+	END OBJ_ARG(execp, 0, "execp needs arguments: <command>")
+		scan_exec_arg(obj, arg, EF_EXEC);
 		obj->parse = true;
 		obj->thread = false;
+		register_exec(obj);
 		obj->callbacks.print = &print_exec;
 		obj->callbacks.free = &free_exec;
-	END OBJ(execbar, 0)
-		scan_exec_arg(obj, arg);
+	END OBJ_ARG(execpi, 0, "execpi needs arguments: <interval> <command>")
+		scan_exec_arg(obj, arg, EF_EXECI);
+		obj->parse = true;
+		obj->thread = false;
+		register_execi(obj);
+		obj->callbacks.print = &print_exec;
+		obj->callbacks.free = &free_execi;
+	END OBJ_ARG(execbar, 0, "execbar needs arguments: [height],[width] <command>")
+		scan_exec_arg(obj, arg, EF_EXEC | EF_BAR);
+		register_exec(obj);
 		obj->callbacks.barval = &execbarval;
 		obj->callbacks.free = &free_exec;
-	END OBJ(execgauge, 0)
-		scan_exec_arg(obj, arg);
+	END OBJ_ARG(execibar, 0, "execibar needs arguments: <interval> [height],[width] <command>")
+		scan_exec_arg(obj, arg, EF_EXECI | EF_BAR);
+		register_execi(obj);
+		obj->callbacks.barval = &execbarval;
+		obj->callbacks.free = &free_execi;
+#ifdef BUILD_X11
+	END OBJ_ARG(execgauge, 0, "execgauge needs arguments: [height],[width] <command>")
+		scan_exec_arg(obj, arg, EF_EXEC | EF_GAUGE);
+		register_exec(obj);
 		obj->callbacks.gaugeval = &execbarval;
 		obj->callbacks.free = &free_exec;
-#ifdef BUILD_X11
-	END OBJ(execgraph, 0)
-		scan_execgraph_arg(obj, arg);
+	END OBJ_ARG(execigauge, 0, "execigauge needs arguments: <interval> [height],[width] <command>")
+		scan_exec_arg(obj, arg, EF_EXECI | EF_GAUGE);
+		register_execi(obj);
+		obj->callbacks.gaugeval = &execbarval;
+		obj->callbacks.free = &free_execi;
+	END OBJ_ARG(execgraph, 0, "execgraph needs arguments: <command> [height],[width] [color1] [color2] [scale] [-t|-l]")
+		scan_exec_arg(obj, arg, EF_EXEC | EF_GRAPH);
+		register_exec(obj);
 		obj->callbacks.graphval = &execbarval;
 		obj->callbacks.free = &free_exec;
-#endif /* BUILD_X11 */
-	END OBJ_ARG(execibar, 0, "execibar needs arguments")
-		scan_execi_bar_arg(obj, arg);
-		obj->callbacks.barval = &execi_barval;
-		obj->callbacks.free = &free_execi;
-#ifdef BUILD_X11
-	END OBJ_ARG(execigraph, 0, "execigraph needs arguments")
-		scan_execgraph_arg(obj, arg);
-		obj->callbacks.graphval = &execi_barval;
-		obj->callbacks.free = &free_execi;
-	END OBJ_ARG(execigauge, 0, "execigauge needs arguments")
-		scan_execi_gauge_arg(obj, arg);
-		obj->callbacks.gaugeval = &execi_barval;
+	END OBJ_ARG(execigraph, 0, "execigraph needs arguments: <interval> <command> [height],[width] [color1] [color2] [scale] [-t|-l]")
+		scan_exec_arg(obj, arg, EF_EXECI | EF_GRAPH);
+		register_execi(obj);
+		obj->callbacks.graphval = &execbarval;
 		obj->callbacks.free = &free_execi;
 #endif /* BUILD_X11 */
-	END OBJ_ARG(execi, 0, "execi needs arguments")
-		scan_execi_arg(obj, arg);
-		obj->parse = false;
-		obj->thread = false;
-		obj->callbacks.print = &print_execi;
-		obj->callbacks.free = &free_execi;
-	END OBJ_ARG(execpi, 0, "execpi needs arguments")
-		scan_execi_arg(obj, arg);
-		obj->parse = true;
-		obj->thread = false;
-		obj->callbacks.print = &print_execi;
-		obj->callbacks.free = &free_execi;
-	END OBJ_ARG(texeci, 0, "texeci needs arguments")
-		scan_execi_arg(obj, arg);
+	END OBJ_ARG(texeci, 0, "texeci needs arguments: <interval> <command>")
+		scan_exec_arg(obj, arg, EF_EXECI);
 		obj->parse = false;
 		obj->thread = true;
-		obj->callbacks.print = &print_execi;
+		register_execi(obj);
+		obj->callbacks.print = &print_exec;
 		obj->callbacks.free = &free_execi;
-	END OBJ_ARG(texecpi, 0, "texecpi needs arguments")
-		scan_execi_arg(obj, arg);
+	END OBJ_ARG(texecpi, 0, "texecpi needs arguments: <interval> <command>")
+		scan_exec_arg(obj, arg, EF_EXECI);
 		obj->parse = true;
 		obj->thread = true;
-		obj->callbacks.print = &print_execi;
+		register_execi(obj);
+		obj->callbacks.print = &print_exec;
 		obj->callbacks.free = &free_execi;
 	END OBJ(fs_bar, &update_fs_stats)
 		init_fs_bar(obj, arg);
@@ -2071,7 +2081,6 @@ void free_text_objects(struct text_object *root)
 	if(root && root->prev) {
 		for (obj = root->prev; obj; obj = root->prev) {
 			root->prev = obj->prev;
-
 			if (obj->callbacks.free) {
 				(*obj->callbacks.free)(obj);
 			}

--- a/src/exec.h
+++ b/src/exec.h
@@ -33,15 +33,52 @@
 
 #include "text_object.h"
 
-void scan_exec_arg(struct text_object *, const char *);
-void scan_execi_arg(struct text_object *, const char *);
-void scan_execi_bar_arg(struct text_object *, const char *);
-void scan_execi_gauge_arg(struct text_object *, const char *);
-void scan_execgraph_arg(struct text_object *, const char *);
+/**
+ * A callback that executes a command and stores the output as a std::string.
+ *
+ * Important note: if more than one exec callback uses the same command,
+ * then only ONE callback is actually stored. This saves space. However,
+ * suppose we have the following ${exec} objects in our conky.text:
+ *
+ * ${exec ~/bin/foo.sh}
+ * ${execi 10 ~/bin/foo.sh}
+ *
+ * To the callback system, these are identical! Furthermore, the callback
+ * with the smallest period/interval is the one that is stored. So the execi
+ * command will in fact run on every update interval, rather than every
+ * ten seconds as one would expect.
+ */
+class exec_cb: public conky::callback<std::string, std::string> {
+	typedef conky::callback<std::string, std::string> Base;
+
+	protected:
+		virtual void work();
+
+	public:
+		exec_cb(uint32_t period, bool wait, const std::string &cmd)
+			: Base(period, wait, Base::Tuple(cmd))
+		{}
+};
+
+/**
+ * Flags used to identify the different types of exec commands during
+ * parsing by scan_exec_arg(). These can be used individually or combined.
+ * For example, to parse an ${execgraph} object, we pass EF_EXEC | EF_GRAPH
+ * as the last argument to scan_exec_arg().
+ */
+enum {
+	EF_EXEC  = (1 << 0),
+	EF_EXECI = (1 << 1),
+	EF_BAR   = (1 << 2),
+	EF_GRAPH = (1 << 3),
+	EF_GAUGE = (1 << 4)
+};
+
+void scan_exec_arg(struct text_object *, const char *, unsigned int);
+void register_exec(struct text_object *);
+void register_execi(struct text_object *);
 void print_exec(struct text_object *, char *, int);
-void print_execi(struct text_object *, char *, int);
 double execbarval(struct text_object *);
-double execi_barval(struct text_object *);
 void free_exec(struct text_object *);
 void free_execi(struct text_object *);
 

--- a/src/update-cb.hh
+++ b/src/update-cb.hh
@@ -56,13 +56,13 @@ namespace conky {
 
 			semaphore sem_start;
 			std::thread *thread;
-			const size_t hash;
-			uint32_t period;
-			uint32_t remaining;
+			const size_t hash;		/* used to determined callback uniqueness */
+			uint32_t period;		/* how often to run a callback */
+			uint32_t remaining;		/* update intervals remaining until we can run a callback */
 			std::pair<int, int> pipefd;
-			const bool wait;
-			bool done;
-			uint8_t unused;
+			const bool wait;		/* whether or not to wait for a callback to finish */
+			bool done;			/* if true, callback is being stopped and destroyed */
+			uint8_t unused;			/* number of update intervals during which no one owns a callback */
 
 			callback_base(const callback_base &) = delete;
 			callback_base& operator=(const callback_base &) = delete;
@@ -159,6 +159,9 @@ namespace conky {
 				));
 	}
 
+	/*
+	 * Callback uniqueness is determined by the hash computed here.
+	 */
 	namespace priv {
 		template<size_t pos, typename... Elements>
 		struct hash_tuple {


### PR DESCRIPTION
### Overview

Prior to this commit, exec_cb callbacks were registered and the results were immediately fetched on every update interval... except the first. Besides not working on the first update, this meant that all exec_cb callbacks were re-registered on every update, which was not efficient.

The solution was to decouple the registration from the result retrieval and only register on the initial startup (or config reload). Now, the callbacks are registered when they are supposed to be, and the first-run issue is gone.

The code is hopefully more understandable now. I consolidated several functions in `exec.cc` into one, which makes the logic much easier to follow. I also added plenty of documentation, both to the code itself and to the manpage.

### Bonuses

  * execgraph works again!
  * optional execgraph parameters are now documented
  * execbar and execgauge now accept height and width parameters

### Known issues

  * technically, execgraph accepts commands with spaces, but such commands will need to be surrounded with double-quotes and you might as well forget adding optional arguments like colors, as the results may not be expected. Just put your spacey command into a script and run the script instead so that everything will just work.
  * the execgraph command comes *before* its arguments, whereas the execbar and execgauge commands come after their arguments.
  * texec{i} is registered on startup like everything else, but sometimes it will not produce output on the first interval. This is an intermittent issue.

### Example

![Exec Demo](https://www.dropbox.com/s/75gq1zodfjfif8u/conky-exec-demo.png?dl=1)

```
conky.text = [[
EXEC DEMO ${hr}
${exec date}

Default execbar w/ default_bar_height = 10
${execbar shuf -i 0-100 -n 1}

Variable size execbars
${execbar 20,150 shuf -i 0-90 -n 1}
${execbar 10,100 shuf -i 0-92 -n 1}
${execbar 3,50 shuf -i 0-94 -n 1}

Customized execgraphs
${execgraph ~/seconds.sh 25,150 FF0000 FFFF00 60 -t}${execgraph ~/random.sh 25,150 -l}

Variable size execgauges
${execgauge 50,80 shuf -i 0-100 -n 1}${execgauge 100,220 shuf -i 0-99 -n 1}
]];
```
