### PR TITLE
Fixed crash caused by temporary virtual net interfaces

### DIFF
--- a/src/net_stat.cc
+++ b/src/net_stat.cc
@@ -51,15 +51,20 @@
 /* network interface stuff */
 
 enum if_up_strictness_ {
-	IFUP_UP, IFUP_LINK, IFUP_ADDR
+	IFUP_UP,
+	IFUP_LINK,
+	IFUP_ADDR
 };
 
 template<>
-conky::lua_traits<if_up_strictness_>::Map conky::lua_traits<if_up_strictness_>::map =
-		{ { "up", IFUP_UP }, { "link", IFUP_LINK }, { "address", IFUP_ADDR } };
+conky::lua_traits<if_up_strictness_>::Map conky::lua_traits<if_up_strictness_>::map = {
+	{ "up",      IFUP_UP },
+	{ "link",    IFUP_LINK },
+	{ "address", IFUP_ADDR }
+};
 
-static conky::simple_config_setting<if_up_strictness_> if_up_strictness(
-		"if_up_strictness", IFUP_UP, true);
+static conky::simple_config_setting<if_up_strictness_> if_up_strictness("if_up_strictness",
+																		IFUP_UP, true);
 /**
  * global array of structs containing network statistics for each interface
  **/
@@ -74,8 +79,8 @@ struct net_stat foo_netstats;
  *
  * @param[in] dev  device / interface name. Silently ignores char * == NULL
  **/
