### PR TITLE
doc/config_settings.xml: change own_window_colours

### DIFF
--- a/doc/config_settings.xml
+++ b/doc/config_settings.xml
@@ -784,9 +784,9 @@
             <option>colour</option>
         </term>
         <listitem>If own_window_transparent no, set a specified
-        background colour (defaults to black). Takes either a hex
-        value (e.g. ffffff, note the lack of '#') or a valid RGB
-        name (see /usr/lib/X11/rgb.txt)
+            background colour (defaults to black). Takes either a hex value
+            (e.g. '#ffffff'), a shorthand hex value (e.g. '#fff'), or a valid
+            RGB name (see /usr/lib/X11/rgb.txt)
         <para /></listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
We can use `#ff99cc` or `#f9c` in `own_window_colours` too. This was not documented.