### PR TITLE
misc.cc: Evaluate the result and then parse it to capitalize

### DIFF
--- a/doc/variables.xml
+++ b/doc/variables.xml
@@ -3925,6 +3925,15 @@
     <varlistentry>
         <term>
             <command>
+                <option>start_case</option>
+            </command>
+            <option>text</option>
+        </term>
+        <listitem>All words capitalized regardless.<para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
                 <option>stippled_hr</option>
             </command>
             <option>(space)</option>

--- a/src/core.cc
+++ b/src/core.cc
@@ -486,7 +486,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
     obj->data.i = atoi(&arg[0]);
   }
   obj->callbacks.print = &print_voltage_v;
-    
+
 #endif /* __linux__ */
 
 #ifdef BUILD_WLAN
@@ -522,7 +522,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
     parse_net_stat_bar_arg(obj, arg, free_at_crash);
     obj->callbacks.barval = &wireless_link_barval;
 #endif /* BUILD_WLAN */
-    
+
 #ifndef __OpenBSD__
   END OBJ(acpifan, nullptr) obj->callbacks.print = &print_acpifan;
   END OBJ(battery, nullptr) char bat[64];
@@ -845,10 +845,9 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ(freq2, 0) obj->callbacks.print = &print_freq2;
 #endif /* __x86_64__ */
 
-  END OBJ(cap, 0) obj->data.s = STRNDUP_ARG;
+  END OBJ(start_case, 0) obj->data.s = STRNDUP_ARG;
   obj->callbacks.print = &print_cap;
   obj->callbacks.free = &gen_free_opaque;
-
   END OBJ(catp, 0) obj->data.s = STRNDUP_ARG;
   obj->callbacks.print = &print_catp;
   obj->callbacks.free = &gen_free_opaque;

--- a/src/misc.cc
+++ b/src/misc.cc
@@ -101,6 +101,11 @@ void print_cap(struct text_object *obj, char *p, unsigned int p_max_size) {
   char *src = obj->data.s;
   char *dest = buf;
 
+  evaluate(obj->data.s, p, p_max_size);
+  if (0 != strcmp(p, "")) {
+    src = p;
+  }
+
   for (; *src && p_max_size-1 > x; src++, x++) {
     if (0 == z) {
       *dest++ = (toupper((unsigned char) *src));


### PR DESCRIPTION
This allows to use other variables inside the `cap` like `${cap ${exec echo sup machine}}`, previously it was requiring a static text/string to be inserted in order to work properly.

edit: this is out to resolve the @lasers  wish to use `${battery_status}` to capitalize the returned string, by default `${battery_status}` prints the result in lower case. #631 