### PR TITLE
doc/config_settings.xml: fix console's default bar value

### DIFF
--- a/doc/config_settings.xml
+++ b/doc/config_settings.xml
@@ -112,10 +112,8 @@
         <listitem>Specify a default width for bars. If not specified,
         the default value is 0, which causes the bar to expand to
         fit the width of your Conky window. If you set
-        out_to_console = true, the text version of the bar will
-        actually have no width and you will need to set a
-        sensible default or set the height and width of each bar
-        individually.
+        out_to_console = true, the default value will be 10
+        for the text version of the bar.
         <para /></listitem>
     </varlistentry>
     <varlistentry>

--- a/doc/config_settings.xml
+++ b/doc/config_settings.xml
@@ -18,7 +18,7 @@
                 <option>append_file</option>
             </command>
         </term>
-        <listitem>Append the file given as argument. 
+        <listitem>Append the file given as argument.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -28,7 +28,7 @@
             </command>
         </term>
         <listitem>Boolean value, if true, Conky will be forked to
-        background when started. 
+        background when started.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -38,7 +38,7 @@
             </command>
         </term>
         <listitem>Inner border margin in pixels (the margin between
-        the border and text). 
+        the border and text).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -48,7 +48,7 @@
             </command>
         </term>
         <listitem>Outer border margin in pixels (the margin between
-        the border and the edge of the window). 
+        the border and the edge of the window).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -57,7 +57,7 @@
                 <option>border_width</option>
             </command>
         </term>
-        <listitem>Border width in pixels. 
+        <listitem>Border width in pixels.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -69,7 +69,7 @@
         <listitem>Predefine a color for use inside conky.text segments.
         Substitute N by a digit between 0 and 9, inclusively. When
         specifying the color value in hex, omit the leading hash
