### PR TITLE
Add new ${github_notifications} variable to count all unread notifications

### DIFF
--- a/doc/variables.xml
+++ b/doc/variables.xml
@@ -1502,12 +1502,19 @@
     <varlistentry>
         <term>
             <command>
+                <option>github_notifications</option>
+            </command>
+        </term>
+        <listitem>Number of GitHub notifications.<para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
                 <option>goto</option>
             </command>
             <option>x</option>
         </term>
         <listitem>The next element will be printed at position 'x'.
-
         <para /></listitem>
     </varlistentry>
     <varlistentry>

--- a/src/common.cc
+++ b/src/common.cc
@@ -700,13 +700,14 @@ static size_t read_github_data_cb(char *data, size_t size, size_t nmemb, char *p
   size_t sz = nmemb * size;
   size_t z = 0;
   static size_t x = 0;
-  unsigned int skip = 0;
+  static unsigned int skip = 0U;
 
   for (; *ptr; ptr++, z++) {
     if (z+4 < sz) { /* Verifying up to *(ptr+4) */
       if ('u' == *ptr && 'n' == *(ptr+1) &&
           'r' == *(ptr+2) && 'e' == *(ptr+3)) { /* "unread" */
         ++x;
+        skip = 0U;
       }
       if ('m' == *ptr && 'e' == *(ptr+1) &&
           's' == *(ptr+2) && 's' == *(ptr+3) && z+13 < sz) { /* "message": */

--- a/src/common.h
+++ b/src/common.h
@@ -76,6 +76,7 @@ unsigned int round_to_int(float);
 extern conky::simple_config_setting<bool> no_buffers;
 extern conky::simple_config_setting<std::string> bar_fill;
 extern conky::simple_config_setting<std::string> bar_unfill;
+extern conky::simple_config_setting<std::string> github_token;
 
 int open_acpi_temperature(const char *name);
 double get_acpi_temperature(int fd);
@@ -170,6 +171,7 @@ void print_updates(struct text_object *, char *, unsigned int);
 int updatenr_iftest(struct text_object *);
 
 #ifdef BUILD_CURL
+void print_github(struct text_object *, char *, unsigned int);
 void print_stock(struct text_object *, char *, unsigned int);
 void free_stock(struct text_object *);
 #endif /* BUILD_CURL */

--- a/src/core.cc
+++ b/src/core.cc
@@ -1697,6 +1697,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
       curl_parse_arg(obj, arg);
   obj->callbacks.print = &curl_print;
   obj->callbacks.free = &curl_obj_free;
+  END OBJ(github_notifications, 0) obj->callbacks.print = &print_github;
 #endif /* BUILD_CURL */
 #ifdef BUILD_RSS
   END OBJ_ARG(rss, 0,


### PR DESCRIPTION
Out to resolve #636 

The user should generate a new and unique token if they want to use this variable - https://github.com/settings/tokens/new?scopes=notifications&description=conky-query-github