### PR TITLE
top.cc: remove hard coded values of MAX_SP

### DIFF
--- a/src/top.cc
+++ b/src/top.cc
@@ -661,8 +661,8 @@ int parse_top_args(const char *s, const char *arg, struct text_object *obj)
 			free_and_zero(obj->data.opaque);
 			return 0;
 		}
-		if (n < 1 || n > 10) {
-			NORM_ERR("invalid num arg for top. Must be between 1 and 10.");
+		if (n < 1 || n > MAX_SP) {
+			NORM_ERR("invalid num arg for top. Must be between 1 and %d.", MAX_SP);
 			free_and_zero(td->s);
 			free_and_zero(obj->data.opaque);
 			return 0;


### PR DESCRIPTION
The value of MAX_SP (e.g. 10) was hard coded in some places in src/top.cc.
This prevents an easy change via changing MAX_SP in src/top.h.
2319a98936c8c5c3065da3fe919bf5ee04e63ae7 substitutes the hard coded values by MAX_SP itself.
If the source is compiled without modification, the existing behaviour is preserved.
However, if MAX_SP is changed, then the change will be consistent (e.g. if MAX_SP is increased to 20, you won't get "conky: invalid num arg for top. Must be between 1 and 10." if accessing ${top name 11} .. ${top name 20} and alike).
I have tested with values of 10 and 20 for MAX_SP, both with valid and invalid top-numbers.