### PR TITLE
solve double counting at start issue

### DIFF
--- a/src/linux.cc
+++ b/src/linux.cc
@@ -470,10 +470,12 @@ int update_net_stats(void)
 		if (ns->last_read_recv == -1) {
 			ns->recv = r;
 			first = 1;
+			ns->last_read_recv = r;
 		}
 		if (ns->last_read_trans == -1) {
 			ns->trans = t;
 			first = 1;
+			ns->last_read_trans = t;
 		}
 		/* move current traffic statistic to last thereby obsoleting the
 		 * current statistic */


### PR DESCRIPTION
In issue #218 I noticed a completely different bug, where after a restart the total traffic displayed changed from 60GB to 69GB. That was because the actual total traffic was actually 35GB. Before this commit `ns->recv` was set to `r` on init and also some lines down below `r` was additionally added to `ns->recv` resulting in a doubling of the total traffic read from `/proc/net/dev`