### PR TITLE
Fix an out-of-range error in new_graph

### DIFF
--- a/src/specials.cc
+++ b/src/specials.cc
@@ -519,14 +519,12 @@ void new_graph(struct text_object *obj, char *buf, int buf_max_size, double val)
 		DBGP("reallocing graph from %d to %d", s->graph_allocated, s->graph_width);
 		if (!s->graph) {
 			/* initialize */
-			memset(graph, 0, s->graph_width * sizeof(double));
+			std::fill_n(graph, s->graph_width, 0.0);
 			s->scale = 100;
 		} else {
 			if (s->graph_width > s->graph_allocated) {
 				/* initialize the new region */
-				memset(graph + (s->graph_allocated * sizeof(double)), 0,
-						(s->graph_width - s->graph_allocated) *
-						sizeof(double));
+				std::fill(graph + s->graph_allocated, graph + s->graph_width, 0.0);
 			}
 		}
 		s->graph = graph;


### PR DESCRIPTION
The code was multiplying the index with the size of the element, and
then adding it to the typed pointer (resulting in a double
multiplication and an OOB access).

Replace the buggy code with a slightly safer c++ alternative.