### PR TITLE
doc/variables.xml: add undocumented lock keys

### DIFF
--- a/doc/variables.xml
+++ b/doc/variables.xml
@@ -2133,6 +2133,33 @@
     <varlistentry>
         <term>
             <command>
+                <option>key_caps_lock</option>
+            </command>
+        </term>
+        <listitem>An indicator for Capital Lock key.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>key_num_lock</option>
+            </command>
+        </term>
+        <listitem>An indicator for Number Lock key.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>key_scroll_lock</option>
+            </command>
+        </term>
+        <listitem>An indicator for Scrolling Lock key.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
                 <option>keyboard_layout</option>
             </command>
         </term>

--- a/src/core.cc
+++ b/src/core.cc
@@ -830,9 +830,9 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   obj->callbacks.free = &gen_free_opaque;
 
 #ifdef BUILD_X11
-  END OBJ(num_led, 0) obj->callbacks.print = &print_num_led;
-  END OBJ(caps_led, 0) obj->callbacks.print = &print_caps_led;
-  END OBJ(scroll_led, 0) obj->callbacks.print = &print_scroll_led;
+  END OBJ(key_num_lock, 0) obj->callbacks.print = &print_key_num_lock;
+  END OBJ(key_caps_lock, 0) obj->callbacks.print = &print_key_caps_lock;
+  END OBJ(key_scroll_lock, 0) obj->callbacks.print = &print_key_scroll_lock;
   END OBJ(keyboard_layout, 0) obj->callbacks.print = &print_keyboard_layout;
   END OBJ(mouse_speed, 0) obj->callbacks.print = &print_mouse_speed;
 #endif /* BUILD_X11 */

--- a/src/x11.cc
+++ b/src/x11.cc
@@ -1266,17 +1266,17 @@ void print_kdb_led(const int keybit, char *p, unsigned int p_max_size) {
   XGetKeyboardControl(display, &x);
   snprintf(p, p_max_size, "%s", (x.led_mask & keybit ? "On" : "Off"));
 }
-void print_caps_led(struct text_object *obj, char *p, unsigned int p_max_size) {
+void print_key_caps_lock(struct text_object *obj, char *p, unsigned int p_max_size) {
   (void)obj;
   print_kdb_led(1, p, p_max_size);
 }
 
-void print_num_led(struct text_object *obj, char *p, unsigned int p_max_size) {
+void print_key_num_lock(struct text_object *obj, char *p, unsigned int p_max_size) {
   (void)obj;
   print_kdb_led(2, p, p_max_size);
 }
 
-void print_scroll_led(struct text_object *obj, char *p,
+void print_key_scroll_lock(struct text_object *obj, char *p,
                       unsigned int p_max_size) {
   (void)obj;
   print_kdb_led(4, p, p_max_size);

--- a/src/x11.h
+++ b/src/x11.h
@@ -116,9 +116,9 @@ void print_desktop_number(struct text_object *, char *, unsigned int);
 void print_desktop_name(struct text_object *, char *, unsigned int);
 
 /* Num lock, Scroll lock, Caps Lock */
-void print_num_led(struct text_object *, char *, unsigned int);
-void print_caps_led(struct text_object *, char *, unsigned int);
-void print_scroll_led(struct text_object *, char *, unsigned int);
+void print_key_num_lock(struct text_object *, char *, unsigned int);
+void print_key_caps_lock(struct text_object *, char *, unsigned int);
+void print_key_scroll_lock(struct text_object *, char *, unsigned int);
 
 /* Keyboard layout and mouse speed in percentage */
 void print_keyboard_layout(struct text_object *, char *, unsigned int);


### PR DESCRIPTION
Hi @su8. I'm documenting the undocumented lock keys. :+1: 

I didn't like that if we use the variable names as-is, the options will be in different places due to naming. I went with `lock_` prefix... https://en.wikipedia.org/wiki/Lock_key

If you have a better name in mind, let me hear it. Alternatively, we could use `keyboard_capital_lock` or `keyboard_caps_lock`. Both are longer than `lock_capital`.. so I don't know. Your code, your decision.

Keep in mind that we have `keyboard_layout` and `mouse_speed`. Maybe it is good to use `keyboard_` prefix after all. Thoughts? Also, your lock keys code does not work for me... Why? :frowning_face: 