### PR TITLE
Fix window positioning on non-primary monitors

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1081,7 +1081,7 @@ static void update_text_area() {
     case TOP_LEFT:
     case TOP_RIGHT:
     case TOP_MIDDLE:
-      y = gap_y.get(*state);
+      y = workarea[1] + gap_y.get(*state);
       break;
 
     case BOTTOM_LEFT:
@@ -1094,7 +1094,7 @@ static void update_text_area() {
     case MIDDLE_LEFT:
     case MIDDLE_RIGHT:
     case MIDDLE_MIDDLE:
-      y = workarea[3] / 2 - text_height / 2 - gap_y.get(*state);
+      y =  workarea[1] + (workarea[3] - workarea[1]) / 2 - text_height / 2 - gap_y.get(*state);
       break;
   }
   switch (align) {
@@ -1102,7 +1102,7 @@ static void update_text_area() {
     case BOTTOM_LEFT:
     case MIDDLE_LEFT:
     default:
-      x = gap_x.get(*state);
+      x = workarea[0] + gap_x.get(*state);
       break;
 
     case TOP_RIGHT:
@@ -1114,7 +1114,7 @@ static void update_text_area() {
     case TOP_MIDDLE:
     case BOTTOM_MIDDLE:
     case MIDDLE_MIDDLE:
-      x = workarea[2] / 2 - text_width / 2 - gap_x.get(*state);
+      x = workarea[0] + (workarea[2] - workarea[0]) / 2 - text_width / 2 - gap_x.get(*state);
       break;
   }
 #ifdef OWN_WINDOW
@@ -1129,9 +1129,6 @@ static void update_text_area() {
 #ifdef OWN_WINDOW
 
   if (own_window.get(*state) && (fixed_pos == 0)) {
-    x += workarea[0];
-    y += workarea[1];
-
     int border_total = get_border_total();
     text_start_x = text_start_y = border_total;
     window.x = x - border_total;
@@ -1139,14 +1136,6 @@ static void update_text_area() {
   } else
 #endif
   {
-    /* If window size doesn't match to workarea's size,
-     * then window probably includes panels (gnome).
-     * Blah, doesn't work on KDE. */
-    if (workarea[2] != window.width || workarea[3] != window.height) {
-      y += workarea[1];
-      x += workarea[0];
-    }
-
     text_start_x = x;
     text_start_y = y;
   }


### PR DESCRIPTION
This patch fixes window position calculations, assuming that "workarea" tuple contains correct (x1, y1, x2, y2) for top-left/bottom-right corners of the selected monitor area within display.

It's important to note that I do not understand why `x += workarea[0];` and similar lines for y were there, and how they could've possibly worked for multiple displays in all middle-alignments, as "y1 + y2/2" (as it was calculated) is not the middle - "y1 + (y2-y1)/2" is (and how it is after the patch).
They all would've worked in single-monitor configuration or with primary monitor in matched-size configurations though, where x1/y1 are always 0 and y2 == h(display).

Tested the patch with all corner and middle-x/y alignments in a mismatched dual-monitor setup (1920x1080+0+0 and 1280x1024+1920+0), all seem to work as expected.

This is to address issue #410 and maybe #430.
[updated to use x1/y1 x2/y2 instead of more confusing x/y w/h naming]