### PR TITLE
 Alignment abbreviations not working , Update x11.cc

### DIFF
--- a/src/x11.cc
+++ b/src/x11.cc
@@ -246,6 +246,15 @@ conky::lua_traits<alignment>::Map conky::lua_traits<alignment>::map = {
 	{ "middle_left",   MIDDLE_LEFT },
 	{ "middle_middle", MIDDLE_MIDDLE },
 	{ "middle_right",  MIDDLE_RIGHT },
+	{ "tl",            TOP_LEFT },
+	{ "tr",            TOP_RIGHT },
+	{ "tm",            TOP_MIDDLE },
+	{ "bl",            BOTTOM_LEFT },
+	{ "br",            BOTTOM_RIGHT },
+	{ "bm",            BOTTOM_MIDDLE },
+	{ "ml",            MIDDLE_LEFT },
+	{ "mm",            MIDDLE_MIDDLE },
+	{ "mr",            MIDDLE_RIGHT },
 	{ "none",          NONE }
 };
 


### PR DESCRIPTION
Allignement abbreviations not working see  #284 

Problem is with x11.cc, I add the good code in the commit.
Can you merge to master branch ?