### PR TITLE
Revert back drawing text shades fix (#371)

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1936,9 +1936,9 @@ static void draw_text(void)
 
 static void draw_stuff(void)
 {
-#ifndef BUILD_X11
+
 	static int text_offset_x, text_offset_y; /* offset for start position */
-#endif
+
 	text_offset_x = text_offset_y = 0;
 #ifdef BUILD_IMLIB2
 	cimlib_render(text_start_x, text_start_y, window.width, window.height);


### PR DESCRIPTION
This patch affect diskio read (write) graphs too. And possible on rest graphs... This is absolutely not good. 