### PR TITLE
Fixed #373, segmentation fault when HOME is unset

### DIFF
--- a/src/common.cc
+++ b/src/common.cc
@@ -130,11 +130,12 @@ double get_time(void)
 	return tv.tv_sec + (tv.tv_nsec * 1e-9);
 }
 
-/* Converts '~/...' paths to '/home/blah/...'
- * It's similar to variable_substitute, except only cheques for $HOME and ~/ in path */
+/* Converts '~/...' paths to '/home/blah/...'.  It's similar to
+ * variable_substitute, except only cheques for $HOME and ~/ in
+ * path. If HOME is unset it uses an empty string for substitution */
 std::string to_real_path(const std::string &source)
 {
-	const char *homedir = getenv("HOME");
+	const char *homedir = getenv("HOME") ? : "";
 	if(source.find("~/") == 0)
 		return homedir + source.substr(1);
 	else if(source.find("$HOME/") == 0)


### PR DESCRIPTION
Running conky with `$HOME` unset would cause a segmentation fault
```
-> unset HOME; conky
Segmentation fault (core dumped)
```
In `std::string to_real_path(const std::string &source)`, the local variable `homedir` is set to the return value of `getenv("HOME")`. This returns a NULL pointer when `$HOME` isn't set. The segmentation fault occurred when `homedir` was later dereferenced. I fixed this by setting `homedir` to an empty string when `$HOME` isn't set.

The segmentation fault no longer occurs when `$HOME` is unset, conky will most likely use the system config in this case. There is no change to how conky acts when `$HOME` is set.