### PR TITLE
Check st_ctime to work with mutt MUA

### DIFF
--- a/src/mail.cc
+++ b/src/mail.cc
@@ -75,6 +75,7 @@ struct local_mail_s {
 	int trashed_mail_count;
 	float interval;
 	time_t last_mtime;
+	time_t last_ctime;      /* needed for mutt at least */
 	double last_update;
 };
 
@@ -333,7 +334,7 @@ static void update_mail_count(struct local_mail_s *mail)
 	}
 #endif
 	/* mbox format */
-	if (st.st_mtime != mail->last_mtime) {
+	if (st.st_mtime != mail->last_mtime || st.st_ctime != mail->last_ctime) {
 		/* yippee, modification time has changed, let's read mail count! */
 		static int rep;
 		FILE *fp;
@@ -438,6 +439,7 @@ static void update_mail_count(struct local_mail_s *mail)
 		}
 
 		mail->last_mtime = st.st_mtime;
+		mail->last_ctime = st.st_ctime;
 	}
 }
 


### PR DESCRIPTION
Check `st_ctime` (time of last status change) to properly update the mail count.
This is required when mutt MUA is used (this fix #277 issue).
Tested on Lubuntu 16.04.

(I have relied on the code of [/src/mboxscan.cc](https://github.com/brndnmtthws/conky/blob/master/src/mboxscan.cc)).

Thanks.
