### PR TITLE
keep next_update_time modulo update_interval zero

### DIFF
--- a/src/common.cc
+++ b/src/common.cc
@@ -123,7 +123,7 @@ double get_time(void)
 {
 	struct timespec tv;
 
-	clock_gettime(CLOCK_MONOTONIC, &tv);
+	clock_gettime(CLOCK_REALTIME, &tv);
 	return tv.tv_sec + (tv.tv_nsec * 1e-9);
 }
 

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -953,12 +953,11 @@ static void generate_text(void)
 	}
 
 	double ui = active_update_interval();
+	double time = get_time();
 	next_update_time += ui;
-	if (next_update_time < get_time()) {
-		next_update_time = get_time() + ui;
-	} else if (next_update_time > get_time() + ui) {
-		next_update_time = get_time() + ui;
-	}
+	if (next_update_time < time ||
+		next_update_time > time + ui)
+		next_update_time = time - fmod(time, ui) + ui;
 	last_update_time = current_update_time;
 	total_updates++;
 }
@@ -2055,7 +2054,7 @@ static void main_loop(void)
 #endif
 
 	last_update_time = 0.0;
-	next_update_time = get_time();
+	next_update_time = get_time() - fmod(get_time(), active_update_interval());
 	info.looped = 0;
 	while (terminate == 0
 			&& (total_run_times.get(*state) == 0 || info.looped < total_run_times.get(*state))) {


### PR DESCRIPTION
This patch modifies logic for setting next_update_time such that the
update is done at full update_interval seconds. That is, for example
with update_interval 60.0, update is done at 00:00:00, 00:01:00,
00:02:00, etc.

This might be useful for using conky as a clock widget which only needs
to be updated once per minute, but is obliged to update exactly at
minute change.

It is implemented in a way that is (hopefully) immune to clockchanges
(as for example by NTP or DST).