### PR TITLE
scroll: add 'wait' and 'interval' parameters.

### DIFF
--- a/doc/variables.xml
+++ b/doc/variables.xml
@@ -3672,19 +3672,22 @@
             <command>
                 <option>scroll</option>
             </command>
-            <option>(direction) length (step) text</option>
+            <option>(direction) length (step) (interval) text</option>
         </term>
         <listitem>Scroll 'text' by 'step' characters to the left
-        or right (set 'direction' to 'left' or 'right') showing
-        'length' number of characters at the same time. The text
-        may also contain variables. 'step' is optional and defaults
-        to 1 if not set. 'direction' is optional and defaults to left
-        if not set. If a var creates output on multiple lines
-        then the lines are placed behind each other separated with
-        a '|'-sign. If you change the textcolor inside $scroll it
-        will automatically have it's old value back at the end of
-        $scroll. The end and the start of text will be separated by
-        'length' number of spaces. 
+	or right (set 'direction' to 'left' or 'right' or 'wait')
+	showing 'length' number of characters at the same time. The
+	text may also contain variables. 'step' is optional and
+	defaults to 1 if not set. 'direction' is optional and defaults
+	to left if not set.  When direction is 'wait' then text will
+	scroll left and wait for 'interval' itertations at the
+	beginning and end of the text.  If a var creates output on
+	multiple lines then the lines are placed behind each other
+	separated with a '|'-sign.  If you change the textcolor inside
+	$scroll it will automatically have it's old value back at the
+	end of $scroll.  The end and the start of text will be
+	separated by 'length' number of spaces unless direction is
+	'wait'.
         <para /></listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
Adds a 'wait' and 'interval' parameter to the scroll variable to pause 'interval' iterations at the beginning and end of the text. Will also trim leading and trailing 'length' from the text. I like this because a longer track title from 'mpd' can pause for me to read it before jumping back to the beginning.