### PR TITLE
Add -m/--xinerama-head command-line option

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -2772,8 +2772,9 @@ static void print_help(const char *prog_name) {
 #ifdef BUILD_X11
          "   -a, --alignment=ALIGNMENT text alignment on screen, "
          "{top,bottom,middle}_{left,right,middle}\n"
-         "   -f, --font=FONT           font to use\n"
          "   -X, --display=DISPLAY     X11 display to use\n"
+         "   -m, --xinerama-head=N     Xinerama monitor index (0=first)\n"
+         "   -f, --font=FONT           font to use\n"
 #ifdef OWN_WINDOW
          "   -o, --own-window          create own window to draw\n"
 #endif
@@ -2805,7 +2806,7 @@ inline void reset_optind() {
 static const char *getopt_string =
     "vVqdDSs:t:u:i:hc:p:"
 #ifdef BUILD_X11
-    "x:y:w:a:f:X:"
+    "x:y:w:a:X:m:f:"
 #ifdef OWN_WINDOW
     "o"
 #endif
@@ -2825,8 +2826,8 @@ static const struct option longopts[] = {
 #endif
     {"daemonize", 0, nullptr, 'd'},
 #ifdef BUILD_X11
-    {"alignment", 1, nullptr, 'a'},     {"font", 1, nullptr, 'f'},
-    {"display", 1, nullptr, 'X'},
+    {"alignment", 1, nullptr, 'a'},     {"display", 1, nullptr, 'X'},
+    {"xinerama-head", 1, nullptr, 'm'}, {"font", 1, nullptr, 'f'},
 #ifdef OWN_WINDOW
     {"own-window", 0, nullptr, 'o'},
 #endif
@@ -2912,6 +2913,13 @@ void initialisation(int argc, char **argv) {
       case 'a':
         state->pushstring(optarg);
         text_alignment.lua_set(*state);
+        break;
+      case 'm':
+        state->pushinteger(strtol(optarg, &conv_end, 10));
+        if (*conv_end != 0) {
+          CRIT_ERR(nullptr, nullptr, "'%s' is a wrong xinerama-head index", optarg);
+        }
+        head_index.lua_set(*state);
         break;
       case 'X':
         state->pushstring(optarg);

--- a/src/x11.cc
+++ b/src/x11.cc
@@ -304,7 +304,7 @@ conky::simple_config_setting<alignment> text_alignment("alignment", BOTTOM_LEFT,
                                                        false);
 conky::simple_config_setting<std::string> display_name("display", std::string(),
                                                        false);
-static conky::simple_config_setting<int> head_index("xinerama_head", 0, true);
+conky::simple_config_setting<int> head_index("xinerama_head", 0, true);
 priv::out_to_x_setting out_to_x;
 
 priv::colour_setting color[10] = {{"color0", 0xffffff}, {"color1", 0xffffff},

--- a/src/x11.h
+++ b/src/x11.h
@@ -220,6 +220,7 @@ class colour_setting
 
 extern priv::out_to_x_setting out_to_x;
 extern conky::simple_config_setting<std::string> display_name;
+extern conky::simple_config_setting<int> head_index;
 extern priv::colour_setting color[10];
 extern priv::colour_setting default_color;
 extern priv::colour_setting default_shade_color;


### PR DESCRIPTION
In earlier conky versions, it was possible to place conky windows on multiple monitors using same configuration via e.g. `conky -a bottom_left ; conky -a bottom_right` (one on the left, one on the right).

But after rebuilding it recently, this is no longer possible - -a/--alignment option only works within same physical monitor, so you have to make separate config file just to change xinerama_head option, keep them in sync, etc - which is not great.

This patch addresses the issue by adding -m/--xinerama-head option on the command-line, similar to --alignment and --display options there.
I've also re-arranged X11 options so that these three are together, to indicate that they have similar purpose, as despite being accurate, --xinerama-head is somewhat confusing label when you look for "physical display" option.

Tested building on current Arch system, seem to work.

One quirk I've noticed though, is that mixing --alignment and --xinerama-head produces weird results, but then so is tweaking them in the config file, which should probably be addressed in a separate issue or PR - this one just for changing the thing via cli.
