### PR TITLE
fs.cc, linux.cc Use /proc/mounts for list of currently mounted fs

### DIFF
--- a/src/fs.cc
+++ b/src/fs.cc
@@ -151,13 +151,13 @@ void get_fs_type(const char *path, char *result)
 #else				/* HAVE_STRUCT_STATFS_F_FSTYPENAME */
 
 	struct mntent *me;
-	FILE *mtab = setmntent("/etc/mtab", "r");
+	FILE *mtab = setmntent("/proc/mounts", "r");
 	char *search_path;
 	int match;
 	char *slash;
 
 	if (mtab == NULL) {
-		NORM_ERR("setmntent /etc/mtab: %s", strerror(errno));
+		NORM_ERR("setmntent /proc/mounts: %s", strerror(errno));
 		strncpy(result, "unknown", DEFAULT_TEXT_BUFFER_SIZE);
 		return;
 	}

--- a/src/linux.cc
+++ b/src/linux.cc
@@ -143,7 +143,7 @@ int check_mount(struct text_object *obj)
 	if (!obj->data.s)
 		return 0;
 
-	if ((mtab = fopen("/etc/mtab", "r"))) {
+	if ((mtab = fopen("/proc/mounts", "r"))) {
 		char buf1[256], buf2[129];
 
 		while (fgets(buf1, 256, mtab)) {


### PR DESCRIPTION
Per manpage of mount(1) in newer util-linux:

>The programs mount and umount traditionally maintained a list of currently mounted filesystems in the file /etc/mtab.  This real mtab file is still supported, but on current Linux systems it is better to make it a symlink to /proc/mounts instead, because a regular mtab file maintained in userspace cannot reliably work with namespaces, containers and other advanced Linux features.

In most new Linux (e.g. Debian) /etc/mtab is already symlinked to /proc/mounts.

See https://github.com/karelzak/util-linux/commit/e778642a9eb96975fcf3baa61dfa10add628af1a for the gory details.