### PR TITLE
Improve to_bytes to work with input values with a decimal point

### DIFF
--- a/src/common.cc
+++ b/src/common.cc
@@ -733,16 +733,16 @@ void free_stock(struct text_object *obj)
 void print_to_bytes(struct text_object *obj, char *p, int p_max_size)
 {
 	std::vector<char> buf(max_user_text.get(*state));
-	long long bytes;
+	long double bytes;
 	char unit[16];	// 16 because we can also have long names (like mega-bytes)
 
 	generate_text_internal(&(buf[0]), max_user_text.get(*state), *obj->sub);
-	if(sscanf(&(buf[0]), "%lli%s", &bytes, unit) == 2 && strlen(unit) < 16){
-		if(strncasecmp("b", unit, 1) == 0) snprintf(&(buf[0]), max_user_text.get(*state), "%lli", bytes);
-		else if(strncasecmp("k", unit, 1) == 0) snprintf(&(buf[0]), max_user_text.get(*state), "%lli", bytes * 1024);
-		else if(strncasecmp("m", unit, 1) == 0) snprintf(&(buf[0]), max_user_text.get(*state), "%lli", bytes * 1024 * 1024);
-		else if(strncasecmp("g", unit, 1) == 0) snprintf(&(buf[0]), max_user_text.get(*state), "%lli", bytes * 1024 * 1024 * 1024);
-		else if(strncasecmp("t", unit, 1) == 0) snprintf(&(buf[0]), max_user_text.get(*state), "%lli", bytes * 1024 * 1024 * 1024 * 1024);
+	if(sscanf(&(buf[0]), "%Lf%s", &bytes, unit) == 2 && strlen(unit) < 16){
+		if(strncasecmp("b", unit, 1) == 0) snprintf(&(buf[0]), max_user_text.get(*state), "%Lf", bytes);
+		else if(strncasecmp("k", unit, 1) == 0) snprintf(&(buf[0]), max_user_text.get(*state), "%Lf", bytes * 1024);
+		else if(strncasecmp("m", unit, 1) == 0) snprintf(&(buf[0]), max_user_text.get(*state), "%Lf", bytes * 1024 * 1024);
+		else if(strncasecmp("g", unit, 1) == 0) snprintf(&(buf[0]), max_user_text.get(*state), "%Lf", bytes * 1024 * 1024 * 1024);
+		else if(strncasecmp("t", unit, 1) == 0) snprintf(&(buf[0]), max_user_text.get(*state), "%Lf", bytes * 1024 * 1024 * 1024 * 1024);
 	}
 	snprintf(p, p_max_size, "%s", &(buf[0]));
 }


### PR DESCRIPTION
Adjust the parsing of to_bytes to work correctly with non-integer input values, e.g. 1.24 MiB/s. Such kind of values may be returned by diskio_read and diskio_write for example.