### PR TITLE
NVIDIA: Cleared TODO for the multi-GPU support

### DIFF
--- a/doc/variables.xml
+++ b/doc/variables.xml
@@ -1103,11 +1103,13 @@
             <command>
                 <option>eve</option>
             </command>
-            <option>api_userid api_key character_id</option>
+            <option>api_keyID api_vCode character_id</option>
         </term>
-        <listitem>Fetches your currently training skill from the
-        Eve Online API servers (http://www.eve-online.com/) and
-        displays the skill along with the remaining training time. 
+        <listitem>Fetches a character's currently training skill from
+        the Eve Online API servers (http://www.eveonline.com/) and
+        displays the skill along with the remaining training time.
+        If the character is not actively training a skill then returns
+        the empty string (for use with $if_empty).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1756,11 +1758,12 @@
             <command>
                 <option>irc</option>
             </command>
-            <option>server(:port) #channel</option>
+            <option>server(:port) #channel (max_msg_lines)</option>
         </term>
         <listitem>Shows everything that's being told in #channel on IRCserver
         'server'. TCP-port 6667 is used for the connection unless 'port' is
-        specified.
+        specified. Shows everything since the last time or the last
+        'max_msg_lines' entries if specified.
         <para /></listitem>
     </varlistentry>
     <varlistentry>

--- a/doc/variables.xml
+++ b/doc/variables.xml
@@ -1103,13 +1103,11 @@
             <command>
                 <option>eve</option>
             </command>
-            <option>api_keyID api_vCode character_id</option>
+            <option>api_userid api_key character_id</option>
         </term>
-        <listitem>Fetches a character's currently training skill from
-        the Eve Online API servers (http://www.eveonline.com/) and
-        displays the skill along with the remaining training time.
-        If the character is not actively training a skill then returns
-        the empty string (for use with $if_empty).
+        <listitem>Fetches your currently training skill from the
+        Eve Online API servers (http://www.eve-online.com/) and
+        displays the skill along with the remaining training time. 
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1758,12 +1756,11 @@
             <command>
                 <option>irc</option>
             </command>
-            <option>server(:port) #channel (max_msg_lines)</option>
+            <option>server(:port) #channel</option>
         </term>
         <listitem>Shows everything that's being told in #channel on IRCserver
         'server'. TCP-port 6667 is used for the connection unless 'port' is
-        specified. Shows everything since the last time or the last
-        'max_msg_lines' entries if specified.
+        specified.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2781,10 +2778,14 @@
                 <option>nvidia</option>
             </command>
             <option>argument</option>
+            <option>(GPU_ID)</option>
         </term>
         <listitem>Nvidia graphics card information via the XNVCtrl
         library.
-        <para />
+        <para>
+        <emphasis>GPU_ID:</emphasis> Optional parameter to choose the GPU to be used as 0,1,2,3,.. Default parameter is 0
+        </para>
+        <para>
         <emphasis>Possible arguments:</emphasis> (Temperatures are
         printed as float, all other values as integer. Bracketed
         arguments are aliases)
@@ -2925,8 +2926,12 @@
                 <command>imagequality</command>
                 <option>Image quality</option>
             </member>
+            <member>
+                <command>modelname</command>
+                <option>name of the GPU card</option>
+            </member>
         </simplelist>
-        <para /></listitem>
+        </para></listitem>
     </varlistentry>
     <varlistentry>
         <term>
@@ -2935,12 +2940,16 @@
             </command>
             <option>(height),(width)</option>
             <option>argument</option>
+            <option>(GPU_ID)</option>
         </term>
         <listitem>Same as nvidia, except it draws its output in a
         horizontal bar. The height and width parameters are optional,
         and default to the default_bar_height and default_bar_width
         config settings, respectively.
-        <para />
+        <para>
+        <emphasis>GPU_ID:</emphasis> Optional parameter to choose the GPU to be used as 0,1,2,3,.. Default parameter is 0
+        </para>
+        <para>
         <emphasis>Note the following arguments are incompatible:</emphasis>
         <simplelist type='horiz' columns='3'>
             <member>
@@ -2982,7 +2991,7 @@
                 <command>fanspeed</command>
             </member>
         </simplelist>
-        <para /></listitem>
+        </para></listitem>
     </varlistentry>
     <varlistentry>
         <term>
@@ -2991,15 +3000,19 @@
             </command>
             <option>(height),(width)</option>
             <option>argument</option>
+            <option>(GPU_ID)</option>
         </term>
         <listitem>Same as nvidiabar, except  a round gauge
         (much like a vehicle speedometer). The height
         and width parameters are optional, and default to the
         default_gauge_height and default_gauge_width config
         settings, respectively.
-        <para />
+        <para>
+        <emphasis>GPU_ID:</emphasis> Optional parameter to choose the GPU to be used as 0,1,2,3,.. Default parameter is 0
+        </para>
+        <para>
         For possible arguments see nvidia and nvidiabar.
-        <para /></listitem>
+        </para></listitem>
     </varlistentry>
     <varlistentry>
         <term>
@@ -3013,17 +3026,21 @@
             <option>(scale)</option>
             <option>(-t)</option>
             <option>(-l)</option>
+            <option>GPU_ID</option>
         </term>
         <listitem>Same as nvidiabar, except a horizontally
         scrolling graph with values from 0-100 plotted on the
         vertical axis. The height and width parameters are
         optional, and default to the default_graph_height and
         default_graph_width config settings, respectively.
-        <para />
+        <para>
+        <emphasis>GPU_ID:</emphasis> NOT optional. This parameter allows to choose the GPU to be used as 0,1,2,3,..
+        </para>
+        <para>
         For possible arguments see nvidia and nvidiabar. To learn more
         about the -t -l and gradient color options,
         see execgraph.
-        <para /></listitem>
+        </para></listitem>
     </varlistentry>
     <varlistentry>
         <term>

--- a/src/nvidia.cc
+++ b/src/nvidia.cc
@@ -35,8 +35,6 @@
  * Fonic <fonic.maxxim@live.com>
  * 
  * TODO:
- * - Add third argument to module to allow querying multiple GPUs/fans etc.,
- *   e.g. ${nvidia gputemp 2}, ${nvidia fanlevel 1}
  * - Move decoding of GPU/MEM freqs to print_nvidia_value() using QUERY_SPECIAL
  *   so that all quirks are located there
  * - Implement nvs->print_type to allow control over how the value is printed
@@ -44,23 +42,24 @@
  * 
  * Showcase (conky.conf):
  * --==| NVIDIA | ==--
- * GPU   ${nvidia gpufreq}MHz (${nvidia gpufreqmin}-${nvidia gpufreqmax}MHz)
- * MEM   ${nvidia memfreq}MHz (${nvidia memfreqmin}-${nvidia memfreqmax}MHz)
- * MTR   ${nvidia mtrfreq}MHz (${nvidia mtrfreqmin}-${nvidia mtrfreqmax}MHz)
- * PERF  Level ${nvidia perflevel} (${nvidia perflevelmin}-${nvidia perflevelmax}), Mode: ${nvidia perfmode}
- * VRAM  ${nvidia memutil}% (${nvidia memused}MB/${nvidia memtotal}MB)
- * LOAD  GPU ${nvidia gpuutil}%, RAM ${nvidia membwutil}%, VIDEO ${nvidia videoutil}%, PCIe ${nvidia pcieutil}%
- * TEMP  GPU ${nvidia gputemp}°C (${nvidia gputempthreshold}°C max.), SYS ${nvidia ambienttemp}°C
- * FAN   ${nvidia fanspeed} RPM (${nvidia fanlevel}%)
+ * GPU    ${nvidia gpufreq [gpu_id]}MHz (${nvidia gpufreqmin [gpu_id]}-${nvidia gpufreqmax [gpu_id]}MHz)
+ * MEM    ${nvidia memfreq [gpu_id]}MHz (${nvidia memfreqmin [gpu_id]}-${nvidia memfreqmax [gpu_id]}MHz)
+ * MTR    ${nvidia mtrfreq [gpu_id]}MHz (${nvidia mtrfreqmin [gpu_id]}-${nvidia mtrfreqmax [gpu_id]}MHz)
+ * PERF   Level ${nvidia perflevel [gpu_id]} (${nvidia perflevelmin [gpu_id]}-${nvidia perflevelmax [gpu_id]}), Mode: ${nvidia perfmode [gpu_id]}
+ * VRAM   ${nvidia memutil [gpu_id]}% (${nvidia memused [gpu_id]}MB/${nvidia memtotal [gpu_id]}MB)
+ * LOAD   GPU ${nvidia gpuutil [gpu_id]}%, RAM ${nvidia membwutil [gpu_id]}%, VIDEO ${nvidia videoutil [gpu_id]}%, PCIe ${nvidia pcieutil [gpu_id]}%
+ * TEMP   GPU ${nvidia gputemp [gpu_id]}°C (${nvidia gputempthreshold [gpu_id]}°C max.), SYS ${nvidia ambienttemp [gpu_id]}°C
+ * FAN    ${nvidia fanspeed [gpu_id]} RPM (${nvidia fanlevel [gpu_id]}%)
+ * OPENGL ${nvidia imagequality [gpu_id]} 
  * 
  * --==| NVIDIA Bars |==--
- * LOAD ${nvidiabar gpuutil}
- * VRAM ${nvidiabar memutil}
- * RAM ${nvidiabar membwutil}
- * VIDEO ${nvidiabar videoutil}
- * PCIe ${nvidiabar pcieutil}
- * Fan ${nvidiabar fanlevel}
- * TEMP ${nvidiabar gputemp}
+ * LOAD ${nvidiabar gpuutil [gpu_id]}
+ * VRAM ${nvidiabar memutil [gpu_id]}
+ * RAM ${nvidiabar membwutil [gpu_id]}
+ * VIDEO ${nvidiabar videoutil [gpu_id]}
+ * PCIe ${nvidiabar pcieutil [gpu_id]}
+ * Fan ${nvidiabar fanlevel [gpu_id]}
+ * TEMP ${nvidiabar gputemp [gpu_id]}
  * 
  */
 
@@ -309,6 +308,31 @@ struct nvidia_s {
 	ATTR_ID attribute;
 	char *token;
 	SEARCH_ID search;
+//  added new field for GPU id
+    int gpu_id;
+};
+
+//maximum number of GPU connected:
+//for cache: choosed a model of direct access to array instead of list for speed improvement
+//value based on the incoming Naples tech and having 256 PCIe lanes available
+const int MAXNUMGPU=64;
+
+//Cache by value
+struct nvidia_c_value {
+    int memtotal = -1;
+	int gputempthreshold = -1;
+};
+
+//Cache by string
+struct nvidia_c_string {
+	int nvclockmin = -1;
+	int nvclockmax = -1;
+	int memclockmin = -1;
+	int memclockmax = -1;
+	int memTransferRatemin = -1;
+	int memTransferRatemax = -1;
+	int perfmin = -1;
+	int perfmax = -1;
 };
 
 static Display *nvdisplay;
@@ -365,11 +389,23 @@ int set_nvidia_query(struct text_object *obj, const char *arg, unsigned int spec
 {
 	struct nvidia_s *nvs;
 	int aid;
+    int argc;
+    char uri[128];
 
 	// Initialize global struct
 	obj->data.opaque = malloc(sizeof(struct nvidia_s));
 	nvs = static_cast<nvidia_s *>(obj->data.opaque);
 	memset(nvs, 0, sizeof(struct nvidia_s));
+
+    // Added new parameter parsing GPU_ID as 0,1,2,..
+    // if no second parameter then default to 0
+    nvs->gpu_id = 0;
+    argc = sscanf(arg, "%s %i", uri, &nvs->gpu_id);
+    arg = uri;
+    
+    //nvs->gpu_id = abs( nvs->gpu_id );
+    if (nvs->gpu_id < 0) nvs->gpu_id = 0;
+      
 
 	// Extract arguments for nvidiabar, etc, and run set_nvidia_query
 	switch (special_type) {
@@ -395,7 +431,7 @@ int set_nvidia_query(struct text_object *obj, const char *arg, unsigned int spec
 	}
 	//fprintf(stderr, "parameter: %s -> aid: %d\n", arg, aid);
 	
-	// Save pointers to the arg and command strings for dubugging and printing
+	// Save pointers to the arg and command strings for debugging and printing
 	nvs->arg = translate_module_argument[aid];
 	nvs->command = translate_nvidia_special_type[special_type];
 
@@ -602,9 +638,11 @@ static inline int get_nvidia_target_count(Display *dpy, TARGET_ID tid)
 }
 
 // Exit if we are unable to get targets of type tid on display dpy
-void check_nvidia_target_count(Display *dpy, TARGET_ID tid, ATTR_ID aid)
+void check_nvidia_target_count(Display *dpy, TARGET_ID tid, ATTR_ID aid, int *gid)
 {
 	int num_tgts = get_nvidia_target_count(dpy, tid);
+    
+    if( *gid > ( num_tgts - 1 ) ) *gid = num_tgts - 1;
 
 	if(num_tgts < 1) {
 		// Print error and exit if there's not enough targets to query
@@ -616,30 +654,29 @@ void check_nvidia_target_count(Display *dpy, TARGET_ID tid, ATTR_ID aid)
 	}
 }
 
-static int cache_nvidia_value(TARGET_ID tid, ATTR_ID aid, Display *dpy, int *value)
+static int cache_nvidia_value(TARGET_ID tid, ATTR_ID aid, Display *dpy, int *value, int gid)
 {
-	static int memtotal = -1;
-	static int gputempthreshold = -1;
+    static nvidia_c_value ac_value[MAXNUMGPU];
 
 	if (aid == ATTR_MEM_TOTAL) {
-		if (memtotal < 0) {
-			if(!dpy || !XNVCTRLQueryTargetAttribute(dpy, translate_nvidia_target[tid], 0, 0, translate_nvidia_attribute[aid], value)){
+		if (ac_value[gid].memtotal < 0) {
+			if(!dpy || !XNVCTRLQueryTargetAttribute(dpy, translate_nvidia_target[tid], gid, 0, translate_nvidia_attribute[aid], value)){
 				NORM_ERR("%s: Something went wrong running nvidia query (tid: %d, aid: %d)", __func__, tid, aid);
 				return -1;
 			}
-			memtotal = *value;
+			ac_value[gid].memtotal = *value;
 		} else {
-			*value = memtotal;
+			*value = ac_value[gid].memtotal;
 		}
 	} else if (aid == ATTR_GPU_TEMP_THRESHOLD) {
-		if (gputempthreshold < 0) {
-			if(!dpy || !XNVCTRLQueryTargetAttribute(dpy, translate_nvidia_target[tid], 0, 0, translate_nvidia_attribute[aid], value)){
+		if (ac_value[gid].gputempthreshold < 0) {
+			if(!dpy || !XNVCTRLQueryTargetAttribute(dpy, translate_nvidia_target[tid], gid, 0, translate_nvidia_attribute[aid], value)){
 				NORM_ERR("%s: Something went wrong running nvidia query (tid: %d, aid: %d)", __func__, tid, aid);
 				return -1;
 			}
-			gputempthreshold = *value;
+			ac_value[gid].gputempthreshold = *value;
 		} else {
-			*value = gputempthreshold;
+			*value = ac_value[gid].gputempthreshold;
 		}
 	}
 
@@ -647,22 +684,24 @@ static int cache_nvidia_value(TARGET_ID tid, ATTR_ID aid, Display *dpy, int *val
 }
 
 // Retrieve attribute value via nvidia interface
-static int get_nvidia_value(TARGET_ID tid, ATTR_ID aid)
+static int get_nvidia_value(TARGET_ID tid, ATTR_ID aid, int gid)
 {
 	Display *dpy = nvdisplay ? nvdisplay : display;
 	int value;
+    int lgid;
 
 	// Check for issues
-	check_nvidia_target_count(dpy, tid, aid);
+    lgid = gid;
+	check_nvidia_target_count(dpy, tid, aid, &lgid);
 
 	// Check if the aid is cacheable
 	if (aid == ATTR_MEM_TOTAL || aid == ATTR_GPU_TEMP_THRESHOLD) {
-		if (cache_nvidia_value(tid, aid, dpy, &value)) {
+		if (cache_nvidia_value(tid, aid, dpy, &value, lgid)) {
 			return -1;
 		}
 	// If not, then query it
 	} else {
-		if(!dpy || !XNVCTRLQueryTargetAttribute(dpy, translate_nvidia_target[tid], 0, 0, translate_nvidia_attribute[aid], &value)){
+		if(!dpy || !XNVCTRLQueryTargetAttribute(dpy, translate_nvidia_target[tid], lgid, 0, translate_nvidia_attribute[aid], &value)){
 			NORM_ERR("%s: Something went wrong running nvidia query (tid: %d, aid: %d)", __func__, tid, aid);
 			return -1;
 		}
@@ -680,84 +719,80 @@ static int get_nvidia_value(TARGET_ID tid, ATTR_ID aid)
 
 
 // Retrieve attribute string via nvidia interface
-static char* get_nvidia_string(TARGET_ID tid, ATTR_ID aid)
+static char* get_nvidia_string(TARGET_ID tid, ATTR_ID aid, int gid)
 {
 	Display *dpy = nvdisplay ? nvdisplay : display;
 	char *str;
+    int lgid;
 
 	// Check for issues
-	check_nvidia_target_count(dpy, tid, aid);
+    lgid = gid;
+	check_nvidia_target_count(dpy, tid, aid, &lgid);
 	
 	// Query nvidia interface
-	if (!dpy || !XNVCTRLQueryTargetStringAttribute(dpy, translate_nvidia_target[tid], 0, 0, translate_nvidia_attribute[aid], &str)) {
-		NORM_ERR("%s: Something went wrong running nvidia string query (tid: %d, aid: %d)", __func__, tid, aid);
+	if (!dpy || !XNVCTRLQueryTargetStringAttribute(dpy, translate_nvidia_target[tid], lgid, 0, translate_nvidia_attribute[aid], &str)) {
+		NORM_ERR("%s: Something went wrong running nvidia string query (tid: %d, aid: %d, GPU %d)", __func__, tid, aid, lgid);
 		return NULL;
 	}
-	//fprintf(stderr, "%s", str);
+	//fprintf(stderr, "checking get_nvidia_string-> '%s'", str);
 	return str;
 }
 
-static int cache_nvidia_string_value(TARGET_ID tid, ATTR_ID aid, char *token, SEARCH_ID search, int *value, int update)
-{
-	static int nvclockmin = -1;
-	static int nvclockmax = -1;
-	static int memclockmin = -1;
-	static int memclockmax = -1;
-	static int memTransferRatemin = -1;
-	static int memTransferRatemax = -1;
-	static int perfmin = -1;
-	static int perfmax = -1;
+static int cache_nvidia_string_value(TARGET_ID tid, ATTR_ID aid, char *token, SEARCH_ID search, int *value, int update, int gid)
+{   
+    static nvidia_c_string ac_string[MAXNUMGPU];
 
 	if (update) {
-		if (strcmp(token, (char*) "nvclockmin") == 0 && nvclockmin < 0){
-			nvclockmin = *value;
-		} else if (strcmp(token, (char*) "nvclockmax") == 0 && nvclockmax < 0){
-			nvclockmax = *value;
-		} else if (strcmp(token, (char*) "memclockmin") == 0 && memclockmin < 0){
-			memclockmin = *value;
-		} else if (strcmp(token, (char*) "memclockmax") == 0 && memclockmax < 0){
-			memclockmax = *value;
-		} else if (strcmp(token, (char*) "memTransferRatemin") == 0 && memTransferRatemin < 0){
-			memTransferRatemin = *value;
-		} else if (strcmp(token, (char*) "memTransferRatemax") == 0 && memTransferRatemax < 0){
-			memTransferRatemax = *value;
+		if (strcmp(token, (char*) "nvclockmin") == 0 && ac_string[gid].nvclockmin < 0){
+			ac_string[gid].nvclockmin = *value;
+		} else if (strcmp(token, (char*) "nvclockmax") == 0 && ac_string[gid].nvclockmax < 0){
+			ac_string[gid].nvclockmax = *value;
+		} else if (strcmp(token, (char*) "memclockmin") == 0 && ac_string[gid].memclockmin < 0){
+			ac_string[gid].memclockmin = *value;
+		} else if (strcmp(token, (char*) "memclockmax") == 0 && ac_string[gid].memclockmax < 0){
+			ac_string[gid].memclockmax = *value;
+		} else if (strcmp(token, (char*) "memTransferRatemin") == 0 && ac_string[gid].memTransferRatemin < 0){
+			ac_string[gid].memTransferRatemin = *value;
+		} else if (strcmp(token, (char*) "memTransferRatemax") == 0 && ac_string[gid].memTransferRatemax < 0){
+			ac_string[gid].memTransferRatemax = *value;
 
-		} else if (strcmp(token, (char*) "perf") == 0 && memTransferRatemax < 0){
+		} else if (strcmp(token, (char*) "perf") == 0 && ac_string[gid].memTransferRatemax < 0){
 			if (search == SEARCH_MIN) {
-				perfmin = *value;
+				ac_string[gid].perfmin = *value;
 			} else if (search == SEARCH_MAX) {
-				perfmax = *value;
+				ac_string[gid].perfmax = *value;
 			}
 		}
-
+        
 	} else {
 		if (strcmp(token, (char*) "nvclockmin") == 0){
-			*value = nvclockmin;
+			*value = ac_string[gid].nvclockmin;
 		} else if (strcmp(token, (char*) "nvclockmax") == 0){
-			*value = nvclockmax;
+			*value = ac_string[gid].nvclockmax;
 		} else if (strcmp(token, (char*) "memclockmin") == 0){
-			*value = memclockmin;
+			*value = ac_string[gid].memclockmin;
 		} else if (strcmp(token, (char*) "memclockmax") == 0){
-			*value = memclockmax;
+			*value = ac_string[gid].memclockmax;
 		} else if (strcmp(token, (char*) "memTransferRatemin") == 0){
-			*value = memTransferRatemin;
+			*value = ac_string[gid].memTransferRatemin;
 		} else if (strcmp(token, (char*) "memTransferRatemax") == 0){
-			*value = memTransferRatemax;
+			*value = ac_string[gid].memTransferRatemax;
 
 		} else if (strcmp(token, (char*) "perf") == 0){
 			if (search == SEARCH_MIN) {
-				*value = perfmin;
+				*value = ac_string[gid].perfmin;
 			} else if (search == SEARCH_MAX) {
-					*value = perfmax;
+					*value = ac_string[gid].perfmax;
 			}
 		}
+        
 	}
 
 	return 0;
 }
 
 // Retrieve token value from nvidia string
-static int get_nvidia_string_value(TARGET_ID tid, ATTR_ID aid, char *token, SEARCH_ID search)
+static int get_nvidia_string_value(TARGET_ID tid, ATTR_ID aid, char *token, SEARCH_ID search, int gid)
 {
 	char *str;
 	char *kvp, *key, *val;
@@ -767,13 +802,13 @@ static int get_nvidia_string_value(TARGET_ID tid, ATTR_ID aid, char *token, SEAR
 	value = -1;
 
 	// Checks if the value is cacheable and is already loaded
-	cache_nvidia_string_value(tid, aid, token, search, &value, 0);
+	cache_nvidia_string_value(tid, aid, token, search, &value, 0, gid);
 	if ( value != -1 ) {
 		return value;
 	}
 
 	// Get string via nvidia interface
-	str = get_nvidia_string(tid, aid);
+	str = get_nvidia_string(tid, aid, gid);
 
 	// Split string into 'key=value' substrings, split substring
 	// into key and value, from value, check if token was found,
@@ -805,7 +840,7 @@ static int get_nvidia_string_value(TARGET_ID tid, ATTR_ID aid, char *token, SEAR
 	}
 
 	// This call updated the cache for the cacheable values;
-	cache_nvidia_string_value(tid, aid, token, search, &value, 1);
+	cache_nvidia_string_value(tid, aid, token, search, &value, 1, gid);
 	
 	// TESTING - print raw string if token was not found;
 	// string has to be queried again due to strtok_r()
@@ -836,18 +871,18 @@ void print_nvidia_value(struct text_object *obj, char *p, int p_max_size)
 	if (nvs != NULL) {
 		switch (nvs->query) {
 			case QUERY_VALUE:
-				value = get_nvidia_value(nvs->target, nvs->attribute);
+				value = get_nvidia_value(nvs->target, nvs->attribute, nvs->gpu_id);
 				break;
 			case QUERY_STRING:
-				str = get_nvidia_string(nvs->target, nvs->attribute);
+				str = get_nvidia_string(nvs->target, nvs->attribute, nvs->gpu_id);
 				break;
 			case QUERY_STRING_VALUE:
-				value = get_nvidia_string_value(nvs->target, nvs->attribute, nvs->token, nvs->search);
+				value = get_nvidia_string_value(nvs->target, nvs->attribute, nvs->token, nvs->search, nvs->gpu_id);
 				break;
 			case QUERY_SPECIAL:
 				switch (nvs->attribute) {
 					case ATTR_PERF_MODE:
-						temp1 = get_nvidia_value(nvs->target, nvs->attribute);
+						temp1 = get_nvidia_value(nvs->target, nvs->attribute, nvs->gpu_id);
 						switch (temp1) {
 							case NV_CTRL_GPU_POWER_MIZER_MODE_ADAPTIVE:
 								temp2 = asprintf(&str, "Adaptive");
@@ -866,19 +901,21 @@ void print_nvidia_value(struct text_object *obj, char *p, int p_max_size)
 						}
 						break;
 					case ATTR_MEM_FREE:
-						temp1 = get_nvidia_value(nvs->target, ATTR_MEM_USED);
-						temp2 = get_nvidia_value(nvs->target, ATTR_MEM_TOTAL);
+						temp1 = get_nvidia_value(nvs->target, ATTR_MEM_USED, nvs->gpu_id);
+						temp2 = get_nvidia_value(nvs->target, ATTR_MEM_TOTAL, nvs->gpu_id);
 						value = temp2 - temp1;
 						break;
 					case ATTR_MEM_UTIL:
-						temp1 = get_nvidia_value(nvs->target, ATTR_MEM_USED);
-						temp2 = get_nvidia_value(nvs->target, ATTR_MEM_TOTAL);
+						temp1 = get_nvidia_value(nvs->target, ATTR_MEM_USED, nvs->gpu_id);
+						temp2 = get_nvidia_value(nvs->target, ATTR_MEM_TOTAL, nvs->gpu_id);
 						value = ((float)temp1 * 100 / (float)temp2) + 0.5;
 						break;
 				}
 				break;
 		}
 	}
+
+//fprintf(stderr, "print_nvidia_value->  value: '%d' str: '%s' GPU: '%i' \n", value, str, nvs->gpu_id);
 	
 	// Print result
 	if (value != -1) {
@@ -889,6 +926,7 @@ void print_nvidia_value(struct text_object *obj, char *p, int p_max_size)
 	} else {
 		snprintf(p, p_max_size, "N/A");
 	}
+
 	
 }
 
@@ -904,17 +942,17 @@ double get_nvidia_barval(struct text_object *obj) {
 	if (nvs != NULL) {
 		switch (nvs->attribute) {
 			case ATTR_UTILS_STRING: // one of the percentage utils (gpuutil, membwutil, videoutil and pcieutil)
-				value = get_nvidia_string_value(nvs->target, ATTR_UTILS_STRING, nvs->token, nvs->search);
+				value = get_nvidia_string_value(nvs->target, ATTR_UTILS_STRING, nvs->token, nvs->search, nvs->gpu_id);
 				break;
 			case ATTR_MEM_UTIL: // memutil
 			case ATTR_MEM_USED:
-				temp1 = get_nvidia_value(nvs->target, ATTR_MEM_USED);
-				temp2 = get_nvidia_value(nvs->target, ATTR_MEM_TOTAL);
+				temp1 = get_nvidia_value(nvs->target, ATTR_MEM_USED, nvs->gpu_id);
+				temp2 = get_nvidia_value(nvs->target, ATTR_MEM_TOTAL, nvs->gpu_id);
 				value = ((float)temp1 * 100 / (float)temp2) + 0.5;
 				break;
 			case ATTR_MEM_FREE: // memfree
-				temp1 = get_nvidia_value(nvs->target, ATTR_MEM_USED);
-				temp2 = get_nvidia_value(nvs->target, ATTR_MEM_TOTAL);
+				temp1 = get_nvidia_value(nvs->target, ATTR_MEM_USED, nvs->gpu_id);
+				temp2 = get_nvidia_value(nvs->target, ATTR_MEM_TOTAL, nvs->gpu_id);
 				value = temp2 - temp1;
 				break;
 			case ATTR_FAN_SPEED: // fanspeed: Warn user we are using fanlevel
@@ -922,26 +960,26 @@ double get_nvidia_barval(struct text_object *obj) {
 								nvs->command, nvs->arg);
 				// No break, continue into fanlevel
 			case ATTR_FAN_LEVEL: // fanlevel
-				value = get_nvidia_value(nvs->target, ATTR_FAN_LEVEL);
+				value = get_nvidia_value(nvs->target, ATTR_FAN_LEVEL, nvs->gpu_id);
 				break;
 			case ATTR_GPU_TEMP: // gputemp (calculate out of gputempthreshold)
-				temp1 = get_nvidia_value(nvs->target, ATTR_GPU_TEMP);
-				temp2 = get_nvidia_value(nvs->target, ATTR_GPU_TEMP_THRESHOLD);
+				temp1 = get_nvidia_value(nvs->target, ATTR_GPU_TEMP, nvs->gpu_id);
+				temp2 = get_nvidia_value(nvs->target, ATTR_GPU_TEMP_THRESHOLD, nvs->gpu_id);
 				value = ((float)temp1 * 100 / (float)temp2) + 0.5;
 				break;
 			case ATTR_AMBIENT_TEMP: // ambienttemp (calculate out of gputempthreshold for consistency)
-				temp1 = get_nvidia_value(nvs->target, ATTR_AMBIENT_TEMP);
-				temp2 = get_nvidia_value(nvs->target, ATTR_GPU_TEMP_THRESHOLD);
+				temp1 = get_nvidia_value(nvs->target, ATTR_AMBIENT_TEMP, nvs->gpu_id);
+				temp2 = get_nvidia_value(nvs->target, ATTR_GPU_TEMP_THRESHOLD, nvs->gpu_id);
 				value = ((float)temp1 * 100 / (float)temp2) + 0.5;
 				break;
 			case ATTR_GPU_FREQ: // gpufreq (calculate out of gpufreqmax)
-				temp1 = get_nvidia_value(nvs->target, ATTR_GPU_FREQ);
-				temp2 = get_nvidia_string_value(nvs->target, ATTR_PERFMODES_STRING, (char*) "nvclockmax", SEARCH_MAX);
+				temp1 = get_nvidia_value(nvs->target, ATTR_GPU_FREQ, nvs->gpu_id);
+				temp2 = get_nvidia_string_value(nvs->target, ATTR_PERFMODES_STRING, (char*) "nvclockmax", SEARCH_MAX, nvs->gpu_id);
 				value = ((float)temp1 * 100 / (float)temp2) + 0.5;
 				break;
 			case ATTR_MEM_FREQ: // memfreq (calculate out of memfreqmax)
-				temp1 = get_nvidia_value(nvs->target, ATTR_MEM_FREQ);
-				temp2 = get_nvidia_string_value(nvs->target, ATTR_PERFMODES_STRING, (char*) "memclockmax", SEARCH_MAX);
+				temp1 = get_nvidia_value(nvs->target, ATTR_MEM_FREQ, nvs->gpu_id);
+				temp2 = get_nvidia_string_value(nvs->target, ATTR_PERFMODES_STRING, (char*) "memclockmax", SEARCH_MAX, nvs->gpu_id);
 				value = ((float)temp1 * 100 / (float)temp2) + 0.5;
 				break;
 			case ATTR_FREQS_STRING: // mtrfreq (calculate out of memfreqmax)
@@ -951,13 +989,13 @@ double get_nvidia_barval(struct text_object *obj) {
 					          nvs->command, nvs->arg);
 					return 0;
 				}
-				temp1 = get_nvidia_string_value(nvs->target, ATTR_FREQS_STRING, nvs->token, SEARCH_MAX);
-				temp2 = get_nvidia_string_value(nvs->target, ATTR_PERFMODES_STRING, (char*) "memTransferRatemax", SEARCH_MAX);
+				temp1 = get_nvidia_string_value(nvs->target, ATTR_FREQS_STRING, nvs->token, SEARCH_MAX, nvs->gpu_id);
+				temp2 = get_nvidia_string_value(nvs->target, ATTR_PERFMODES_STRING, (char*) "memTransferRatemax", SEARCH_MAX, nvs->gpu_id);
 				if (temp2 > temp1) temp1 = temp2; // extra safe here
 				value = ((float)temp1 * 100 / (float)temp2) + 0.5;
 				break;
 			case ATTR_IMAGE_QUALITY: // imagequality
-				value = get_nvidia_value(nvs->target, ATTR_IMAGE_QUALITY);
+				value = get_nvidia_value(nvs->target, ATTR_IMAGE_QUALITY, nvs->gpu_id);
 				break;
 
 			default: // Throw error if unsupported args are used


### PR DESCRIPTION
## Added an optional parameter to the commands nvidia and nvidiabar for Multi-GPU support

- If the parameter is omited default value is 0 for GPU0
              The parameter is the GPU index starting at 0 as 0,1,2,3,...

              Note: Except for the command nvidiagraph where the parameter is not optional

- Updated the conky.conf showcase to see how to use the enhancement

- Enhanced the cache system for multi-GPU support.

- Added a new variable for the command nvidia:
             modelname return a string with the model name of the GPU

- Optimized execution:
            In every execution the query XNVCTRLQueryTargetCount was executed. 
            Now this query is only executed once the first time

- Updated the documentation to explain how to use the multi-gpu as well as the new command "modelname"


## Proof test of the cache system for cache-value and cache-string:

[nvidia_cache_value_test.txt](https://github.com/brndnmtthws/conky/files/877302/nvidia_cache_value_test.txt)

[nvidia_cache_string_test.txt](https://github.com/brndnmtthws/conky/files/877304/nvidia_cache_string_test.txt)

## Suggested update for wiki/configuration-variables:
[Configuration-Variables_new_text.txt](https://github.com/brndnmtthws/conky/files/877307/Configuration-Variables_new_text.txt)

## Conky running on four Nvidia 1080:
Advantages of this pull request

- Avoiding the execi commands and the optimization of the query has reduced dramatically the CPU usage. 
- Because of the resource usage reduction it is possible now to have it with an interval of 1s without impact

![image](https://cloud.githubusercontent.com/assets/26737562/24775274/614b6672-1b1c-11e7-93eb-1cecc4ecc1a9.png)

