### PR TITLE
eve: address apparently spurious libcurl recv errors

### DIFF
--- a/src/eve.cc
+++ b/src/eve.cc
@@ -186,7 +186,9 @@ static char *getXmlFromAPI(const char *apiKeyID, const char *apiVCode, const cha
 
 	curl_easy_setopt(curl_handle, CURLOPT_URL, real_url.c_str());
 
-	if ((rc = curl_easy_perform(curl_handle)) != CURLE_OK) {
+	rc = curl_easy_perform(curl_handle);
+
+	if (chr.data == NULL) {
 		return NULL;
 	}
 


### PR DESCRIPTION
Some time after the last eve-related PR libcurl began returning
`CURLE_RECV_ERROR` from `curl_easy_perform()`, even when the request returns
good data that is otherwise usable.

Now, if the `struct xmlData` has been populated by write_data, we use whatever
came back (almost invariably a complete XML response). We don't depend on
libcurl returning CURLE_OK.