### PR TITLE
fix missing variables when using multiple out_to_xxx

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -128,10 +128,10 @@
 #include "dragonfly.h"
 #elif defined(__OpenBSD__)
 #include "openbsd.h"
-#endif
+#endif /* __OpenBSD__ */
 #ifdef BUILD_HTTP
 #include <microhttpd.h>
-#endif
+#endif /* BUILD_HTTP */
 
 #if defined(__FreeBSD_kernel__)
 #include <bsd/bsd.h>
@@ -185,7 +185,7 @@ static conky::simple_config_setting<bool> short_units("short_units", false,
 static conky::simple_config_setting<bool> format_human_readable(
     "format_human_readable", true, true);
 
-static conky::simple_config_setting<bool> out_to_stdout("out_to_console",
+conky::simple_config_setting<bool> out_to_stdout("out_to_console",
 // Default value is false, unless we are building without X
 #ifdef BUILD_X11
                                                         false,
@@ -276,7 +276,7 @@ static void print_version() {
 #endif /* BUILD_PORT_MONITORS */
 #ifdef BUILD_HTTP
             << _("  * HTTP\n")
-#endif
+#endif /* BUILD_HTTP */
 #ifdef BUILD_IPV6
             << _("  * IPv6\n")
 #endif /* BUILD_IPV6 */
@@ -408,10 +408,10 @@ static void print_version() {
             << "  * Local configfile: " CONFIG_FILE "\n"
 #ifdef BUILD_I18N
             << "  * Localedir: " LOCALE_DIR "\n"
-#endif
+#endif /* BUILD_I18N */
 #ifdef BUILD_HTTP
             << "  * HTTP-port: " << HTTPPORT << "\n"
-#endif
+#endif /* BUILD_HTTP */
             << "  * Maximum netdevices: " << MAX_NET_INTERFACES << "\n"
             << "  * Maximum text size: " << MAX_USER_TEXT_DEFAULT << "\n"
             << "  * Size text buffer: " << DEFAULT_TEXT_BUFFER_SIZE << "\n";
@@ -532,7 +532,7 @@ class out_to_http_setting : public conky::simple_config_setting<bool> {
   out_to_http_setting() : Base("out_to_http", false, false) {}
 };
 static out_to_http_setting out_to_http;
-#endif
+#endif /* BUILD_HTTP */
 
 #ifdef BUILD_X11
 
@@ -1273,7 +1273,7 @@ static void draw_string(const char *s) {
   }
 #ifdef BUILD_NCURSES
   if (out_to_ncurses.get(*state) && draw_mode == FG) { printw("%s", s); }
-#endif
+#endif /* BUILD_NCURSES */
 #ifdef BUILD_HTTP
   if (out_to_http.get(*state) && draw_mode == FG) {
     std::string::size_type origlen = webpage.length();
@@ -1283,7 +1283,7 @@ static void draw_string(const char *s) {
     webpage = string_replace_all(webpage, "&nbsp; ", "&nbsp;&nbsp;", origlen);
     webpage.append("<br />");
   }
-#endif
+#endif /* BUILD_HTTP */
   int tbs = text_buffer_size.get(*state);
   memset(tmpstring1, 0, tbs);
   memset(tmpstring2, 0, tbs);
@@ -1823,7 +1823,7 @@ static void draw_text() {
     }
     webpage.append(WEBPAGE_START2);
   }
-#endif
+#endif /* BUILD_HTTP */
 #ifdef BUILD_X11
   if (out_to_x.get(*state)) {
     cur_y = text_start_y;
@@ -1860,7 +1860,7 @@ static void draw_text() {
   for_each_line(text_buffer, draw_line);
 #ifdef BUILD_HTTP
   if (out_to_http.get(*state)) { webpage.append(WEBPAGE_END); }
-#endif
+#endif /* BUILD_HTTP */
 }
 
 static void draw_stuff() {

--- a/src/conky.h
+++ b/src/conky.h
@@ -363,4 +363,6 @@ extern std::unique_ptr<lua::state> state;
 extern int argc_copy;
 extern char **argv_copy;
 
+extern conky::simple_config_setting<bool> out_to_stdout;
+
 #endif /* _conky_h_ */

--- a/src/core.cc
+++ b/src/core.cc
@@ -42,28 +42,28 @@
 #include "text_object.h"
 #ifdef BUILD_IMLIB2
 #include "imlib2.h"
-#endif
+#endif /* BUILD_IMLIB2 */
 #include "proc.h"
 #ifdef BUILD_MYSQL
 #include "mysql.h"
-#endif
+#endif /* BUILD_MYSQL */
 #ifdef BUILD_ICAL
 #include "ical.h"
-#endif
+#endif /* BUILD_ICAL */
 #ifdef BUILD_IRC
 #include "irc.h"
-#endif
+#endif /* BUILD_IRC */
 #ifdef BUILD_X11
 #include "fonts.h"
-#endif
+#endif /* BUILD_X11 */
 #include "fs.h"
 #ifdef BUILD_IBM
 #include "ibm.h"
 #include "smapi.h"
-#endif
+#endif /* BUILD_IBM */
 #ifdef BUILD_ICONV
 #include "iconv_tools.h"
-#endif
+#endif /* BUILD_ICONV */
 #include "llua.h"
 #include "logging.h"
 #include "mail.h"
@@ -73,7 +73,7 @@
 #include "net_stat.h"
 #ifdef BUILD_NVIDIA
 #include "nvidia.h"
-#endif
+#endif /* BUILD_NVIDIA */
 #include <inttypes.h>
 #include "cpu.h"
 #include "read_tcpip.h"
@@ -97,16 +97,16 @@
 #endif /* BUILD_RSS */
 #ifdef BUILD_AUDACIOUS
 #include "audacious.h"
-#endif
+#endif /* BUILD_AUDACIOUS */
 #ifdef BUILD_CMUS
 #include "cmus.h"
-#endif
+#endif /* BUILD_CMUS */
 #ifdef BUILD_JOURNAL
 #include "journal.h"
-#endif
+#endif /* BUILD_JOURNAL */
 #ifdef BUILD_PULSEAUDIO
 #include "pulseaudio.h"
-#endif
+#endif /* BUILD_PULSEAUDIO */
 
 /* check for OS and include appropriate headers */
 #if defined(__linux__)

--- a/src/specials.cc
+++ b/src/specials.cc
@@ -41,6 +41,7 @@
 #include <algorithm>
 #include <sstream>
 #include "common.h"
+#include "conky.h"
 
 struct special_t *specials = nullptr;
 
@@ -422,7 +423,8 @@ void new_gauge(struct text_object *obj, char *p, unsigned int p_max_size, double
 #ifdef BUILD_X11
   if (out_to_x.get(*state)) {
     new_gauge_in_x11(obj, p, usage);
-  } else {
+  }
+  if (out_to_stdout.get(*state)) {
     new_gauge_in_shell(obj, p, p_max_size, usage);
   }
 #else /* BUILD_X11 */
@@ -591,7 +593,7 @@ void new_graph(struct text_object *obj, char *buf, int buf_max_size,
 #endif
   graph_append(s, val, g->flags);
 
-  if (not out_to_x.get(*state)) {
+  if (out_to_stdout.get(*state)) {
     new_graph_in_shell(s, buf, buf_max_size);
   }
 }
@@ -747,7 +749,8 @@ void new_bar(struct text_object *obj, char *p, unsigned int p_max_size, double u
 #ifdef BUILD_X11
   if (out_to_x.get(*state)) {
     new_bar_in_x11(obj, p, usage);
-  } else {
+  }
+  if (out_to_stdout.get(*state)) {
     new_bar_in_shell(obj, p, p_max_size, usage);
   }
 #else /* BUILD_X11 */


### PR DESCRIPTION
Shoutout to @lasers :heart_eyes_cat:  EDIT: Addresses ~~`628`~~ #515. <3


edit: we should add `out_to_x=true` to all configs in the Wiki, and open up a new issue with title `[SOLVED] conky doesn't show up` and stating that `out_to_x=true` should be added, because of this commit that disables it by default.