### PR TITLE
Added destroy methods to some functions to fix memory leaks.

### DIFF
--- a/lua/cairo.pkg
+++ b/lua/cairo.pkg
@@ -61,6 +61,7 @@ typedef struct _cairo_matrix {
 	double x0;
 	double y0;
 	static tolua_outside cairo_matrix_t* create_cairo_matrix_t @ create();
+	static tolua_outside void destroy_cairo_matrix_t @ destroy(cairo_matrix_t *pointer);
 } cairo_matrix_t;
 typedef int cairo_bool_t;
 
@@ -410,6 +411,7 @@ typedef struct {
 	double x_advance;
 	double y_advance;
 	static tolua_outside cairo_text_extents_t* create_cairo_text_extents_t @ create();
+	static tolua_outside void destroy_cairo_text_extents_t @ destroy(cairo_text_extents_t *pointer);
 } cairo_text_extents_t;
 
 typedef struct {
@@ -419,6 +421,7 @@ typedef struct {
 	double max_x_advance;
 	double max_y_advance;
 	static tolua_outside cairo_font_extents_t* create_cairo_font_extents_t @ create();
+	static tolua_outside void destroy_cairo_font_extents_t @ destroy(cairo_font_extents_t *pointer);
 } cairo_font_extents_t;
 
 typedef enum _cairo_font_slant {

--- a/lua/libcairo-helper.h
+++ b/lua/libcairo-helper.h
@@ -39,4 +39,17 @@ cairo_matrix_t *create_cairo_matrix_t(void) {
   return calloc(1, sizeof(cairo_matrix_t));
 }
 
+void destroy_cairo_text_extents_t(cairo_text_extents_t *pointer) {
+  free(pointer);
+}
+
+void destroy_cairo_font_extents_t(cairo_font_extents_t *pointer) {
+  free(pointer);
+}
+
+void destroy_cairo_matrix_t(cairo_matrix_t *pointer) {
+  free(pointer);
+}
+
+
 #endif /* _LIBCAIRO_HELPER_H_ */


### PR DESCRIPTION
Accidentally I noticed that my conky .lua file produces a lot of memory leaks. I used Google (and this too: http://u-scripts.blogspot.com/2011/01/memory-leaks-in-conkyluacairo.html) and fixed everything I could. It doesn't work.

By increasing the refresh rate conky ate over 700 mb in a few seconds.
![qtox_image_2018-07-08 23-04-37 478](https://user-images.githubusercontent.com/3750982/42424772-3371e0a0-8312-11e8-83cf-346bb9ffb784.png)

Then I just did this for testing:
```
for i = 1, 1000 do
    local te = cairo_text_extents_t:create()
    local fe = cairo_font_extents_t:create()
end
```
It seems that memory created by cairo_*_extents_t:create() is never freed.

I added functions to free unused memory.
```
for i = 1, 1000 do
    local te = cairo_text_extents_t:create()
    local fe = cairo_font_extents_t:create()
    cairo_text_extents_t:destroy(te)
    cairo_font_extents_t:destroy(fe)
end
```

Now, it works fine even on very high refresh rate.




 