-        (#). 
+        (#).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -90,7 +90,7 @@
             </command>
         </term>
         <listitem>The number of samples to average for CPU
-        monitoring. 
+        monitoring.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -124,7 +124,7 @@
                 <option>default_color</option>
             </command>
         </term>
-        <listitem>Default color and border color 
+        <listitem>Default color and border color
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -178,7 +178,7 @@
                 <option>default_outline_color</option>
             </command>
         </term>
-        <listitem>Default outline color 
+        <listitem>Default outline color
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -187,7 +187,7 @@
                 <option>default_shade_color</option>
             </command>
         </term>
-        <listitem>Default shading color and border's shading color 
+        <listitem>Default shading color and border's shading color
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -206,7 +206,7 @@
             </command>
         </term>
         <listitem>The number of samples to average for disk I/O
-        monitoring. 
+        monitoring.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -215,7 +215,7 @@
                 <option>display</option>
             </command>
         </term>
-        <listitem>Specify an X display to connect to. 
+        <listitem>Specify an X display to connect to.
         <para /></listitem>
 	</varlistentry>
 	<varlistentry>
@@ -224,7 +224,7 @@
                 <option>xinerama_head</option>
             </command>
         </term>
-        <listitem>Specify a Xinerama head. 
+        <listitem>Specify a Xinerama head.
         <para /></listitem>
 	</varlistentry>
     <varlistentry>
@@ -235,7 +235,7 @@
         </term>
         <listitem>Use the Xdbe extension? (eliminates flicker) It
         is highly recommended to use own window with this one so
-        double buffer won't be so big. 
+        double buffer won't be so big.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -244,7 +244,7 @@
                 <option>draw_borders</option>
             </command>
         </term>
-        <listitem>Draw borders around text? 
+        <listitem>Draw borders around text?
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -253,7 +253,7 @@
                 <option>draw_graph_borders</option>
             </command>
         </term>
-        <listitem>Draw borders around graphs? 
+        <listitem>Draw borders around graphs?
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -262,7 +262,7 @@
                 <option>draw_outline</option>
             </command>
         </term>
-        <listitem>Draw outlines? 
+        <listitem>Draw outlines?
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -271,7 +271,7 @@
                 <option>draw_shades</option>
             </command>
         </term>
-        <listitem>Draw shades? 
+        <listitem>Draw shades?
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -281,7 +281,7 @@
             </command>
         </term>
         <listitem>Put an extra newline at the end when writing to
-        stdout, useful for writing to awesome's wiboxes. 
+        stdout, useful for writing to awesome's wiboxes.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -291,7 +291,7 @@
             </command>
         </term>
         <listitem>Font name in X, xfontsel can be used to get a
-        nice font 
+        nice font
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -302,7 +302,7 @@
         </term>
         <listitem>If enabled, values which are in bytes will be
         printed in human readable format (i.e., KiB, MiB, etc). If
-        disabled, the number of bytes is printed instead. 
+        disabled, the number of bytes is printed instead.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -313,7 +313,7 @@
         </term>
         <listitem>Gap, in pixels, between right or left border of
         screen, same as passing -x at command line, e.g. gap_x 10.
-        For other position related stuff, see 'alignment'. 
+        For other position related stuff, see 'alignment'.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -324,7 +324,7 @@
         </term>
         <listitem>Gap, in pixels, between top or bottom border of
         screen, same as passing -y at command line, e.g. gap_y 10.
-        For other position related stuff, see 'alignment'. 
+        For other position related stuff, see 'alignment'.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -368,7 +368,7 @@
         interface for being up? The value is one of up, link or
         address, to check for the interface being solely up, being
         up and having link or being up, having link and an assigned
-        IP address. 
+        IP address.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -383,7 +383,7 @@
         folder is 'INBOX', default interval is 5 minutes, and
         default number of retries before giving up is 5. If the
         password is supplied as '*', you will be prompted to enter
-        the password when Conky starts. 
+        the password when Conky starts.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -392,7 +392,7 @@
                 <option>imlib_cache_flush_interval</option>
             </command>
         </term>
-        <listitem>Interval (in seconds) to flush Imlib2 cache. 
+        <listitem>Interval (in seconds) to flush Imlib2 cache.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -449,7 +449,7 @@
                 <option>lua_load</option>
             </command>
         </term>
-        <listitem>Loads the Lua scripts separated by spaces. 
+        <listitem>Loads the Lua scripts separated by spaces.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -493,7 +493,7 @@
                 <option>mail_spool</option>
             </command>
         </term>
-        <listitem>Mail spool for mail checking 
+        <listitem>Mail spool for mail checking
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -503,7 +503,7 @@
             </command>
         </term>
         <listitem>Allow each port monitor to track at most this
-        many connections (if 0 or not set, default is 256) 
+        many connections (if 0 or not set, default is 256)
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -537,7 +537,7 @@
             </command>
             <option>pixels</option>
         </term>
-        <listitem>Maximum width of window 
+        <listitem>Maximum width of window
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -547,7 +547,7 @@
             </command>
             <option>height</option>
         </term>
-        <listitem>Minimum height of the window 
+        <listitem>Minimum height of the window
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -557,7 +557,7 @@
             </command>
             <option>width</option>
         </term>
-        <listitem>Minimum width of window 
+        <listitem>Minimum width of window
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -566,7 +566,7 @@
                 <option>mpd_host</option>
             </command>
         </term>
-        <listitem>Host of MPD server 
+        <listitem>Host of MPD server
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -575,7 +575,7 @@
                 <option>mpd_password</option>
             </command>
         </term>
-        <listitem>MPD server password 
+        <listitem>MPD server password
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -584,7 +584,7 @@
                 <option>mpd_port</option>
             </command>
         </term>
-        <listitem>Port of MPD server 
+        <listitem>Port of MPD server
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -640,7 +640,7 @@
             </command>
         </term>
         <listitem>Music player thread update interval (defaults to
-        Conky's update interval) 
+        Conky's update interval)
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -649,7 +649,7 @@
                 <option>net_avg_samples</option>
             </command>
         </term>
-        <listitem>The number of samples to average for net data 
+        <listitem>The number of samples to average for net data
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -659,7 +659,7 @@
             </command>
         </term>
         <listitem>Subtract (file system) buffers from used memory?
-        
+
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -678,7 +678,7 @@
                 <option>out_to_console</option>
             </command>
         </term>
-        <listitem>Print text to stdout. 
+        <listitem>Print text to stdout.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -698,7 +698,7 @@
         </term>
         <listitem>Print text in the console, but use ncurses so
         that conky can print the text of a new update over the old
-        text. (In the future this will provide more useful things) 
+        text. (In the future this will provide more useful things)
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -707,7 +707,7 @@
                 <option>out_to_stderr</option>
             </command>
         </term>
-        <listitem>Print text to stderr. 
+        <listitem>Print text to stderr.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -720,7 +720,7 @@
         (useful when you also use things like out_to_console). If
         you set it to no, make sure that it's placed before all
         other X-related setting (take the first line of your
-        configfile to be sure). Default value is yes 
+        configfile to be sure). Default value is yes
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -729,7 +729,7 @@
                 <option>override_utf8_locale</option>
             </command>
         </term>
-        <listitem>Force UTF8? requires XFT 
+        <listitem>Force UTF8? requires XFT
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -738,7 +738,7 @@
                 <option>overwrite_file</option>
             </command>
         </term>
-        <listitem>Overwrite the file given as argument. 
+        <listitem>Overwrite the file given as argument.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -747,7 +747,7 @@
                 <option>own_window</option>
             </command>
         </term>
-        <listitem>Boolean, create own window to draw? 
+        <listitem>Boolean, create own window to draw?
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -757,7 +757,7 @@
             </command>
         </term>
         <listitem>Manually set the WM_CLASS name. Defaults to
-        "Conky". 
+        "Conky".
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -786,7 +786,7 @@
         own_window_type desktop as another way to implement many of
         these hints implicitly. If you use own_window_type
         override, window manager hints have no meaning and are
-        ignored. 
+        ignored.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -796,7 +796,7 @@
             </command>
         </term>
         <listitem>Manually set the window name. Defaults to
-        "conky (&lt;hostname&gt;)". 
+        "conky (&lt;hostname&gt;)".
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -846,7 +846,7 @@
         windows from overlapping them. The edge is chosen based on
         the alignment option. Override windows are not under the
         control of the window manager. Hints are ignored. This type
-        of window can be useful for certain situations. 
+        of window can be useful for certain situations.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -856,7 +856,7 @@
             </command>
         </term>
         <listitem>Pad percentages to this many decimals (0 = no
-        padding) 
+        padding)
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -870,7 +870,7 @@
         [-r retries]". Default port is 110, default interval is 5
         minutes, and default number of retries before giving up is
         5. If the password is supplied as '*', you will be prompted
-        to enter the password when Conky starts. 
+        to enter the password when Conky starts.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -880,7 +880,7 @@
             </command>
         </term>
         <listitem>Shortens units to a single character (kiB-&gt;k,
-        GiB-&gt;G, etc.). Default is off. 
+        GiB-&gt;G, etc.). Default is off.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -889,7 +889,7 @@
                 <option>show_graph_range</option>
             </command>
         </term>
