### PR TITLE
doc/config_settings.xml: add github_token

### DIFF
--- a/doc/config_settings.xml
+++ b/doc/config_settings.xml
@@ -346,6 +346,20 @@
     <varlistentry>
         <term>
             <command>
+                <option>github_token</option>
+            </command>
+        </term>
+        <listitem>Specify API token for GitHub notifications.
+        <simplelist>
+            <member>
+        https://github.com/settings/tokens/new?scopes=notifications&amp;description=conky
+            </member>
+        </simplelist>
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
                 <option>hddtemp_host</option>
             </command>
         </term>


### PR DESCRIPTION
This adds the missing option `github_token` to the documentation.