### PR TITLE
Fix build failures on Debian kfreebsd

### DIFF
--- a/cmake/ConkyPlatformChecks.cmake
+++ b/cmake/ConkyPlatformChecks.cmake
@@ -54,7 +54,7 @@ endif(CMAKE_SYSTEM_NAME MATCHES "Linux")
 
 if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
 	set(OS_FREEBSD true)
-	set(conky_libs ${conky_libs} -lkvm -ldevstat)
+	set(conky_libs ${conky_libs} -lkvm -ldevstat -lbsd)
 endif(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
 
 if(CMAKE_SYSTEM_NAME MATCHES "DragonFly")

--- a/src/freebsd.cc
+++ b/src/freebsd.cc
@@ -725,9 +725,7 @@ void get_top_info(void)
 
 	for (i = 0; i < n_processes; i++) {
 		if (!((p[i].ki_flag & P_SYSTEM)) && p[i].ki_comm != NULL) {
-			proc = find_process(p[i].ki_pid);
-			if (!proc)
-				proc = new_process(p[i].ki_pid);
+			proc = get_process(p[i].ki_pid);
 
 			proc->time_stamp = g_time;
 			proc->name = strndup(p[i].ki_comm, text_buffer_size.get(*state));


### PR DESCRIPTION
( Forwarded from Debian [#815347](https://bugs.debian.org/815347) )

Conky currently fails to build from source on Debian's kfreebsd port:
```
[ 83%] Building CXX object src/CMakeFiles/conky.dir/freebsd.cc.o
cd /«PKGBUILDDIR»/build-std/src && /usr/bin/c++   -D_LARGEFILE64_SOURCE -D_POSIX_C_SOURCE=200809L -std=c++0x -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -I/«PKGBUILDDIR»/build-std -I/usr/include/freetype2 -I/usr/include/lua5.1 -I/«PKGBUILDDIR»/build-std/data    -o CMakeFiles/conky.dir/freebsd.cc.o -c /«PKGBUILDDIR»/src/freebsd.cc
/«PKGBUILDDIR»/src/freebsd.cc: In function 'void get_top_info()':
/«PKGBUILDDIR»/src/freebsd.cc:728:35: error: 'find_process' was not declared in this scope
    proc = find_process(p[i].ki_pid);
                                   ^
/«PKGBUILDDIR»/src/freebsd.cc:730:35: error: 'new_process' was not declared in this scope
     proc = new_process(p[i].ki_pid);
                                   ^
src/CMakeFiles/conky.dir/build.make:816: recipe for target 'src/CMakeFiles/conky.dir/freebsd.cc.o' failed
make[4]: *** [src/CMakeFiles/conky.dir/freebsd.cc.o] Error 1
```

With the above fixed, there's also a link-time failure:
```
Linking CXX executable conky
cd /home/vcheng/build/conky-1.10.2/build-std/src && /usr/bin/cmake -E cmake_link_script CMakeFiles/conky.dir/link.txt --verbose=1
/usr/bin/c++   -std=c++0x -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2   -Wl,-z,relro -Wl,--as-needed CMakeFiles/conky.dir/c++wrap.cc.o CMakeFiles/conky.dir/colours.cc.o CMakeFiles/conky.dir/combine.cc.o CMakeFiles/conky.dir/common.cc.o CMakeFiles/conky.dir/conky.cc.o CMakeFiles/conky.dir/core.cc.o CMakeFiles/conky.dir/diskio.cc.o CMakeFiles/conky.dir/entropy.cc.o CMakeFiles/conky.dir/exec.cc.o CMakeFiles/conky.dir/fs.cc.o CMakeFiles/conky.dir/mail.cc.o CMakeFiles/conky.dir/mixer.cc.o CMakeFiles/conky.dir/net_stat.cc.o CMakeFiles/conky.dir/template.cc.o CMakeFiles/conky.dir/mboxscan.cc.o CMakeFiles/conky.dir/read_tcpip.cc.o CMakeFiles/conky.dir/scroll.cc.o CMakeFiles/conky.dir/specials.cc.o CMakeFiles/conky.dir/tailhead.cc.o CMakeFiles/conky.dir/temphelper.cc.o CMakeFiles/conky.dir/text_object.cc.o CMakeFiles/conky.dir/timeinfo.cc.o CMakeFiles/conky.dir/top.cc.o CMakeFiles/conky.dir/algebra.cc.o CMakeFiles/conky.dir/prioqueue.cc.o CMakeFiles/conky.dir/proc.cc.o CMakeFiles/conky.dir/user.cc.o CMakeFiles/conky.dir/luamm.cc.o CMakeFiles/conky.dir/data-source.cc.o CMakeFiles/conky.dir/lua-config.cc.o CMakeFiles/conky.dir/setting.cc.o CMakeFiles/conky.dir/llua.cc.o CMakeFiles/conky.dir/update-cb.cc.o CMakeFiles/conky.dir/freebsd.cc.o CMakeFiles/conky.dir/bsdapm.cc.o CMakeFiles/conky.dir/mpd.cc.o CMakeFiles/conky.dir/libmpdclient.cc.o CMakeFiles/conky.dir/moc.cc.o CMakeFiles/conky.dir/x11.cc.o CMakeFiles/conky.dir/fonts.cc.o CMakeFiles/conky.dir/apcupsd.cc.o CMakeFiles/conky.dir/nc.cc.o  -o conky  -lpthread -lkvm -ldevstat -lm -lncurses -lSM -lICE -lX11 -lXext -lXdamage -lXfixes -lXft -lXext -llua5.1 -lXinerama -lXdamage -lXfixes -lXft -llua5.1 -lXinerama 
/usr/bin/ld: CMakeFiles/conky.dir/conky.cc.o: undefined reference to symbol 'optreset@@LIBBSD_0.0'
//lib/x86_64-kfreebsd-gnu/libbsd.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
src/CMakeFiles/conky.dir/build.make:1127: recipe for target 'src/conky' failed
make[4]: *** [src/conky] Error 1
```

This PR fixes both issues and allows conky to be compiled on Debian kfreebsd. Thanks for considering!
