### PR TITLE
Add diskiof/diskio_readf/diskio_writef

### DIFF
--- a/src/core.cc
+++ b/src/core.cc
@@ -609,12 +609,21 @@ struct text_object *construct_text_object(char *s, const char *arg,
 	END OBJ(diskio, &update_diskio)
 		parse_diskio_arg(obj, arg);
 		obj->callbacks.print = &print_diskio;
+	END OBJ(diskiof, &update_diskio)
+		parse_diskio_arg(obj, arg);
+		obj->callbacks.print = &print_diskiof;
 	END OBJ(diskio_read, &update_diskio)
 		parse_diskio_arg(obj, arg);
 		obj->callbacks.print = &print_diskio_read;
+	END OBJ(diskio_readf, &update_diskio)
+		parse_diskio_arg(obj, arg);
+		obj->callbacks.print = &print_diskio_readf;
 	END OBJ(diskio_write, &update_diskio)
 		parse_diskio_arg(obj, arg);
 		obj->callbacks.print = &print_diskio_write;
+	END OBJ(diskio_writef, &update_diskio)
+		parse_diskio_arg(obj, arg);
+		obj->callbacks.print = &print_diskio_writef;
 #ifdef BUILD_X11
 	END OBJ(diskiograph, &update_diskio)
 		parse_diskiograph_arg(obj, arg);

--- a/src/diskio.cc
+++ b/src/diskio.cc
@@ -117,44 +117,64 @@ void parse_diskio_arg(struct text_object *obj, const char *arg)
 	obj->data.opaque = prepare_diskio_stat(arg);
 }
 
-/* dir indicates the direction:
- * -1: read
- *  0: read + write
- *  1: write
- */
-static void print_diskio_dir(struct text_object *obj, int dir, char *p, int p_max_size)
+static void print_diskio_human_readable(double val, char *p, int p_max_size)
 {
-	struct diskio_stat *diskio = (struct diskio_stat *)obj->data.opaque;
-	double val;
-
-	if (!diskio)
-		return;
-
-	if (dir < 0)
-		val = diskio->current_read;
-	else if (dir == 0)
-		val = diskio->current;
-	else
-		val = diskio->current_write;
-
 	/* TODO: move this correction from kB to kB/s elsewhere
 	 * (or get rid of it??) */
 	human_readable((val / active_update_interval()) * 1024LL, p, p_max_size);
 }
 
+static void print_diskio_kib(double val, char *p, int p_max_size)
+{
+	spaced_print(p, p_max_size, "%.1f", 8, val / active_update_interval());
+}
+
 void print_diskio(struct text_object *obj, char *p, int p_max_size)
 {
-	print_diskio_dir(obj, 0, p, p_max_size);
+	struct diskio_stat *diskio = (struct diskio_stat *)obj->data.opaque;
+	if (!diskio)
+		return;
+	print_diskio_human_readable(diskio->current, p, p_max_size);
+}
+
+void print_diskiof(struct text_object *obj, char *p, int p_max_size)
+{
+	struct diskio_stat *diskio = (struct diskio_stat *)obj->data.opaque;
+	if (!diskio)
+		return;
+	print_diskio_kib(diskio->current, p, p_max_size);
 }
 
 void print_diskio_read(struct text_object *obj, char *p, int p_max_size)
 {
-	print_diskio_dir(obj, -1, p, p_max_size);
+	struct diskio_stat *diskio = (struct diskio_stat *)obj->data.opaque;
+	if (!diskio)
+		return;
+	print_diskio_human_readable(diskio->current_read, p, p_max_size);
+}
+
+void print_diskio_readf(struct text_object *obj, char *p, int p_max_size)
+{
+	struct diskio_stat *diskio = (struct diskio_stat *)obj->data.opaque;
+	if (!diskio)
+		return;
+	print_diskio_kib(diskio->current_read, p, p_max_size);
 }
 
 void print_diskio_write(struct text_object *obj, char *p, int p_max_size)
 {
-	print_diskio_dir(obj, 1, p, p_max_size);
+	struct diskio_stat *diskio = (struct diskio_stat *)obj->data.opaque;
+	if (!diskio)
+		return;
+	print_diskio_human_readable(diskio->current_write, p, p_max_size);
+}
+
+void print_diskio_writef(struct text_object *obj, char *p, int p_max_size)
+{
+	struct diskio_stat *diskio = (struct diskio_stat *)obj->data.opaque;
+	if (!diskio)
+		return;
+	print_diskio_kib(diskio->current_write, p, p_max_size);
 }
 
 #ifdef BUILD_X11

--- a/src/diskio.h
+++ b/src/diskio.h
@@ -69,8 +69,11 @@ void update_diskio_values(struct diskio_stat *, unsigned int, unsigned int);
 
 void parse_diskio_arg(struct text_object *, const char *);
 void print_diskio(struct text_object *, char *, int);
+void print_diskiof(struct text_object *, char *, int);
 void print_diskio_read(struct text_object *, char *, int);
+void print_diskio_readf(struct text_object *, char *, int);
 void print_diskio_write(struct text_object *, char *, int);
+void print_diskio_writef(struct text_object *, char *, int);
 #ifdef BUILD_X11
 void parse_diskiograph_arg(struct text_object *, const char *);
 double diskiographval(struct text_object *);


### PR DESCRIPTION
Add an interface to unformatted disk i/o statistics (like we have e.g.
downspeed/downspeedf for formatted/unformatted download speed). This
makes it easier to consume disk i/o statistics for custom graphs.