### PR TITLE
fix build failure when compiled with -DBUILD_NVIDIA=ON

### DIFF
--- a/src/nvidia.cc
+++ b/src/nvidia.cc
@@ -232,7 +232,7 @@ const int translate_nvidia_attribute[] = {
 					0,
 					
 					NV_CTRL_THERMAL_COOLER_SPEED,
-					NV_CTRL_THERMAL_COOLER_CURRENT_LEVEL,		// NOTE: not sure if this should be NV_CTRL_THERMAL_COOLER_LEVEL instead
+					NV_CTRL_THERMAL_COOLER_LEVEL,
 
 					NV_CTRL_GPU_CURRENT_PERFORMANCE_LEVEL,
 					NV_CTRL_IMAGE_SETTINGS,


### PR DESCRIPTION
When conky 1.10.2 is built with -DBUILD_NVIDIA=ON, the following error occurs:

```
[ 94%] Building CXX object src/CMakeFiles/conky.dir/nvidia.cc.o
cd /build/conky-1.10.2/build-all/src && /usr/bin/c++   -D_LARGEFILE64_SOURCE -D_POSIX_C_SOURCE=200809L -I/build/conky-1.10.2/build-all -I/usr/include/freetype2 -I/usr/include/lua5.1 -I/usr/include/dbus-1.0 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/xmms2 -I/usr/include/libxml2 -I/build/conky-1.10.2/build-all/data  -std=c++0x -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2   -o CMakeFiles/conky.dir/nvidia.cc.o -c /build/conky-1.10.2/src/nvidia.cc
/build/conky-1.10.2/src/nvidia.cc:235:6: error: 'NV_CTRL_THERMAL_COOLER_CURRENT_LEVEL' was not declared in this scope
      NV_CTRL_THERMAL_COOLER_CURRENT_LEVEL,  // NOTE: not sure if this should be NV_CTRL_THERMAL_COOLER_LEVEL instead
      ^
src/CMakeFiles/conky.dir/build.make:1337: recipe for target 'src/CMakeFiles/conky.dir/nvidia.cc.o' failed
make[4]: *** [src/CMakeFiles/conky.dir/nvidia.cc.o] Error 1
```

This pull request fixes the above issue. Thanks!