### PR TITLE
enable persistent view of irc messages

### DIFF
--- a/cmake/ConkyPlatformChecks.cmake
+++ b/cmake/ConkyPlatformChecks.cmake
@@ -95,7 +95,7 @@ if(BUILD_ICAL)
 endif(BUILD_ICAL)
 
 if(BUILD_IRC)
-	check_include_files(libircclient/libircclient.h IRC_H_)
+	check_include_files(libircclient.h IRC_H_)
 	if(NOT IRC_H_)
 		message(FATAL_ERROR "Unable to find libircclient")
 	endif(NOT IRC_H_)

--- a/doc/variables.xml
+++ b/doc/variables.xml
@@ -1756,11 +1756,12 @@
             <command>
                 <option>irc</option>
             </command>
-            <option>server(:port) #channel</option>
+            <option>server(:port) #channel (max_msg_lines)</option>
         </term>
         <listitem>Shows everything that's being told in #channel on IRCserver
         'server'. TCP-port 6667 is used for the connection unless 'port' is
-        specified.
+        specified. Shows everything since the last time or the last
+        'max_msg_lines' entries if specified.
         <para /></listitem>
     </varlistentry>
     <varlistentry>

--- a/src/irc.cc
+++ b/src/irc.cc
@@ -62,23 +62,27 @@ void addmessage(struct ctx *ctxptr, char *nick, const char *text) {
 	newmsg->text = (char*) malloc(strlen(nick) + strlen(text) + 4);	//4 = ": \n"
 	sprintf(newmsg->text, "%s: %s\n", nick, text);
 	newmsg->next = NULL;
+	int msgcnt = 1;
 	if(!lastmsg) {
 		ctxptr->messages = newmsg;
 	} else {
+		msgcnt++;
 		while(lastmsg->next) {
 			lastmsg = lastmsg->next;
+			msgcnt++;
+			if(msgcnt<0) {
+				NORM_ERR("irc: too many messages, discarding the last one.");
+				free(newmsg->text);
+				free(newmsg);
+				return;
+			}
 		}
 		lastmsg->next = newmsg;
 	}
 	if(ctxptr->max_msg_lines>0) {
-		int msgcnt = 0;
 		newmsg = ctxptr->messages;
-		while(newmsg) {
-			newmsg = newmsg->next;
-			msgcnt++;
-		}
 		msgcnt -= ctxptr->max_msg_lines;
-		while(msgcnt>0) {
+		while((msgcnt>0) && (ctxptr->messages)) {
 			msgcnt--;
 			newmsg = ctxptr->messages->next;
 			free(ctxptr->messages->text);

--- a/src/irc.cc
+++ b/src/irc.cc
@@ -29,7 +29,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "text_object.h"
-#include <libircclient/libircclient.h>
+#include <libircclient.h>
 
 struct ll_text {
 	char *text;


### PR DESCRIPTION
* remove directory from `libirc`-include
* give possibility to specify number-of-last-lines to show for irc instead of showing all lines since last time `${irc server(:port) #channel (number-of-lines)}`
* is backwards compatible: omitting number-of-lines resorts to old behaviour