### PR TITLE
Arguments to character-handling functions must be representable as an unsigned char

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -951,7 +951,7 @@ static void generate_text() {
 
     tmp_p = text_buffer;
     while (*tmp_p != 0) {
-      *tmp_p = toupper(*tmp_p);
+      *tmp_p = toupper((unsigned char)*tmp_p);
       tmp_p++;
     }
   }

--- a/src/core.cc
+++ b/src/core.cc
@@ -2076,7 +2076,7 @@ int extract_variable_text_internal(struct text_object *retval,
         /* lowercase variable name */
         tmp_p = buf;
         while (*tmp_p != 0) {
-          *tmp_p = tolower(*tmp_p);
+          *tmp_p = tolower((unsigned char)*tmp_p);
           tmp_p++;
         }
 

--- a/src/libmpdclient.cc
+++ b/src/libmpdclient.cc
@@ -1876,7 +1876,7 @@ void mpd_startFieldSearch(mpd_Connection *connection, int type) {
   len = 5 + strlen(strtype) + 1;
   connection->request = static_cast<char *>(malloc(len));
 
-  snprintf(connection->request, len, "list %c%s", tolower(strtype[0]),
+  snprintf(connection->request, len, "list %c%s", tolower((unsigned char)strtype[0]),
            strtype + 1);
 }
 
@@ -1914,7 +1914,7 @@ void mpd_addConstraintSearch(mpd_Connection *connection, int type,
   len = strlen(string) + 1 + strlen(strtype) + 2 + strlen(arg) + 2;
   connection->request = static_cast<char *>(realloc(connection->request, len));
   snprintf(connection->request, len, "%s %c%s \"%s\"", string,
-           tolower(strtype[0]), strtype + 1, arg);
+           tolower((unsigned char)strtype[0]), strtype + 1, arg);
 
   free(string);
   free(arg);

--- a/src/proc.cc
+++ b/src/proc.cc
@@ -168,7 +168,7 @@ void print_pid_environ(struct text_object *obj, char *p, unsigned int p_max_size
   generate_text_internal(objbuf.get(), max_user_text.get(*state), *obj->sub);
   if (sscanf(objbuf.get(), "%d %s", &pid, var) == 2) {
     for (i = 0; var[i] != 0; i++) {
-      var[i] = toupper(var[i]);
+      var[i] = toupper((unsigned char)var[i]);
     }
     pathstream << PROCDIR "/"  << pid << "/cwd";
     buf = readfile(pathstream.str().c_str(), &total_read, 1);


### PR DESCRIPTION
As recommend by secure coding: https://wiki.sei.cmu.edu/confluence/display/c/STR37-C.+Arguments+to+character-handling+functions+must+be+representable+as+an+unsigned+char