### PR TITLE
Fix gcc-7 compilation error.

### DIFF
--- a/src/luamm.hh
+++ b/src/luamm.hh
@@ -28,6 +28,7 @@
 #include <exception>
 #include <stdexcept>
 #include <string>
+#include <functional>
 
 #include <lua.hpp>
 


### PR DESCRIPTION
Fix for issue #396.
Also gentoo bug:
https://bugs.gentoo.org/show_bug.cgi?id=624104

Needed due to GCC include changes as stated in documentation:
Several C++ Standard Library headers have been changed to no longer include the <functional> header. As such, C++ programs that used components defined in <functional> without explicitly including that header will no longer compile.