### PR TITLE
Fix error when generating man pages from XML

### DIFF
--- a/doc/config_settings.xml
+++ b/doc/config_settings.xml
@@ -80,7 +80,7 @@
         </term>
         <listitem>A comma-separated list of strings to use as the bars of a graph output
         to console/shell. The first list item is used for the minimum bar height and the
-        last item is used for the maximum. Example: " ,_,▁,▂,▃,▄,▅,▆,▇,█".
+        last item is used for the maximum. Example: " ,_,=,#".
         <para /></listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
Fixes the following error when running `docgen.sh`:

    /usr/bin/iconv: illegal input sequence at position 8008
    /usr/bin/db2x_manxml: program in pipeline exited with an error

Solution: Replace Unicode characters with characters that iconv can
convert. Uses the same characters as the default setting, defined in
9809f7cd91be1aa56932e655a78cad451f236304.

Seen when using:
- `iconv` from glibc 2.24
- `db2x_manxml` from linuxdoc-tools 0.9.72 (with docbook2X 0.8.8-14 debian)
- Slackware64 -current