-struct net_stat *get_net_stat(const char *dev, void *free_at_crash1,
-		void *free_at_crash2) {
+struct net_stat *get_net_stat(const char *dev, void *free_at_crash1, void *free_at_crash2)
+{
 	unsigned int i;
 
 	if (!dev) {
@@ -89,17 +94,18 @@ struct net_stat *get_net_stat(const char *dev, void *free_at_crash1,
 		}
 	}
 
-	/* wasn't found? add it or returning foo_netstats if list already full*/
+	/* wasn't found? add it */
 	for (i = 0; i < MAX_NET_INTERFACES; i++) {
 		if (netstats[i].dev == 0) {
 			netstats[i].dev = strndup(dev, text_buffer_size.get(*state));
 			/* initialize last_read_recv and last_read_trans to -1 denoting
 			 * that they were never read before */
-			netstats[i].last_read_recv = -1;
+			netstats[i].last_read_recv  = -1;
 			netstats[i].last_read_trans = -1;
 			return &netstats[i];
 		}
 	}
+
 	clear_net_stats(&foo_netstats);
 	foo_netstats.dev = strndup(dev, text_buffer_size.get(*state));
 	/* initialize last_read_recv and last_read_trans to -1 denoting
@@ -109,37 +115,31 @@ struct net_stat *get_net_stat(const char *dev, void *free_at_crash1,
 	return &foo_netstats;
 }
 
-void parse_net_stat_arg(struct text_object *obj, const char *arg,
-		void *free_at_crash) {
+void parse_net_stat_arg(struct text_object *obj, const char *arg, void *free_at_crash)
+{
 	bool shownetmask = false;
 	bool showscope = false;
 	char nextarg[21];	//longest arg possible is a devname (max 20 chars)
-	int i = 0;
+	int i=0;
 	struct net_stat *netstat = NULL;
 
 	if (!arg)
 		arg = DEFAULTNETDEV;
 
-	while (sscanf(arg + i, " %20s", nextarg) == 1) {
-		if (strcmp(nextarg, "-n") == 0 || strcmp(nextarg, "--netmask") == 0)
-			shownetmask = true;
-		else if (strcmp(nextarg, "-s") == 0 || strcmp(nextarg, "--scope") == 0)
-			showscope = true;
-		else if (nextarg[0] == '-') {	//multiple flags in 1 arg
-			for (int j = 1; nextarg[j] != 0; j++) {
-				if (nextarg[j] == 'n')
-					shownetmask = true;
-				if (nextarg[j] == 's')
-					showscope = true;
+	while(sscanf(arg+i, " %20s", nextarg) == 1) {
+		if(strcmp(nextarg, "-n") == 0 || strcmp(nextarg, "--netmask") == 0) shownetmask = true;
+		else if(strcmp(nextarg, "-s") == 0 || strcmp(nextarg, "--scope") == 0) showscope = true;
+		else if(nextarg[0]=='-') {	//multiple flags in 1 arg
+			for(int j=1; nextarg[j] != 0; j++) {
+				if(nextarg[j]=='n') shownetmask = true;
+				if(nextarg[j]=='s') showscope = true;
 			}
-		} else
-			netstat = get_net_stat(nextarg, obj, free_at_crash);
-		i += strlen(nextarg);	//skip this arg
-		while (!(isspace(arg[i]) || arg[i] == 0))
-			i++; //and skip the spaces in front of it
+		}
+		else netstat = get_net_stat(nextarg, obj, free_at_crash);
+		i+=strlen(nextarg);	//skip this arg
+		while( ! (isspace(arg[i]) || arg[i] == 0)) i++; //and skip the spaces in front of it
 	}
-	if (netstat == NULL)
-		netstat = get_net_stat(DEFAULTNETDEV, obj, free_at_crash);
+	if(netstat == NULL) netstat = get_net_stat(DEFAULTNETDEV, obj, free_at_crash);
 
 #ifdef BUILD_IPV6
 	netstat->v6show_nm = shownetmask;
@@ -148,8 +148,8 @@ void parse_net_stat_arg(struct text_object *obj, const char *arg,
 	obj->data.opaque = netstat;
 }
 
-void parse_net_stat_bar_arg(struct text_object *obj, const char *arg,
-		void *free_at_crash) {
+void parse_net_stat_bar_arg(struct text_object *obj, const char *arg, void *free_at_crash)
+{
 	if (arg) {
 		arg = scan_bar(obj, arg, 1);
 		obj->data.opaque = get_net_stat(arg, obj, free_at_crash);
@@ -161,8 +161,9 @@ void parse_net_stat_bar_arg(struct text_object *obj, const char *arg,
 	}
 }
 
-void print_downspeed(struct text_object *obj, char *p, int p_max_size) {
-	struct net_stat *ns = (struct net_stat *) obj->data.opaque;
+void print_downspeed(struct text_object *obj, char *p, int p_max_size)
+{
+	struct net_stat *ns = (struct net_stat *)obj->data.opaque;
 
 	if (!ns)
 		return;
@@ -170,8 +171,9 @@ void print_downspeed(struct text_object *obj, char *p, int p_max_size) {
 	human_readable(ns->recv_speed, p, p_max_size);
 }
 
-void print_downspeedf(struct text_object *obj, char *p, int p_max_size) {
-	struct net_stat *ns = (struct net_stat *) obj->data.opaque;
+void print_downspeedf(struct text_object *obj, char *p, int p_max_size)
+{
+	struct net_stat *ns = (struct net_stat *)obj->data.opaque;
 
 	if (!ns)
 		return;
@@ -179,8 +181,9 @@ void print_downspeedf(struct text_object *obj, char *p, int p_max_size) {
 	spaced_print(p, p_max_size, "%.1f", 8, ns->recv_speed / 1024.0);
 }
 
-void print_upspeed(struct text_object *obj, char *p, int p_max_size) {
-	struct net_stat *ns = (struct net_stat *) obj->data.opaque;
+void print_upspeed(struct text_object *obj, char *p, int p_max_size)
+{
+	struct net_stat *ns = (struct net_stat *)obj->data.opaque;
 
 	if (!ns)
 		return;
@@ -188,8 +191,9 @@ void print_upspeed(struct text_object *obj, char *p, int p_max_size) {
 	human_readable(ns->trans_speed, p, p_max_size);
 }
 
-void print_upspeedf(struct text_object *obj, char *p, int p_max_size) {
-	struct net_stat *ns = (struct net_stat *) obj->data.opaque;
+void print_upspeedf(struct text_object *obj, char *p, int p_max_size)
+{
+	struct net_stat *ns = (struct net_stat *)obj->data.opaque;
 
 	if (!ns)
 		return;
@@ -197,8 +201,9 @@ void print_upspeedf(struct text_object *obj, char *p, int p_max_size) {
 	spaced_print(p, p_max_size, "%.1f", 8, ns->trans_speed / 1024.0);
 }
 
-void print_totaldown(struct text_object *obj, char *p, int p_max_size) {
-	struct net_stat *ns = (struct net_stat *) obj->data.opaque;
+void print_totaldown(struct text_object *obj, char *p, int p_max_size)
+{
+	struct net_stat *ns = (struct net_stat *)obj->data.opaque;
 
 	if (!ns)
 		return;
@@ -206,8 +211,9 @@ void print_totaldown(struct text_object *obj, char *p, int p_max_size) {
 	human_readable(ns->recv, p, p_max_size);
 }
 
-void print_totalup(struct text_object *obj, char *p, int p_max_size) {
-	struct net_stat *ns = (struct net_stat *) obj->data.opaque;
+void print_totalup(struct text_object *obj, char *p, int p_max_size)
+{
+	struct net_stat *ns = (struct net_stat *)obj->data.opaque;
 
 	if (!ns)
 		return;
@@ -215,26 +221,31 @@ void print_totalup(struct text_object *obj, char *p, int p_max_size) {
 	human_readable(ns->trans, p, p_max_size);
 }
 
-void print_addr(struct text_object *obj, char *p, int p_max_size) {
-	struct net_stat *ns = (struct net_stat *) obj->data.opaque;
+void print_addr(struct text_object *obj, char *p, int p_max_size)
+{
+	struct net_stat *ns = (struct net_stat *)obj->data.opaque;
 
 	if (!ns)
 		return;
 
-	if ((ns->addr.sa_data[2] & 255) == 0 && (ns->addr.sa_data[3] & 255) == 0
-			&& (ns->addr.sa_data[4] & 255) == 0
-			&& (ns->addr.sa_data[5] & 255) == 0) {
+	if ((ns->addr.sa_data[2] & 255) == 0 &&
+	    (ns->addr.sa_data[3] & 255) == 0 &&
+	    (ns->addr.sa_data[4] & 255) == 0 &&
+	    (ns->addr.sa_data[5] & 255) == 0) {
 		snprintf(p, p_max_size, "No Address");
 	} else {
-		snprintf(p, p_max_size, "%u.%u.%u.%u", ns->addr.sa_data[2] & 255,
-				ns->addr.sa_data[3] & 255, ns->addr.sa_data[4] & 255,
-				ns->addr.sa_data[5] & 255);
+		snprintf(p, p_max_size, "%u.%u.%u.%u",
+		         ns->addr.sa_data[2] & 255,
+		         ns->addr.sa_data[3] & 255,
+		         ns->addr.sa_data[4] & 255,
+		         ns->addr.sa_data[5] & 255);
 	}
 }
 
 #ifdef __linux__
-void print_addrs(struct text_object *obj, char *p, int p_max_size) {
-	struct net_stat *ns = (struct net_stat *) obj->data.opaque;
+void print_addrs(struct text_object *obj, char *p, int p_max_size)
+{
+	struct net_stat *ns = (struct net_stat *)obj->data.opaque;
 
 	if (!ns)
 		return;
@@ -248,40 +259,39 @@ void print_addrs(struct text_object *obj, char *p, int p_max_size) {
 }
 
 #ifdef BUILD_IPV6
-void print_v6addrs(struct text_object *obj, char *p, int p_max_size) {
-	struct net_stat *ns = (struct net_stat *) obj->data.opaque;
+void print_v6addrs(struct text_object *obj, char *p, int p_max_size)
+{
+	struct net_stat *ns = (struct net_stat *)obj->data.opaque;
 	char tempaddress[INET6_ADDRSTRLEN];
 	struct v6addr *current_v6 = ns->v6addrs;
 
 	if (!ns)
 		return;
 
-	if (p_max_size == 0)
-		return;
-	if (!ns->v6addrs) {
+	if(p_max_size == 0) return;
+	if( ! ns->v6addrs) {
 		snprintf(p, p_max_size, "No Address");
 		return;
 	}
-	*p = 0;
-	while (current_v6) {
+	*p=0;
+	while(current_v6) {
 		inet_ntop(AF_INET6, &(current_v6->addr), tempaddress, INET6_ADDRSTRLEN);
 		strncat(p, tempaddress, p_max_size);
 		//netmask
-		if (ns->v6show_nm) {
+		if(ns->v6show_nm) {
 			char netmaskstr[5]; //max 5 chars (/128 + null-terminator)
 			sprintf(netmaskstr, "/%u", current_v6->netmask);
 			strncat(p, netmaskstr, p_max_size);
 		}
 		//scope
-		if (ns->v6show_sc) {
+		if(ns->v6show_sc) {
 			char scopestr[3];
 			sprintf(scopestr, "(%c)", current_v6->scope);
 			strncat(p, scopestr, p_max_size);
 		}
 		//next (or last) address
 		current_v6 = current_v6->next;
-		if (current_v6)
-			strncat(p, ", ", p_max_size);
+		if(current_v6) strncat(p, ", ", p_max_size);
 	}
 }
 #endif /* BUILD_IPV6 */
@@ -299,8 +309,8 @@ void print_v6addrs(struct text_object *obj, char *p, int p_max_size) {
  * @param[out] obj  struct which will hold evaluated arguments
  * @param[in]  arg  argument string to evaluate
  **/
-void parse_net_stat_graph_arg(struct text_object *obj, const char *arg,
-		void *free_at_crash) {
+void parse_net_stat_graph_arg(struct text_object *obj, const char *arg, void *free_at_crash)
+{
 	/* scan arguments and get interface name back */
 	char *buf = 0;
 	buf = scan_graph(obj, arg, 0);
@@ -320,14 +330,16 @@ void parse_net_stat_graph_arg(struct text_object *obj, const char *arg,
  * @param[in] obj struct containting a member data, which is a struct
  *                containing a void * to a net_stat struct
  **/
-double downspeedgraphval(struct text_object *obj) {
-	struct net_stat *ns = (struct net_stat *) obj->data.opaque;
+double downspeedgraphval(struct text_object *obj)
+{
+	struct net_stat *ns = (struct net_stat *)obj->data.opaque;
 
 	return (ns ? (ns->recv_speed / 1024.0) : 0);
 }
 
-double upspeedgraphval(struct text_object *obj) {
-	struct net_stat *ns = (struct net_stat *) obj->data.opaque;
+double upspeedgraphval(struct text_object *obj)
+{
+	struct net_stat *ns = (struct net_stat *)obj->data.opaque;
 
 	return (ns ? (ns->trans_speed / 1024.0) : 0);
 }
@@ -355,7 +367,7 @@ void print_wireless_mode(struct text_object *obj, char *p, int p_max_size)
 	struct net_stat *ns = (struct net_stat *)obj->data.opaque;
 
 	if (!ns)
-	return;
+		return;
 
 	snprintf(p, p_max_size, "%s", ns->mode);
 }
@@ -364,7 +376,7 @@ void print_wireless_channel(struct text_object *obj, char *p, int p_max_size)
 	struct net_stat *ns = (struct net_stat *)obj->data.opaque;
 
 	if (!ns)
-	return;
+		return;
 
 	if(ns->channel != 0) {
 		snprintf(p, p_max_size, "%i", ns->channel);
@@ -377,7 +389,7 @@ void print_wireless_frequency(struct text_object *obj, char *p, int p_max_size)
 	struct net_stat *ns = (struct net_stat *)obj->data.opaque;
 
 	if (!ns)
-	return;
+		return;
 
 	if(ns->freq[0] != 0) {
 		snprintf(p, p_max_size, "%s", ns->freq);
@@ -390,7 +402,7 @@ void print_wireless_bitrate(struct text_object *obj, char *p, int p_max_size)
 	struct net_stat *ns = (struct net_stat *)obj->data.opaque;
 
 	if (!ns)
-	return;
+		return;
 
 	snprintf(p, p_max_size, "%s", ns->bitrate);
 }
@@ -399,7 +411,7 @@ void print_wireless_ap(struct text_object *obj, char *p, int p_max_size)
 	struct net_stat *ns = (struct net_stat *)obj->data.opaque;
 
 	if (!ns)
-	return;
+		return;
 
 	snprintf(p, p_max_size, "%s", ns->ap);
 }
@@ -408,7 +420,7 @@ void print_wireless_link_qual(struct text_object *obj, char *p, int p_max_size)
 	struct net_stat *ns = (struct net_stat *)obj->data.opaque;
 
 	if (!ns)
-	return;
+		return;
 
 	spaced_print(p, p_max_size, "%d", 4, ns->link_qual);
 }
@@ -417,7 +429,7 @@ void print_wireless_link_qual_max(struct text_object *obj, char *p, int p_max_si
 	struct net_stat *ns = (struct net_stat *)obj->data.opaque;
 
 	if (!ns)
-	return;
+		return;
 
 	spaced_print(p, p_max_size, "%d", 4, ns->link_qual_max);
 }
@@ -426,7 +438,7 @@ void print_wireless_link_qual_perc(struct text_object *obj, char *p, int p_max_s
 	struct net_stat *ns = (struct net_stat *)obj->data.opaque;
 
 	if (!ns)
-	return;
+		return;
 
 	if (ns->link_qual_max > 0) {
 		spaced_print(p, p_max_size, "%.0f", 5,
@@ -441,17 +453,19 @@ double wireless_link_barval(struct text_object *obj)
 	struct net_stat *ns = (struct net_stat *)obj->data.opaque;
 
 	if (!ns)
-	return 0;
+		return 0;
 
 	return (double)ns->link_qual / ns->link_qual_max;
 }
 #endif /* BUILD_WLAN */
 
+
 /**
  * Clears the global array of net_stat structs which contains networks
  * statistics for every interface.
  **/
-void clear_net_stats(void) {
+void clear_net_stats(void)
+{
 #ifdef BUILD_IPV6
 	struct v6addr *nextv6;
 #endif /* BUILD_IPV6 */
@@ -459,7 +473,7 @@ void clear_net_stats(void) {
 	for (i = 0; i < MAX_NET_INTERFACES; i++) {
 		free_and_zero(netstats[i].dev);
 #ifdef BUILD_IPV6
-		while (netstats[i].v6addrs) {
+		while(netstats[i].v6addrs) {
 			nextv6 = netstats[i].v6addrs;
 			netstats[i].v6addrs = netstats[i].v6addrs->next;
 			free_and_zero(nextv6);
@@ -483,19 +497,22 @@ void clear_net_stats(net_stat *in) {
 #endif /* BUILD_IPV6 */
 }
 
-void parse_if_up_arg(struct text_object *obj, const char *arg) {
+void parse_if_up_arg(struct text_object *obj, const char *arg)
+{
 	obj->data.opaque = strndup(arg, text_buffer_size.get(*state));
 }
 
-void free_if_up(struct text_object *obj) {
+void free_if_up(struct text_object *obj)
+{
 	free_and_zero(obj->data.opaque);
 }
 
 /* We should check if this is ok with OpenBSD and NetBSD as well. */
-int interface_up(struct text_object *obj) {
+int interface_up(struct text_object *obj)
+{
 	int fd;
 	struct ifreq ifr;
-	char *dev = (char*) obj->data.opaque;
+	char *dev = (char*)obj->data.opaque;
 
 	if (!dev)
 		return 0;
@@ -528,29 +545,30 @@ int interface_up(struct text_object *obj) {
 		perror("SIOCGIFADDR");
 		goto END_FALSE;
 	}
-	if (((struct sockaddr_in *) &(ifr.ifr_addr))->sin_addr.s_addr)
+	if (((struct sockaddr_in *)&(ifr.ifr_addr))->sin_addr.s_addr)
 		goto END_TRUE;
 
-	END_FALSE: close(fd);
+END_FALSE:
+	close(fd);
 	return 0;
-	END_TRUE: close(fd);
+END_TRUE:
+	close(fd);
 	return 1;
 }
 
 struct _dns_data {
-	_dns_data() :
-			nscount(0), ns_list(0) {
-	}
+	_dns_data() : nscount(0), ns_list(0) {}
 	int nscount;
 	char **ns_list;
 };
 
 static _dns_data dns_data;
 
-void free_dns_data(struct text_object *obj) {
+void free_dns_data(struct text_object *obj)
+{
 	int i;
 
-	(void) obj;
+	(void)obj;
 
 	for (i = 0; i < dns_data.nscount; i++)
 		free(dns_data.ns_list[i]);
@@ -558,44 +576,45 @@ void free_dns_data(struct text_object *obj) {
 	memset(&dns_data, 0, sizeof(dns_data));
 }
 
-int update_dns_data(void) {
+int update_dns_data(void)
+{
 	FILE *fp;
 	char line[256];
 	//static double last_dns_update = 0.0;
 
 	/* maybe updating too often causes higher load because of /etc lying on a real FS
-	 if (current_update_time - last_dns_update < 10.0)
-	 return 0;
+	if (current_update_time - last_dns_update < 10.0)
+		return 0;
 
-	 last_dns_update = current_update_time;
-	 */
+	last_dns_update = current_update_time;
+	*/
 
 	free_dns_data(NULL);
 
 	if ((fp = fopen("/etc/resolv.conf", "r")) == NULL)
 		return 0;
-	while (!feof(fp)) {
+	while(!feof(fp)) {
 		if (fgets(line, 255, fp) == NULL) {
 			break;
 		}
 		if (!strncmp(line, "nameserver ", 11)) {
 			line[strlen(line) - 1] = '\0';	// remove trailing newline
 			dns_data.nscount++;
-			dns_data.ns_list = (char**) realloc(dns_data.ns_list,
-					dns_data.nscount * sizeof(char *));
-			dns_data.ns_list[dns_data.nscount - 1] = strndup(line + 11,
-					text_buffer_size.get(*state));
+			dns_data.ns_list = (char**)realloc(dns_data.ns_list, dns_data.nscount * sizeof(char *));
+			dns_data.ns_list[dns_data.nscount - 1] = strndup(line + 11, text_buffer_size.get(*state));
 		}
 	}
 	fclose(fp);
 	return 0;
 }
 
-void parse_nameserver_arg(struct text_object *obj, const char *arg) {
+void parse_nameserver_arg(struct text_object *obj, const char *arg)
+{
 	obj->data.l = arg ? atoi(arg) : 0;
 }
 
-void print_nameserver(struct text_object *obj, char *p, int p_max_size) {
+void print_nameserver(struct text_object *obj, char *p, int p_max_size)
+{
 	if (dns_data.nscount > obj->data.l)
 		snprintf(p, p_max_size, "%s", dns_data.ns_list[obj->data.l]);
 }

--- a/src/net_stat.h
+++ b/src/net_stat.h
@@ -120,6 +120,7 @@ double wireless_link_barval(struct text_object *);
 #endif /* BUILD_WLAN */
 
 void clear_net_stats(void);
+void clear_net_stats(net_stat*);
 
 void parse_if_up_arg(struct text_object *, const char *);
 int interface_up(struct text_object *);


### PR DESCRIPTION
Net interfaces are managed the following way in Conky:
- A static array of size `MAX_NET_INTERFACES` is created (by default, 64),
- Net interfaces are parsed from system file (e.g. `/proc/net/dev` for general linux),
- When a new net interface is found, it is added to the array,
- If the array is full, Conky fails.

However, if an interface does not exist anymore in the system list, it is never removed from the list. With processes like Docker which creates a lot of virtual net interfaces, Conky is likely to crash quite fast.

I modified `net_stat.<h,cc>` to prevent Conky from crashing. The new behaviour is:
- For the `MAX_NET_INTERFACES` first interfaces, the behaviour is still the same,
- When a new interface is met, it is stored in a unique static `struct net_stat` which address is returned.
Therefore, when a new interface is found, the same static `struct net_stat` is cleared and rebuilt from the new interface's parameters. This way, there are never more than `MAX_NET_INTERFACES + 1` interfaces saved and no crash.

N.B: I used Eclipse auto-indent function so the files indentations have changed. I can fix that if necessary.