### PR TITLE
Fix drawing text shades

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1930,7 +1930,9 @@ static void draw_text(void)
 
 static void draw_stuff(void)
 {
+#ifndef BUILD_X11
 	static int text_offset_x, text_offset_y; /* offset for start position */
+#endif
 	text_offset_x = text_offset_y = 0;
 #ifdef BUILD_IMLIB2
 	cimlib_render(text_start_x, text_start_y, window.width, window.height);


### PR DESCRIPTION
I was notified in a Gentoo bug [1] that there are issues with drawing text shades. This was also mentioned in issue #331. According to the bug/issue this pull request should fix the problem.

[1] https://bugs.gentoo.org/show_bug.cgi?id=610444