### PR TITLE
Added detect_battery setting (multiple batteries) to fix #190

### DIFF
--- a/doc/config_settings.xml
+++ b/doc/config_settings.xml
@@ -1032,6 +1032,15 @@
     <varlistentry>
         <term>
             <command>
+                <option>detect_battery</option>
+            </command>
+        </term>
+        <listitem>One or more batteries to check in order to use update_interval_on_battery (comma separated, BAT0 default)
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
                 <option>uppercase</option>
             </command>
         </term>


### PR DESCRIPTION
Very similar to #406 (3e170a6639ec5ae0fd056d9a55a17879e61cce5e) by djpohly.

Added the setting `detect_battery` to specify one **or more** batteries to check in order to use `update_interval_on_battery` instead of `update_interval`.

This fixes #190 and also prevents, on double-battery laptops, to use `update_interval_on_battery` only when the rear battery is empty or removed.

I know the parser is ugly, but this is the first time I use C++/obj-oriented programming, so forgive me.