### PR TITLE
Make conky resolve symlinks before using them.

### DIFF
--- a/src/core.cc
+++ b/src/core.cc
@@ -122,17 +122,15 @@
  */
 const char *dev_name(const char *path)
 {
-	static char buf[255];	/* should be enough for pathnames */
-	ssize_t buflen;
+	static char buf[PATH_MAX];
 
 	if (!path)
 		return NULL;
 
 #define DEV_NAME(x) \
   x != NULL && strlen(x) > 5 && strncmp(x, "/dev/", 5) == 0 ? x + 5 : x
-	if ((buflen = readlink(path, buf, 254)) == -1)
+	if (realpath(path, buf) == NULL)
 		return DEV_NAME(path);
-	buf[buflen] = '\0';
 	return DEV_NAME(buf);
 #undef DEV_NAME
 }

--- a/src/diskio.cc
+++ b/src/diskio.cc
@@ -89,7 +89,7 @@ struct diskio_stat *prepare_diskio_stat(const char *s)
 
 	snprintf(&(stat_name[0]), text_buffer_size.get(*state), "/dev/%s", &(device_name[0]));
 
-	if (stat(&(stat_name[0]), &sb)) {
+	if (stat(&(stat_name[0]), &sb) || !S_ISBLK(sb.st_mode)) {
 		NORM_ERR("diskio device '%s' does not exist", &device_s[0]);
 	}
 

--- a/src/diskio.cc
+++ b/src/diskio.cc
@@ -60,23 +60,22 @@ struct diskio_stat *prepare_diskio_stat(const char *s)
 	struct stat sb;
 	std::vector<char> stat_name(text_buffer_size.get(*state)), device_name(text_buffer_size.get(*state)), device_s(text_buffer_size.get(*state));
 	struct diskio_stat *cur = &stats;
+	char * rpbuf;
 
 	if (!s) {
 		return &stats;
-	} else {
-		strncpy(&(device_s[0]), s, text_buffer_size.get(*state));
 	}
 
-	if (strncmp(&(device_s[0]), "label:", 6) == 0) {
-		snprintf(&(device_name[0]), text_buffer_size.get(*state), "/dev/disk/by-label/%s", &(device_s[6]));
-
-		char * rpbuf;
+	if (strncmp(s, "label:", 6) == 0) {
+		snprintf(&(device_name[0]), text_buffer_size.get(*state), "/dev/disk/by-label/%s", s+6);
 		rpbuf = realpath(&device_name[0], NULL);
-		if (rpbuf) {
-			strncpy(&device_s[0], rpbuf, text_buffer_size.get(*state));
-		}
-		free(rpbuf);
+	} else {
+		rpbuf = realpath(s, NULL);
+	}
 
+	if (rpbuf) {
+		strncpy(&device_s[0], rpbuf, text_buffer_size.get(*state));
+		free(rpbuf);
 	} else {
 		strncpy(&device_s[0], s, text_buffer_size.get(*state));
 	}
@@ -91,7 +90,7 @@ struct diskio_stat *prepare_diskio_stat(const char *s)
 	snprintf(&(stat_name[0]), text_buffer_size.get(*state), "/dev/%s", &(device_name[0]));
 
 	if (stat(&(stat_name[0]), &sb)) {
-		NORM_ERR("diskio device '%s' does not exist", s);
+		NORM_ERR("diskio device '%s' does not exist", &device_s[0]);
 	}
 
 	/* lookup existing */


### PR DESCRIPTION
This will fix an issue where someone wants to use a symlink like /dev/disk/by-id/wwn-* in its conkyrc. Usually, those links are pointed to ../../sd? and will break when used with readlink since conky cwd can be anywhere.

I made sure to replace readlink by realpath where diskio/diskiograph were in use.

I made sure to test conky with symlink, real device and label:.

Edit: Commits are now GPG signed.