### PR TITLE
enable irc to use ipv6 if host can't be reached via ipv4

### DIFF
--- a/src/irc.cc
+++ b/src/irc.cc
@@ -157,8 +157,20 @@ void *ircclient(void *ptr) {
 	} else {
 		port = IRCPORT;
 	}
-	if(irc_connect(ircobj->session, server, port, IRCSERVERPASS, IRCNICK, IRCUSER, IRCREAL) != 0) {
-		NORM_ERR("irc: %s", irc_strerror(irc_errno(ircobj->session)));
+	int err = irc_connect(ircobj->session, server, port, IRCSERVERPASS, IRCNICK, IRCUSER, IRCREAL);
+	if(err != 0) {
+		err = irc_errno(ircobj->session);
+	}
+#ifdef BUILD_IPV6
+	if(err == LIBIRC_ERR_RESOLV) {
+		err = irc_connect6(ircobj->session, server, port, IRCSERVERPASS, IRCNICK, IRCUSER, IRCREAL);
+		if(err != 0) {
+			err = irc_errno(ircobj->session);
+		}
+	}
+#endif /* BUILD_IPV6 */
+	if(err != 0) {
+		NORM_ERR("irc: %s", irc_strerror(err));
 	}
 	if(irc_run(ircobj->session) != 0) {
 		int ircerror = irc_errno(ircobj->session);


### PR DESCRIPTION
With this patch, the irc client tries to resolve a host as IPv4 address and if that fails, it tries to resolve the host as IPv6. (Obviously, in order to succeed, the latter requires libircclient to be compiled with "--enable-ipv6")