### PR TITLE
Update immediately when the root pixmap changes

### DIFF
--- a/src/common.cc
+++ b/src/common.cc
@@ -122,8 +122,11 @@ int update_uname(void)
 double get_time(void)
 {
 	struct timespec tv;
-
+#ifdef _POSIX_MONOTONIC_CLOCK
+	clock_gettime(CLOCK_MONOTONIC, &tv);
+#else
 	clock_gettime(CLOCK_REALTIME, &tv);
+#endif
 	return tv.tv_sec + (tv.tv_nsec * 1e-9);
 }
 

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -2242,6 +2242,18 @@ static void main_loop(void)
 						if ( ev.xproperty.state == PropertyNewValue ) {
 							get_x11_desktop_info( ev.xproperty.display, ev.xproperty.atom );
 						}
+#ifdef USE_ARGB
+						if (!have_argb_visual) {
+#endif
+							if ( ev.xproperty.atom == ATOM(_XROOTPMAP_ID)
+									|| ev.xproperty.atom == ATOM(_XROOTMAP_ID)) {
+								draw_stuff();
+								next_update_time = get_time();
+								need_to_update = 1;
+							}
+#ifdef USE_ARGB
+						}
+#endif
 						break;
 					}
 


### PR DESCRIPTION
Second patch prefers the monotic timer, which cannot run backwards (and is cheaper to fetch ;-)