### PR TITLE
lua: remove useless conky_info 'uptime' table

### DIFF
--- a/doc/lua.xml
+++ b/doc/lua.xml
@@ -118,10 +118,6 @@
                     <option>Conky's update interval (in
                     seconds).</option>
                 </member>
-                <member>
-                    <command>uptime</command>
-                    <option>System uptime, in seconds.</option>
-                </member>
             </simplelist>
         </listitem>
     </varlistentry>

--- a/src/llua.cc
+++ b/src/llua.cc
@@ -536,7 +536,7 @@ void llua_setup_info(struct information *i, double u_interval) {
   lua_newtable(lua_L);
 
   llua_set_number("update_interval", u_interval);
-  llua_set_number("uptime", i->uptime);
+  (void)i;
 
   lua_setglobal(lua_L, "conky_info");
 }
@@ -552,7 +552,7 @@ void llua_update_info(struct information *i, double u_interval) {
   }
 
   llua_set_number("update_interval", u_interval);
-  llua_set_number("uptime", i->uptime);
+  (void)i;
 
   lua_setglobal(lua_L, "conky_info");
 }


### PR DESCRIPTION
Addresses https://github.com/brndnmtthws/conky/issues/596 