### PR TITLE
Make mouse-through workable

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -60,6 +60,9 @@
 #ifdef BUILD_IMLIB2
 #include "imlib2.h"
 #endif /* BUILD_IMLIB2 */
+#ifdef BUILD_XSHAPE
+#include <X11/extensions/shape.h>
+#endif /* BUILD_XSHAPE */
 #endif /* BUILD_X11 */
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -2053,6 +2056,21 @@ static void main_loop(void)
 	sigaddset(&newmask, SIGTERM);
 	sigaddset(&newmask, SIGUSR1);
 #endif
+
+#ifdef BUILD_XSHAPE
+	/* allow only decorated windows to be given mouse input */
+	int major_version, minor_version;
+	if (!XShapeQueryVersion(display, &major_version, &minor_version)) {
+		NORM_ERR("Input shapes are not supported");
+	} else {
+		if (own_window.get(*state) &&
+		    (own_window_type.get(*state) != TYPE_NORMAL ||
+		     (TEST_HINT(own_window_hints.get(*state), HINT_UNDECORATED)))) {
+			XShapeCombineRectangles(display, window.window, ShapeInput, 0, 0,
+			   NULL, 0, ShapeSet, Unsorted);
+		}
+	}
+#endif /* BUILD_XSHAPE */
 
 	last_update_time = 0.0;
 	next_update_time = get_time();

--- a/src/x11.cc
+++ b/src/x11.cc
@@ -47,10 +47,6 @@
 #ifdef BUILD_XFT
 #include <X11/Xft/Xft.h>
 #endif
-#ifdef BUILD_XSHAPE
-#include <X11/extensions/shape.h>
-#include <X11/extensions/shapeconst.h>
-#endif
 #ifdef BUILD_XINERAMA
 #include <X11/extensions/Xinerama.h>
 #endif
@@ -761,24 +757,6 @@ static void init_window(lua::state &l __attribute__((unused)), bool own)
 			/* allow decorated windows to be given input focus by WM */
 			wmHint.input =
 				TEST_HINT(hints, HINT_UNDECORATED) ? False : True;
-#ifdef BUILD_XSHAPE
-			if (!wmHint.input) {
-				int event_base, error_base;
-				if (XShapeQueryExtension(display, &event_base, &error_base)) {
-					int major_version = 0, minor_version = 0;
-					XShapeQueryVersion(display, &major_version, &minor_version);
-					if ((major_version > 1) || ((major_version == 1) && (minor_version >=1))) {
-						Region empty_region = XCreateRegion();
-						XShapeCombineRegion(display, window.window, ShapeInput, 0, 0, empty_region, ShapeSet);
-						XDestroyRegion(empty_region);
-					} else {
-						NORM_ERR("Input shapes are not supported");
-					}
-				} else {
-					NORM_ERR("No shape extension found");
-				}
-			}
-#endif
 			if (own_window_type.get(l) == TYPE_DOCK || own_window_type.get(l) == TYPE_PANEL) {
 				wmHint.initial_state = WithdrawnState;
 			} else {


### PR DESCRIPTION
(Excuse me my bad english)
"Mouse-through" (or mouse transparency) is a significant feature for conky. It mean that all mouse events happened above the conky window must be passed to the next window in z-order (usually desktop window).
  Conku 1.9 did not provide the true mouse transparency, but it contains simulation of this: mouse clicks sends to the desktop window.
  Conky 1.10 loss this simulation and contains new code for the true mouse transparency using XSHAPE extension. This code  looks correct but in fact it has no effects for reasons unknown to me. As result conky 1.10 "eat" all mouse events above typical conky window. The similar code executed later works fine.
  This patch change also the conditions for mouse transparency enabling to the same from the conky 1.9 that looks more reasonable.
