### PR TITLE
Use text_buffer_size in print_evaluate for the buffer size

### DIFF
--- a/src/common.cc
+++ b/src/common.cc
@@ -556,7 +556,7 @@ void print_cached(struct text_object *obj, char *p, int p_max_size)
 
 void print_evaluate(struct text_object *obj, char *p, int p_max_size)
 {
-	std::vector<char> buf(max_user_text.get(*state));
+	std::vector<char> buf(text_buffer_size.get(*state));
 	evaluate(obj->data.s, &buf[0], buf.size());
 	evaluate(&buf[0], p, p_max_size);
 }


### PR DESCRIPTION
In response to https://github.com/brndnmtthws/conky/pull/226/files/933852d1b8194f1b22cd458ad412f52803a256f2#r62419283 .