### PR TITLE
Provide support to query the active port on PulseAudio's default sink

### DIFF
--- a/doc/variables.xml
+++ b/doc/variables.xml
@@ -3075,6 +3075,24 @@
     <varlistentry>
         <term>
             <command>
+                <option>pa_sink_active_port_name</option>
+            </command>
+        </term>
+        <listitem>Pulseaudio's default sink active port name. 
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>pa_sink_active_port_description</option>
+            </command>
+        </term>
+        <listitem>Pulseaudio's default sink active port description. 
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
                 <option>pa_card_name</option>
             </command>
         </term>

--- a/src/core.cc
+++ b/src/core.cc
@@ -1888,6 +1888,14 @@ struct text_object *construct_text_object(char *s, const char *arg,
 		obj->callbacks.print = &print_puau_sink_description;
         obj->callbacks.free = &free_pulseaudio;
 	    init_pulseaudio(obj);
+	END OBJ(pa_sink_active_port_name, 0)
+		obj->callbacks.print = &print_puau_sink_active_port_name;
+		obj->callbacks.free = &free_pulseaudio;
+		init_pulseaudio(obj);
+	END OBJ(pa_sink_active_port_description, 0)
+		obj->callbacks.print = &print_puau_sink_active_port_description;
+		obj->callbacks.free = &free_pulseaudio;
+		init_pulseaudio(obj);
 	END OBJ(pa_sink_volume, 0)
 		obj->callbacks.percentage = &puau_vol;
         obj->callbacks.free = &free_pulseaudio;

--- a/src/pulseaudio.cc
+++ b/src/pulseaudio.cc
@@ -43,7 +43,7 @@ struct pulseaudio_default_results get_result_copy();
 
 
 const struct pulseaudio_default_results pulseaudio_result0 =
-             { std::string(), std::string(), 0, 0, 0, 0, std::string(), std::string(), 0 };
+             { std::string(), std::string(), std::string(), std::string(), 0, 0, 0, 0, std::string(), std::string(), 0 };
 pulseaudio_c *pulseaudio = NULL;
 
 void pa_sink_info_callback(pa_context *c, const pa_sink_info *i, int eol, void *data) {
@@ -53,6 +53,8 @@ void pa_sink_info_callback(pa_context *c, const pa_sink_info *i, int eol, void *
         pdr->sink_mute = i->mute;
         pdr->sink_card = i->card;
         pdr->sink_index = i->index;
+        pdr->sink_active_port_name.assign(i->active_port->name);
+        pdr->sink_active_port_description.assign(i->active_port->description);
         pdr->sink_volume = round_to_int(100.0f * (float)pa_cvolume_avg(&(i->volume)) / (float)PA_VOLUME_NORM);
         pa_threaded_mainloop_signal(pulseaudio->mainloop, 0);
     }
@@ -282,6 +284,14 @@ int puau_muted(struct text_object *obj) {
 
 void print_puau_sink_description(struct text_object *obj, char *p, int p_max_size) {
     snprintf(p, p_max_size, "%s", get_pulseaudio(obj).sink_description.c_str());
+}
+
+void print_puau_sink_active_port_name(struct text_object *obj, char *p, int p_max_size) {
+	snprintf(p, p_max_size, "%s", get_pulseaudio(obj).sink_active_port_name.c_str());
+}
+
+void print_puau_sink_active_port_description(struct text_object *obj, char *p, int p_max_size) {
+	snprintf(p, p_max_size, "%s", get_pulseaudio(obj).sink_active_port_description.c_str());
 }
 
 void print_puau_card_active_profile(struct text_object *obj, char *p, int p_max_size) {

--- a/src/pulseaudio.h
+++ b/src/pulseaudio.h
@@ -38,6 +38,8 @@ void init_pulseaudio(struct text_object *obj);
 void free_pulseaudio(struct text_object *obj);
 uint8_t puau_vol(struct text_object *); // preserve pa_* for libpulse
 void  print_puau_sink_description(struct text_object *obj, char *p, int p_max_size);
+void  print_puau_sink_active_port_name(struct text_object *obj, char *p, int p_max_size);
+void  print_puau_sink_active_port_description(struct text_object *obj, char *p, int p_max_size);
 void  print_puau_card_name(struct text_object *obj, char *p, int p_max_size);
 void  print_puau_card_active_profile(struct text_object *obj, char *p, int p_max_size);
 double puau_volumebarval(struct text_object *obj);
@@ -47,6 +49,8 @@ struct pulseaudio_default_results {
     // default sink
     std::string sink_name;
     std::string sink_description;
+    std::string sink_active_port_name;
+    std::string sink_active_port_description;
     uint32_t sink_card;
     int sink_mute;
 	uint32_t sink_index;
@@ -77,7 +81,7 @@ class pulseaudio_c {
 				   context(NULL),
 				   cstate(PULSE_CONTEXT_INITIALIZING),
 				   ninits(0),
-				   result({ std::string(), std::string(), 0, 0, 0, 0, std::string(), std::string(), 0 }){};
+				   result({ std::string(), std::string(), std::string(), std::string(), 0, 0, 0, 0, std::string(), std::string(), 0 }){};
 };
 
 #endif /* _PULSEAUDIO_H */


### PR DESCRIPTION
The rationale for this is to make Conky aware of different ports on a PA sink (e.g. Speakers/Headphones/Line-In)
Usage example: (somewhere in the config)
`${if_match "${pa_sink_active_port_description}"=="Headphones"}Headphones are plugged in${endif}`
Also see some screenshots: ![some](https://user-images.githubusercontent.com/1869179/28523032-47d44c24-7083-11e7-8690-6d9594bce29f.png) ![screenshots](https://user-images.githubusercontent.com/1869179/28523033-47ddef40-7083-11e7-8f27-a036daa0b512.png)