-        <listitem>Shows the time range covered by a graph. 
+        <listitem>Shows the time range covered by a graph.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -898,7 +898,7 @@
                 <option>show_graph_scale</option>
             </command>
         </term>
-        <listitem>Shows the maximum value in scaled graphs. 
+        <listitem>Shows the maximum value in scaled graphs.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -907,7 +907,7 @@
                 <option>stippled_borders</option>
             </command>
         </term>
-        <listitem>Border stippling (dashing) in pixels 
+        <listitem>Border stippling (dashing) in pixels
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -918,7 +918,7 @@
         </term>
         <listitem>Desired output unit of all objects displaying a
         temperature. Parameters are either "fahrenheit" or
-        "celsius". The default unit is degree Celsius. 
+        "celsius". The default unit is degree Celsius.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -931,7 +931,7 @@
         segments. Substitute N by a digit between 0 and 9,
         inclusively. The value of the variable is being inserted
         into the stuff inside conky.text at the corresponding position,
-        but before some substitutions are applied: 
+        but before some substitutions are applied:
         <simplelist>
             <member>'\n' -&gt; newline</member>
             <member>'\\' -&gt; backslash</member>
@@ -953,7 +953,7 @@
         variables. Increasing the size of this buffer can
         drastically reduce Conky's performance, but will allow for
         more text display per variable. The size of this buffer
-        cannot be smaller than the default value of 256 bytes. 
+        cannot be smaller than the default value of 256 bytes.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -975,7 +975,7 @@
         </term>
         <listitem>If true, cpu in top will show usage of one
         processor's power. If false, cpu in top will show the usage
-        of all processors' power combined. 
+        of all processors' power combined.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -996,7 +996,7 @@
             </command>
         </term>
         <listitem>Width for $top name value (defaults to 15
-        characters). 
+        characters).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1006,7 +1006,7 @@
             </command>
         </term>
         <listitem>Total number of times for Conky to update before
-        quitting. Zero makes Conky run forever 
+        quitting. Zero makes Conky run forever
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1016,7 +1016,7 @@
             </command>
             <option>seconds</option>
         </term>
-        <listitem>Update interval 
+        <listitem>Update interval
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1026,7 +1026,7 @@
             </command>
             <option>seconds</option>
         </term>
-        <listitem>Update interval when running on batterypower 
+        <listitem>Update interval when running on batterypower
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1045,7 +1045,7 @@
             </command>
         </term>
         <listitem>Boolean value, if true, text is rendered in upper
-        case 
+        case
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1059,7 +1059,7 @@
         and none (default). The old true/false values are
         deprecated and default to right/none respectively. Note
         that this only helps if you are using a mono font, such as
-        Bitstream Vera Sans Mono. 
+        Bitstream Vera Sans Mono.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1068,7 +1068,7 @@
                 <option>use_xft</option>
             </command>
         </term>
-        <listitem>Use Xft (anti-aliased font and stuff) 
+        <listitem>Use Xft (anti-aliased font and stuff)
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1078,7 +1078,7 @@
             </command>
         </term>
         <listitem>Alpha of Xft font. Must be a value at or between
-        1 and 0. 
+        1 and 0.
         <para /></listitem>
     </varlistentry>
 </variablelist>


### PR DESCRIPTION
With `out_to_console=true`, the default width will be `10`, not `0`. I fix this now.