### PR TITLE
GUI backends phase 1

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,14 @@
+- [X] fix crash when no output is enabled
+- [X] display: fix logging (stderr)
+- [X] display: test build without X11, ncurses
+- [ ] conky.cc: case GOTO: cur_x always = current->arg regardless !? (draw_mode == BG = dead code!!) -> per display ++ ? (but exists already in master if CONFIG_X11 && CONFIG_NCURSES)
+- [X] check for regression (changes in master missed since rebase)
+- [ ] move BUILD_IMLIB2 stuff from conky.cc to display-x11 ??
+- [ ] display: add required ignored -W pragmas for clang & GCC in new files (display-x11.*)
+- [X] move font handling to X11 code
+- [ ] drop x11.h include from font.h
+- [ ] display: profile code
+- [ ] display: remove extra virtual on final classes
+- [ ] display: use int*_t types from cstdint instead of plain int.
+- [ ] display: use std::string in draw_string() and friends
+- [ ] display: use std::pair for x,y arguments

--- a/cmake/ConkyBuildOptions.cmake
+++ b/cmake/ConkyBuildOptions.cmake
@@ -207,6 +207,11 @@ else(BUILD_X11)
   set(BUILD_NVIDIA false)
 endif(BUILD_X11)
 
+# if we build with any GUI support
+if(BUILD_X11)
+  set(BUILD_GUI true)
+endif(BUILD_X11)
+
 if(OWN_WINDOW)
   option(BUILD_ARGB "Build ARGB (real transparency) support" true)
 else(OWN_WINDOW)

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -113,6 +113,8 @@
 
 #cmakedefine BUILD_HTTP 1
 
+#cmakedefine BUILD_GUI 1
+
 #cmakedefine BUILD_ICONV 1
 
 #cmakedefine BUILD_LUA_CAIRO 1

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,6 +106,16 @@ set(conky_sources
     luamm.hh
     data-source.cc
     data-source.hh
+    display-output.cc
+    display-output.hh
+    display-console.cc
+    display-console.hh
+    display-ncurses.cc
+    display-ncurses.hh
+    display-http.cc
+    display-http.hh
+    display-x11.cc
+    display-x11.hh
     lua-config.cc
     lua-config.hh
     setting.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -110,6 +110,8 @@ set(conky_sources
     display-output.hh
     display-console.cc
     display-console.hh
+    display-file.cc
+    display-file.hh
     display-ncurses.cc
     display-ncurses.hh
     display-http.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -224,8 +224,13 @@ if(BUILD_PORT_MONITORS)
   set(optional_sources ${optional_sources} ${port_monitors})
 endif(BUILD_PORT_MONITORS)
 
+if(BUILD_GUI)
+  set(gui fonts.cc fonts.h)
+  set(optional_sources ${optional_sources} ${gui})
+endif(BUILD_GUI)
+
 if(BUILD_X11)
-  set(x11 x11.cc x11.h fonts.cc fonts.h)
+  set(x11 x11.cc x11.h)
   set(optional_sources ${optional_sources} ${x11})
 
   if(BUILD_XINERAMA)

--- a/src/common.cc
+++ b/src/common.cc
@@ -350,7 +350,7 @@ void print_no_update(struct text_object *obj, char *p,
   snprintf(p, p_max_size, "%s", obj->data.s);
 }
 
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
 void scan_loadgraph_arg(struct text_object *obj, const char *arg) {
   char *buf = nullptr;
 
@@ -363,7 +363,7 @@ double loadgraphval(struct text_object *obj) {
 
   return info.loadavg[0];
 }
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 
 uint8_t cpu_percentage(struct text_object *obj) {
   if (static_cast<unsigned int>(obj->data.i) > info.cpu_count) {

--- a/src/common.h
+++ b/src/common.h
@@ -94,10 +94,10 @@ void free_no_update(struct text_object *);
 
 void scan_loadavg_arg(struct text_object *, const char *);
 void print_loadavg(struct text_object *, char *, unsigned int);
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
 void scan_loadgraph_arg(struct text_object *, const char *);
 double loadgraphval(struct text_object *);
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 
 uint8_t cpu_percentage(struct text_object *);
 double cpu_barval(struct text_object *);

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -310,15 +310,6 @@ conky::range_config_setting<int> net_avg_samples("net_avg_samples", 1, 14, 2,
 conky::range_config_setting<int> diskio_avg_samples("diskio_avg_samples", 1, 14,
                                                     2, true);
 
-/* filenames for output */
-static conky::simple_config_setting<std::string> overwrite_file(
-    "overwrite_file", std::string(), true);
-static FILE *overwrite_fpointer = nullptr;
-static conky::simple_config_setting<std::string> append_file("append_file",
-                                                             std::string(),
-                                                             true);
-static FILE *append_fpointer = nullptr;
-
 #ifdef BUILD_X11
 
 static conky::simple_config_setting<bool> show_graph_scale("show_graph_scale",
@@ -1073,12 +1064,6 @@ static void draw_string(const char *s) {
 #ifdef BUILD_X11
   width_of_s = get_string_width(s);
 #endif /* BUILD_X11 */
-  if (draw_mode == FG && (overwrite_fpointer != nullptr)) {
-    fprintf(overwrite_fpointer, "%s\n", s);
-  }
-  if (draw_mode == FG && (append_fpointer != nullptr)) {
-    fprintf(append_fpointer, "%s\n", s);
-  }
   if (conky::active_display_outputs.size() && draw_mode == FG)
     for (auto output : conky::active_display_outputs)
       output->draw_string(s, width_of_s);
@@ -1672,18 +1657,7 @@ static void draw_stuff() {
   cimlib_render(text_start_x, text_start_y, window.width, window.height);
 #endif /* BUILD_IMLIB2 */
 #endif /* BUILD_X11 */
-  if (static_cast<unsigned int>(!overwrite_file.get(*state).empty()) != 0u) {
-    overwrite_fpointer = fopen(overwrite_file.get(*state).c_str(), "we");
-    if (overwrite_fpointer == nullptr) {
-      NORM_ERR("Cannot overwrite '%s'", overwrite_file.get(*state).c_str());
-    }
-  }
-  if (static_cast<unsigned int>(!append_file.get(*state).empty()) != 0u) {
-    append_fpointer = fopen(append_file.get(*state).c_str(), "ae");
-    if (append_fpointer == nullptr) {
-      NORM_ERR("Cannot append to '%s'", append_file.get(*state).c_str());
-    }
-  }
+  for (auto output : display_outputs()) output->begin_draw_stuff();
 #ifdef BUILD_X11
   llua_draw_pre_hook();
   if (out_to_x.get(*state)) {
@@ -1723,14 +1697,7 @@ static void draw_stuff() {
   if (out_to_x.get(*state)) { xpmdb_swap_buffers(); }
 #endif
 #endif /* BUILD_X11 && BUILD_XDBE */
-  if (overwrite_fpointer != nullptr) {
-    fclose(overwrite_fpointer);
-    overwrite_fpointer = nullptr;
-  }
-  if (append_fpointer != nullptr) {
-    fclose(append_fpointer);
-    append_fpointer = nullptr;
-  }
+  for (auto output : display_outputs()) output->end_draw_stuff();
 }
 
 #ifdef BUILD_X11

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -200,8 +200,7 @@ conky::simple_config_setting<bool> out_to_stdout("out_to_console",
                                                  true,
 #endif
                                                  false);
-static conky::simple_config_setting<bool> out_to_stderr("out_to_stderr", false,
-                                                        false);
+conky::simple_config_setting<bool> out_to_stderr("out_to_stderr", false, false);
 
 int top_cpu, top_mem, top_time;
 #ifdef BUILD_IOSTATS

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -121,6 +121,7 @@
 #include "weather.h"
 #endif /* BUILD_WEATHER_METAR */
 
+#include "display-output.hh"
 #include "lua-config.hh"
 #include "setting.hh"
 
@@ -2910,6 +2911,10 @@ void initialisation(int argc, char **argv) {
   memset(tmpstring1, 0, text_buffer_size.get(*state));
   tmpstring2 = new char[text_buffer_size.get(*state)];
   memset(tmpstring2, 0, text_buffer_size.get(*state));
+
+  if (!conky::initialize_display_outputs()) {
+    CRIT_ERR(nullptr, nullptr, "initialize_display_outputs() failed.");
+  }
 
 #ifdef BUILD_X11
   X11_create_window();

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -135,9 +135,6 @@
 #elif defined(__OpenBSD__)
 #include "openbsd.h"
 #endif /* __OpenBSD__ */
-#ifdef BUILD_HTTP
-#include <microhttpd.h>
-#endif /* BUILD_HTTP */
 
 #ifdef BUILD_HSV_GRADIENT
 #include "hsv_gradient.h"
@@ -327,63 +324,6 @@ static conky::simple_config_setting<std::string> append_file("append_file",
                                                              std::string(),
                                                              true);
 static FILE *append_fpointer = nullptr;
-
-#ifdef BUILD_HTTP
-#ifdef MHD_YES
-/* older API */
-#define MHD_Result int
-#endif /* MHD_YES */
-std::string webpage;
-struct MHD_Daemon *httpd;
-static conky::simple_config_setting<bool> http_refresh("http_refresh", false,
-                                                       true);
-
-MHD_Result sendanswer(void *cls, struct MHD_Connection *connection,
-                      const char *url, const char *method, const char *version,
-                      const char *upload_data, size_t *upload_data_size,
-                      void **con_cls) {
-  struct MHD_Response *response = MHD_create_response_from_buffer(
-      webpage.length(), (void *)webpage.c_str(), MHD_RESPMEM_PERSISTENT);
-  MHD_Result ret = MHD_queue_response(connection, MHD_HTTP_OK, response);
-  MHD_destroy_response(response);
-  if (cls || url || method || version || upload_data || upload_data_size ||
-      con_cls) {}  // make compiler happy
-  return ret;
-}
-
-class out_to_http_setting : public conky::simple_config_setting<bool> {
-  typedef conky::simple_config_setting<bool> Base;
-
- protected:
-  virtual void lua_setter(lua::state &l, bool init) {
-    lua::stack_sentry s(l, -2);
-
-    Base::lua_setter(l, init);
-
-    if (init && do_convert(l, -1).first) {
-      httpd = MHD_start_daemon(MHD_USE_SELECT_INTERNALLY, HTTPPORT, nullptr,
-                               NULL, &sendanswer, nullptr, MHD_OPTION_END);
-    }
-
-    ++s;
-  }
-
-  virtual void cleanup(lua::state &l) {
-    lua::stack_sentry s(l, -1);
-
-    if (do_convert(l, -1).first) {
-      MHD_stop_daemon(httpd);
-      httpd = nullptr;
-    }
-
-    l.pop();
-  }
-
- public:
-  out_to_http_setting() : Base("out_to_http", false, false) {}
-};
-static out_to_http_setting out_to_http;
-#endif /* BUILD_HTTP */
 
 #ifdef BUILD_X11
 
@@ -1125,19 +1065,6 @@ static inline void set_foreground_color(long c) {
   UNUSED(c);
 }
 
-std::string string_replace_all(std::string original, const std::string &oldpart,
-                               const std::string &newpart,
-                               std::string::size_type start) {
-  std::string::size_type i = start;
-  int oldpartlen = oldpart.length();
-  while (1) {
-    i = original.find(oldpart, i);
-    if (i == std::string::npos) { break; }
-    original.replace(i, oldpartlen, newpart);
-  }
-  return original;
-}
-
 static void draw_string(const char *s) {
   int i;
   int i2;
@@ -1171,16 +1098,8 @@ static void draw_string(const char *s) {
 #ifdef BUILD_NCURSES
   if (out_to_ncurses.get(*state) && draw_mode == FG) { printw("%s", s); }
 #endif /* BUILD_NCURSES */
-#ifdef BUILD_HTTP
-  if (out_to_http.get(*state) && draw_mode == FG) {
-    std::string::size_type origlen = webpage.length();
-    webpage.append(s);
-    webpage = string_replace_all(webpage, "\n", "<br />", origlen);
-    webpage = string_replace_all(webpage, "  ", "&nbsp;&nbsp;", origlen);
-    webpage = string_replace_all(webpage, "&nbsp; ", "&nbsp;&nbsp;", origlen);
-    webpage.append("<br />");
-  }
-#endif /* BUILD_HTTP */
+  if (conky::active_display_output != nullptr && draw_mode == FG)
+    conky::active_display_output->draw_string(s, width_of_s);
   int tbs = text_buffer_size.get(*state);
   memset(tmpstring1, 0, tbs);
   memset(tmpstring2, 0, tbs);
@@ -1738,27 +1657,8 @@ static int draw_line(char *s, int special_index) {
 }
 
 static void draw_text() {
-#ifdef BUILD_HTTP
-#define WEBPAGE_START1                                             \
-  "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" "    \
-  "\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n<html " \
-  "xmlns=\"http://www.w3.org/1999/xhtml\"><head><meta "            \
-  "http-equiv=\"Content-type\" content=\"text/html;charset=UTF-8\" />"
-#define WEBPAGE_START2 \
-  "<title>Conky</title></head><body style=\"font-family: monospace\"><p>"
-#define WEBPAGE_END "</p></body></html>"
-  if (out_to_http.get(*state)) {
-    webpage = WEBPAGE_START1;
-    if (http_refresh.get(*state)) {
-      webpage.append("<meta http-equiv=\"refresh\" content=\"");
-      std::stringstream update_interval_str;
-      update_interval_str << update_interval.get(*state);
-      webpage.append(update_interval_str.str());
-      webpage.append("\" />");
-    }
-    webpage.append(WEBPAGE_START2);
-  }
-#endif /* BUILD_HTTP */
+  if (conky::active_display_output)
+    conky::active_display_output->begin_draw_text();
 #ifdef BUILD_X11
   if (out_to_x.get(*state)) {
     cur_y = text_start_y;
@@ -1793,9 +1693,8 @@ static void draw_text() {
   attron(COLOR_PAIR(COLOR_WHITE));
 #endif /* BUILD_NCURSES */
   for_each_line(text_buffer, draw_line);
-#ifdef BUILD_HTTP
-  if (out_to_http.get(*state)) { webpage.append(WEBPAGE_END); }
-#endif /* BUILD_HTTP */
+  if (conky::active_display_output)
+    conky::active_display_output->end_draw_text();
 }
 
 static void draw_stuff() {

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -201,8 +201,6 @@ int top_cpu, top_mem, top_time;
 int top_io;
 #endif
 int top_running;
-static conky::simple_config_setting<bool> extra_newline("extra_newline", false,
-                                                        false);
 
 /* Update interval */
 conky::range_config_setting<double> update_interval(
@@ -1075,15 +1073,6 @@ static void draw_string(const char *s) {
 #ifdef BUILD_X11
   width_of_s = get_string_width(s);
 #endif /* BUILD_X11 */
-  if (out_to_stdout.get(*state) && draw_mode == FG) {
-    printf("%s\n", s);
-    if (extra_newline.get(*state)) { fputc('\n', stdout); }
-    fflush(stdout); /* output immediately, don't buffer */
-  }
-  if (out_to_stderr.get(*state) && draw_mode == FG) {
-    fprintf(stderr, "%s\n", s);
-    fflush(stderr); /* output immediately, don't buffer */
-  }
   if (draw_mode == FG && (overwrite_fpointer != nullptr)) {
     fprintf(overwrite_fpointer, "%s\n", s);
   }

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -171,10 +171,6 @@ static conky::simple_config_setting<bool> disable_auto_reload(
 /* two strings for internal use */
 static char *tmpstring1, *tmpstring2;
 
-#ifdef BUILD_NCURSES
-extern WINDOW *ncurses_window;
-#endif
-
 enum spacer_state { NO_SPACER = 0, LEFT_SPACER, RIGHT_SPACER };
 template <>
 conky::lua_traits<spacer_state>::Map conky::lua_traits<spacer_state>::map = {
@@ -1059,9 +1055,8 @@ static inline void set_foreground_color(long c) {
     XSetForeground(display, window.gc, current_color);
   }
 #endif /* BUILD_X11 */
-#ifdef BUILD_NCURSES
-  if (out_to_ncurses.get(*state)) { attron(COLOR_PAIR(c)); }
-#endif /* BUILD_NCURSES */
+  for (auto output : conky::active_display_outputs)
+    output->set_foreground_color(c);
   UNUSED(c);
 }
 
@@ -1095,9 +1090,6 @@ static void draw_string(const char *s) {
   if (draw_mode == FG && (append_fpointer != nullptr)) {
     fprintf(append_fpointer, "%s\n", s);
   }
-#ifdef BUILD_NCURSES
-  if (out_to_ncurses.get(*state) && draw_mode == FG) { printw("%s", s); }
-#endif /* BUILD_NCURSES */
   if (conky::active_display_outputs.size() && draw_mode == FG)
     for (auto output : conky::active_display_outputs)
       output->draw_string(s, width_of_s);
@@ -1602,14 +1594,9 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
             // make sure shades are 1 pixel to the right of the text
             if (draw_mode == BG) { cur_x++; }
 #endif /* BUILD_X11 */
-#ifdef BUILD_NCURSES
             cur_x = static_cast<int>(current->arg);
-            if (out_to_ncurses.get(*state)) {
-              int x, y;
-              getyx(ncurses_window, y, x);
-              move(y, cur_x);
-            }
-#endif /* BUILD_NCURSES */
+            for (auto output : conky::active_display_outputs)
+              output->gotox(cur_x);
           }
           break;
       }
@@ -1632,9 +1619,7 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
   cur_y += cur_y_add;
 #endif /* BUILD_X11 */
   draw_string(s);
-#ifdef BUILD_NCURSES
-  if (out_to_ncurses.get(*state)) { printw("\n"); }
-#endif /* BUILD_NCURSES */
+  for (auto output : display_outputs()) output->line_inner_done();
 #ifdef BUILD_X11
   if (out_to_x.get(*state)) { cur_y += font_descent(); }
 #endif /* BUILD_X11 */
@@ -1647,11 +1632,10 @@ static int draw_line(char *s, int special_index) {
     return draw_each_line_inner(s, special_index, -1);
   }
 #endif /* BUILD_X11 */
-#ifdef BUILD_NCURSES
-  if (out_to_ncurses.get(*state)) {
+
+  if (display_output() && display_output()->draw_line_inner_required()) {
     return draw_each_line_inner(s, special_index, -1);
   }
-#endif /* BUILD_NCURSES */
   draw_string(s);
   UNUSED(special_index);
   return 0;
@@ -1688,10 +1672,6 @@ static void draw_text() {
   }
   setup_fonts();
 #endif /* BUILD_X11 */
-#ifdef BUILD_NCURSES
-  init_pair(COLOR_WHITE, COLOR_WHITE, COLOR_BLACK);
-  attron(COLOR_PAIR(COLOR_WHITE));
-#endif /* BUILD_NCURSES */
   for_each_line(text_buffer, draw_line);
   for (auto output : conky::active_display_outputs) output->end_draw_text();
 }
@@ -2207,12 +2187,7 @@ void main_loop() {
       nanosleep(&req, &rem);
       update_text();
       draw_stuff();
-#ifdef BUILD_NCURSES
-      if (out_to_ncurses.get(*state)) {
-        refresh();
-        clear();
-      }
-#endif
+      for (auto output : conky::active_display_outputs) output->flush();
 #ifdef BUILD_X11
     }
 #endif /* BUILD_X11 */
@@ -2237,12 +2212,7 @@ void main_loop() {
       NORM_ERR("received SIGUSR2. refreshing.");
       update_text();
       draw_stuff();
-#ifdef BUILD_NCURSES
-      if (out_to_ncurses.get(*state)) {
-        refresh();
-        clear();
-      }
-#endif
+      for (auto output : conky::active_display_outputs) output->flush();
     }
 
     if (g_sigterm_pending != 0) {

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1098,8 +1098,9 @@ static void draw_string(const char *s) {
 #ifdef BUILD_NCURSES
   if (out_to_ncurses.get(*state) && draw_mode == FG) { printw("%s", s); }
 #endif /* BUILD_NCURSES */
-  if (conky::active_display_output != nullptr && draw_mode == FG)
-    conky::active_display_output->draw_string(s, width_of_s);
+  if (conky::active_display_outputs.size() && draw_mode == FG)
+    for (auto output : conky::active_display_outputs)
+      output->draw_string(s, width_of_s);
   int tbs = text_buffer_size.get(*state);
   memset(tmpstring1, 0, tbs);
   memset(tmpstring2, 0, tbs);
@@ -1657,8 +1658,7 @@ static int draw_line(char *s, int special_index) {
 }
 
 static void draw_text() {
-  if (conky::active_display_output)
-    conky::active_display_output->begin_draw_text();
+  for (auto output : conky::active_display_outputs) output->begin_draw_text();
 #ifdef BUILD_X11
   if (out_to_x.get(*state)) {
     cur_y = text_start_y;
@@ -1693,8 +1693,7 @@ static void draw_text() {
   attron(COLOR_PAIR(COLOR_WHITE));
 #endif /* BUILD_NCURSES */
   for_each_line(text_buffer, draw_line);
-  if (conky::active_display_output)
-    conky::active_display_output->end_draw_text();
+  for (auto output : conky::active_display_outputs) output->end_draw_text();
 }
 
 static void draw_stuff() {

--- a/src/conky.h
+++ b/src/conky.h
@@ -292,7 +292,15 @@ extern conky::range_config_setting<double> update_interval;
 extern conky::range_config_setting<double> update_interval_on_battery;
 double active_update_interval();
 
+extern conky::simple_config_setting<bool> show_graph_scale;
+extern conky::simple_config_setting<bool> show_graph_range;
+extern conky::simple_config_setting<int> gap_x;
+extern conky::simple_config_setting<int> gap_y;
+extern conky::simple_config_setting<bool> draw_borders;
+extern conky::simple_config_setting<bool> draw_graph_borders;
 extern conky::range_config_setting<char> stippled_borders;
+extern conky::simple_config_setting<bool> draw_shades;
+extern conky::simple_config_setting<bool> draw_outline;
 
 void set_current_text_color(long colour);
 long get_current_text_color(void);
@@ -301,7 +309,7 @@ void set_updatereset(int);
 int get_updatereset(void);
 int get_total_updates(void);
 
-int xft_dpi_scale(int value);
+int dpi_scale(int value);
 
 int get_saved_coordinates_x(int);
 int get_saved_coordinates_y(int);
@@ -321,6 +329,9 @@ void parse_conky_vars(struct text_object *, const char *, char *, int);
 void extract_object_args_to_sub(struct text_object *, const char *);
 
 void generate_text_internal(char *, int, struct text_object);
+
+void update_text_area();
+void draw_stuff();
 
 int percent_print(char *, int, unsigned);
 void human_readable(long long, char *, int);

--- a/src/conky.h
+++ b/src/conky.h
@@ -380,4 +380,7 @@ extern char **argv_copy;
 extern const char *getopt_string;
 extern const struct option longopts[];
 
+extern conky::simple_config_setting<bool> out_to_stdout;
+extern conky::simple_config_setting<bool> out_to_stderr;
+
 #endif /* _conky_h_ */

--- a/src/core.cc
+++ b/src/core.cc
@@ -53,9 +53,9 @@
 #ifdef BUILD_IRC
 #include "irc.h"
 #endif /* BUILD_IRC */
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
 #include "fonts.h"
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 #include "fs.h"
 #ifdef BUILD_IBM
 #include "ibm.h"
@@ -403,12 +403,12 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   }         \
   else
 
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   if (s[0] == '#') {
     obj->data.l = get_x11_color(s);
     obj->callbacks.print = &new_fg;
   } else
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 #ifndef __OpenBSD__
     OBJ(acpitemp, nullptr)
   obj->data.i = open_acpi_temperature(arg);
@@ -687,7 +687,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   obj->callbacks.percentage = &cpu_percentage;
   obj->callbacks.free = &free_cpu;
   DBGP2("Adding $cpu for CPU %d", obj->data.i);
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   END OBJ(cpugauge, &update_cpu_usage) get_cpu_count();
   SCAN_CPU(arg, obj->data.i);
   scan_gauge(obj, arg, 1);
@@ -701,7 +701,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   obj->callbacks.barval = &cpu_barval;
   obj->callbacks.free = &free_cpu;
   DBGP2("Adding $cpubar for CPU %d", obj->data.i);
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   END OBJ(cpugraph, &update_cpu_usage) get_cpu_count();
   char *buf = nullptr;
   SCAN_CPU(arg, obj->data.i);
@@ -712,29 +712,29 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   obj->callbacks.free = &free_cpu;
   END OBJ(loadgraph, &update_load_average) scan_loadgraph_arg(obj, arg);
   obj->callbacks.graphval = &loadgraphval;
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
   END OBJ(diskio, &update_diskio) parse_diskio_arg(obj, arg);
   obj->callbacks.print = &print_diskio;
   END OBJ(diskio_read, &update_diskio) parse_diskio_arg(obj, arg);
   obj->callbacks.print = &print_diskio_read;
   END OBJ(diskio_write, &update_diskio) parse_diskio_arg(obj, arg);
   obj->callbacks.print = &print_diskio_write;
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   END OBJ(diskiograph, &update_diskio) parse_diskiograph_arg(obj, arg);
   obj->callbacks.graphval = &diskiographval;
   END OBJ(diskiograph_read, &update_diskio) parse_diskiograph_arg(obj, arg);
   obj->callbacks.graphval = &diskiographval_read;
   END OBJ(diskiograph_write, &update_diskio) parse_diskiograph_arg(obj, arg);
   obj->callbacks.graphval = &diskiographval_write;
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
   END OBJ(color, nullptr)
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
       if (out_to_x.get(*state)) {
     obj->data.l =
         arg != nullptr ? get_x11_color(arg) : default_color.get(*state);
     set_current_text_color(obj->data.l);
   }
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 #ifdef BUILD_NCURSES
   if (out_to_ncurses.get(*state)) {
     obj->data.l = COLOR_WHITE;
@@ -760,7 +760,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   }
 #endif /* BUILD_NCURSES */
   obj->callbacks.print = &new_fg;
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   END OBJ(color0, nullptr) obj->data.l = color[0].get(*state);
   set_current_text_color(obj->data.l);
   obj->callbacks.print = &new_fg;
@@ -824,7 +824,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ(font9, nullptr) scan_font(obj, font_template[9].get(*state).c_str());
   obj->callbacks.print = &new_font;
   obj->callbacks.free = &gen_free_opaque;
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
   END OBJ(conky_version, nullptr) obj_be_plain_text(obj, VERSION);
   END OBJ(conky_build_date, nullptr) obj_be_plain_text(obj, BUILD_DATE);
   END OBJ(conky_build_arch, nullptr) obj_be_plain_text(obj, BUILD_ARCH);
@@ -834,11 +834,11 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ(downspeedf, &update_net_stats)
       parse_net_stat_arg(obj, arg, free_at_crash);
   obj->callbacks.print = &print_downspeedf;
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   END OBJ(downspeedgraph, &update_net_stats)
       parse_net_stat_graph_arg(obj, arg, free_at_crash);
   obj->callbacks.graphval = &downspeedgraphval;
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
   END OBJ(else, nullptr) obj_be_ifblock_else(ifblock_opaque, obj);
   obj->callbacks.iftest = &gen_false_iftest;
   END OBJ(endif, nullptr) obj_be_ifblock_endif(ifblock_opaque, obj);
@@ -846,7 +846,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ(eval, nullptr) obj->data.s = STRNDUP_ARG;
   obj->callbacks.print = &print_evaluate;
   obj->callbacks.free = &gen_free_opaque;
-#if defined(BUILD_IMLIB2) && defined(BUILD_X11)
+#if defined(BUILD_IMLIB2) && defined(BUILD_GUI)
   END OBJ(image, nullptr) obj->data.s = STRNDUP_ARG;
   obj->callbacks.print = &print_image_callback;
   obj->callbacks.free = &gen_free_opaque;
@@ -863,13 +863,13 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   obj->callbacks.print = &print_cat;
   obj->callbacks.free = &gen_free_opaque;
 
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   END OBJ(key_num_lock, 0) obj->callbacks.print = &print_key_num_lock;
   END OBJ(key_caps_lock, 0) obj->callbacks.print = &print_key_caps_lock;
   END OBJ(key_scroll_lock, 0) obj->callbacks.print = &print_key_scroll_lock;
   END OBJ(keyboard_layout, 0) obj->callbacks.print = &print_keyboard_layout;
   END OBJ(mouse_speed, 0) obj->callbacks.print = &print_mouse_speed;
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 
 #ifdef __FreeBSD__
   END OBJ(sysctlbyname, 0) obj->data.s = STRNDUP_ARG;
@@ -944,7 +944,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   register_execi(obj);
   obj->callbacks.barval = &execbarval;
   obj->callbacks.free = &free_execi;
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   END OBJ_ARG(execgauge, nullptr,
               "execgauge needs arguments: [height],[width] <command>")
       scan_exec_arg(obj, arg, EF_EXEC | EF_GAUGE);
@@ -972,7 +972,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   register_execi(obj);
   obj->callbacks.graphval = &execbarval;
   obj->callbacks.free = &free_execi;
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
   END OBJ_ARG(texeci, nullptr, "texeci needs arguments: <interval> <command>")
       scan_exec_arg(obj, arg, EF_EXECI);
   obj->parse = false;
@@ -1003,10 +1003,10 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   obj->callbacks.print = &print_fs_type;
   END OBJ(fs_used, &update_fs_stats) init_fs(obj, arg);
   obj->callbacks.print = &print_fs_used;
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   END OBJ(hr, nullptr) obj->data.l = arg != nullptr ? atoi(arg) : 1;
   obj->callbacks.print = &new_hr;
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
   END OBJ(nameserver, &update_dns_data) parse_nameserver_arg(obj, arg);
   obj->callbacks.print = &print_nameserver;
   obj->callbacks.free = &free_dns_data;
@@ -1019,10 +1019,10 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   obj->callbacks.print = &new_save_coordinates;
   END OBJ_ARG(goto, nullptr, "goto needs arguments") obj->data.l = atoi(arg);
   obj->callbacks.print = &new_goto;
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   END OBJ(tab, nullptr) scan_tab(obj, arg);
   obj->callbacks.print = &new_tab;
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 #ifdef __linux__
   END OBJ_ARG(i2c, 0, "i2c needs arguments") parse_i2c_sensor(obj, arg);
   obj->callbacks.print = &print_sysfs_sensor;
@@ -1193,15 +1193,15 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   obj->callbacks.print = &print_memdirty;
   obj->callbacks.free = &gen_free_opaque;
 #endif /* __linux__ */
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   END OBJ(memgauge, &update_meminfo) scan_gauge(obj, arg, 1);
   obj->callbacks.gaugeval = &mem_barval;
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
   END OBJ(membar, &update_meminfo) scan_bar(obj, arg, 1);
   obj->callbacks.barval = &mem_barval;
   END OBJ(memwithbuffersbar, &update_meminfo) scan_bar(obj, arg, 1);
   obj->callbacks.barval = &mem_with_buffers_barval;
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   END OBJ(memgraph, &update_meminfo) char *buf = nullptr;
   buf = scan_graph(obj, arg, 1);
   free_and_zero(buf);
@@ -1210,7 +1210,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   buf = scan_graph(obj, arg, 1);
   free_and_zero(buf);
   obj->callbacks.graphval = &mem_with_buffers_barval;
-#endif /* BUILD_X11*/
+#endif /* BUILD_GUI*/
 #ifdef HAVE_SOME_SOUNDCARD_H
   END OBJ(mixer, 0) parse_mixer_arg(obj, arg);
   obj->callbacks.percentage = &mixer_percentage;
@@ -1227,13 +1227,13 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ_IF(if_mixer_mute, 0) parse_mixer_arg(obj, arg);
   obj->callbacks.iftest = &check_mixer_muted;
 #endif /* HAVE_SOME_SOUNDCARD_H */
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   END OBJ(monitor, nullptr) obj->callbacks.print = &print_monitor;
   END OBJ(monitor_number, nullptr) obj->callbacks.print = &print_monitor_number;
   END OBJ(desktop, nullptr) obj->callbacks.print = &print_desktop;
   END OBJ(desktop_number, nullptr) obj->callbacks.print = &print_desktop_number;
   END OBJ(desktop_name, nullptr) obj->callbacks.print = &print_desktop_name;
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
   END OBJ_ARG(format_time, nullptr, "format_time needs a pid as argument")
       obj->sub = static_cast<text_object *>(malloc(sizeof(struct text_object)));
   extract_variable_text_internal(obj->sub, arg);
@@ -1405,22 +1405,22 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
 #endif
 #endif /* __linux__ */
   END OBJ(shadecolor, nullptr)
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
       obj->data.l =
       arg != nullptr ? get_x11_color(arg) : default_shade_color.get(*state);
   obj->callbacks.print = &new_bg;
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
   END OBJ(outlinecolor, nullptr)
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
       obj->data.l =
       arg != nullptr ? get_x11_color(arg) : default_outline_color.get(*state);
   obj->callbacks.print = &new_outline;
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
   END OBJ(stippled_hr, nullptr)
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
       scan_stippled_hr(obj, arg);
   obj->callbacks.print = &new_stippled_hr;
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
   END OBJ(swap, &update_meminfo) obj->data.s = STRNDUP_ARG;
   obj->callbacks.print = &print_swap;
   obj->callbacks.free = &gen_free_opaque;
@@ -1489,7 +1489,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ(upspeedf, &update_net_stats)
       parse_net_stat_arg(obj, arg, free_at_crash);
   obj->callbacks.print = &print_upspeedf;
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   END OBJ(upspeedgraph, &update_net_stats)
       parse_net_stat_graph_arg(obj, arg, free_at_crash);
   obj->callbacks.graphval = &upspeedgraphval;
@@ -1782,7 +1782,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   }
   obj->callbacks.barval = &lua_barval;
   obj->callbacks.free = &gen_free_opaque;
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   END OBJ_ARG(
       lua_graph, nullptr,
       "lua_graph needs arguments: <function name> [height],[width] [gradient "
@@ -1809,7 +1809,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   }
   obj->callbacks.gaugeval = &lua_barval;
   obj->callbacks.free = &gen_free_opaque;
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 #ifdef BUILD_HDDTEMP
   END OBJ(hddtemp, &update_hddtemp) if (arg) obj->data.s = STRNDUP_ARG;
   obj->callbacks.print = &print_hddtemp;
@@ -1843,9 +1843,9 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   obj->callbacks.free = &free_stock;
 #endif /* BUILD_CURL */
   END OBJ(scroll, nullptr)
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   /* allocate a follower to reset any color changes */
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
       parse_scroll_arg(obj, arg, free_at_crash, s);
   obj->callbacks.print = &print_scroll;
   obj->callbacks.free = &free_scroll;
@@ -1923,14 +1923,14 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
       &print_apcupsd_load;
   END OBJ(apcupsd_loadbar, &update_apcupsd) scan_bar(obj, arg, 100);
   obj->callbacks.barval = &apcupsd_loadbarval;
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   END OBJ(apcupsd_loadgraph, &update_apcupsd) char *buf = nullptr;
   buf = scan_graph(obj, arg, 100);
   free_and_zero(buf);
   obj->callbacks.graphval = &apcupsd_loadbarval;
   END OBJ(apcupsd_loadgauge, &update_apcupsd) scan_gauge(obj, arg, 100);
   obj->callbacks.gaugeval = &apcupsd_loadbarval;
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
   END OBJ(apcupsd_charge, &update_apcupsd) obj->callbacks.print =
       &print_apcupsd_charge;
   END OBJ(apcupsd_timeleft, &update_apcupsd) obj->callbacks.print =

--- a/src/diskio.cc
+++ b/src/diskio.cc
@@ -170,7 +170,7 @@ void print_diskio_write(struct text_object *obj, char *p,
   print_diskio_dir(obj, 1, p, p_max_size);
 }
 
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
 void parse_diskiograph_arg(struct text_object *obj, const char *arg) {
   char *buf = nullptr;
   buf = scan_graph(obj, arg, 0);
@@ -196,7 +196,7 @@ double diskiographval_write(struct text_object *obj) {
 
   return (diskio != nullptr ? diskio->current_write : 0);
 }
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 
 void update_diskio_values(struct diskio_stat *ds, unsigned int reads,
                           unsigned int writes) {

--- a/src/diskio.h
+++ b/src/diskio.h
@@ -70,11 +70,11 @@ void parse_diskio_arg(struct text_object *, const char *);
 void print_diskio(struct text_object *, char *, unsigned int);
 void print_diskio_read(struct text_object *, char *, unsigned int);
 void print_diskio_write(struct text_object *, char *, unsigned int);
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
 void parse_diskiograph_arg(struct text_object *, const char *);
 double diskiographval(struct text_object *);
 double diskiographval_read(struct text_object *);
 double diskiographval_write(struct text_object *);
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 
 #endif /* DISKIO_H_ */

--- a/src/display-console.cc
+++ b/src/display-console.cc
@@ -24,6 +24,7 @@
 
 #include "conky.h"
 #include "display-console.hh"
+#include "nc.h"
 
 #include <iostream>
 #include <sstream>
@@ -45,7 +46,8 @@ display_output_console::display_output_console(const std::string &name_)
 }
 
 bool display_output_console::detect() {
-  if (out_to_stdout.get(*state) || out_to_stderr.get(*state)) {
+  if ((out_to_stdout.get(*state) || out_to_stderr.get(*state)) &&
+      !out_to_ncurses.get(*state)) {
     std::cerr << "Display output '" << name << "' enabled in config."
               << std::endl;
     return true;

--- a/src/display-console.cc
+++ b/src/display-console.cc
@@ -1,0 +1,60 @@
+/*
+ *
+ * Conky, a system monitor, based on torsmo
+ *
+ * Please see COPYING for details
+ *
+ * Copyright (C) 2010 Pavel Labath et al.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <config.h>
+
+#include "conky.h"
+#include "display-console.hh"
+
+#include <iostream>
+#include <sstream>
+#include <unordered_map>
+
+namespace conky {
+namespace {
+
+conky::display_output_console console_output("console");
+
+}  // namespace
+
+namespace priv {}  // namespace priv
+
+display_output_console::display_output_console(const std::string &name_)
+    : display_output_base(name_) {
+  // lowest priority, it's a fallback
+  priority = 0;
+}
+
+bool display_output_console::detect() {
+  if (out_to_stdout.get(*state) || out_to_stderr.get(*state)) {
+    std::cerr << "Display output '" << name << "' enabled in config."
+              << std::endl;
+    return true;
+  }
+  return false;
+}
+
+bool display_output_console::initialize() { return true; }
+
+bool display_output_console::shutdown() { return true; }
+
+}  // namespace conky

--- a/src/display-console.cc
+++ b/src/display-console.cc
@@ -34,6 +34,9 @@
 #include <sstream>
 #include <unordered_map>
 
+static conky::simple_config_setting<bool> extra_newline("extra_newline", false,
+                                                        false);
+
 namespace conky {
 namespace {
 
@@ -62,5 +65,17 @@ bool display_output_console::detect() {
 bool display_output_console::initialize() { return true; }
 
 bool display_output_console::shutdown() { return true; }
+
+void display_output_console::draw_string(const char *s, int w) {
+  if (out_to_stdout.get(*state)) {
+    printf("%s\n", s);
+    if (extra_newline.get(*state)) { fputc('\n', stdout); }
+    fflush(stdout); /* output immediately, don't buffer */
+  }
+  if (out_to_stderr.get(*state)) {
+    fprintf(stderr, "%s\n", s);
+    fflush(stderr); /* output immediately, don't buffer */
+  }
+}
 
 }  // namespace conky

--- a/src/display-console.cc
+++ b/src/display-console.cc
@@ -4,7 +4,11 @@
  *
  * Please see COPYING for details
  *
- * Copyright (C) 2010 Pavel Labath et al.
+ * Copyright (C) 2018 François Revol et al.
+ * Copyright (c) 2004, Hannu Saransaari and Lauri Hakkarainen
+ * Copyright (c) 2005-2019 Brenden Matthews, Philip Kovacs, et. al.
+ *	(see AUTHORS)
+ * All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/display-console.cc
+++ b/src/display-console.cc
@@ -65,7 +65,7 @@ bool display_output_console::initialize() { return true; }
 
 bool display_output_console::shutdown() { return true; }
 
-void display_output_console::draw_string(const char *s, int w) {
+void display_output_console::draw_string(const char *s, int) {
   if (out_to_stdout.get(*state)) {
     printf("%s\n", s);
     if (extra_newline.get(*state)) { fputc('\n', stdout); }

--- a/src/display-console.cc
+++ b/src/display-console.cc
@@ -43,6 +43,7 @@ namespace {
 conky::display_output_console console_output("console");
 
 }  // namespace
+void init_console_output() {}
 
 namespace priv {}  // namespace priv
 

--- a/src/display-console.cc
+++ b/src/display-console.cc
@@ -55,8 +55,7 @@ display_output_console::display_output_console(const std::string &name_)
 bool display_output_console::detect() {
   if ((out_to_stdout.get(*state) || out_to_stderr.get(*state)) &&
       !out_to_ncurses.get(*state)) {
-    std::cerr << "Display output '" << name << "' enabled in config."
-              << std::endl;
+    DBGP2("Display output '%s' enabled in config.", name.c_str());
     return true;
   }
   return false;

--- a/src/display-console.cc
+++ b/src/display-console.cc
@@ -6,7 +6,7 @@
  *
  * Copyright (C) 2018 François Revol et al.
  * Copyright (c) 2004, Hannu Saransaari and Lauri Hakkarainen
- * Copyright (c) 2005-2019 Brenden Matthews, Philip Kovacs, et. al.
+ * Copyright (c) 2005-2021 Brenden Matthews, Philip Kovacs, et. al.
  *	(see AUTHORS)
  * All rights reserved.
  *

--- a/src/display-console.hh
+++ b/src/display-console.hh
@@ -47,6 +47,8 @@ class display_output_console : public display_output_base {
   virtual bool initialize();
   virtual bool shutdown();
 
+  virtual void draw_string(const char *s, int w);
+
   // console-specific
 };
 

--- a/src/display-console.hh
+++ b/src/display-console.hh
@@ -4,7 +4,7 @@
  *
  * Please see COPYING for details
  *
- * Copyright (C) 2010 Pavel Labath et al.
+ * Copyright (C) 2018 François Revol et al.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/display-console.hh
+++ b/src/display-console.hh
@@ -1,0 +1,55 @@
+/*
+ *
+ * Conky, a system monitor, based on torsmo
+ *
+ * Please see COPYING for details
+ *
+ * Copyright (C) 2010 Pavel Labath et al.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DISPLAY_CONSOLE_HH
+#define DISPLAY_CONSOLE_HH
+
+#include <limits>
+#include <string>
+#include <type_traits>
+
+#include "display-output.hh"
+#include "luamm.hh"
+
+namespace conky {
+
+/*
+ * A base class for console display output.
+ */
+class display_output_console : public display_output_base {
+ public:
+  explicit display_output_console(const std::string &name_);
+
+  virtual ~display_output_console() {}
+
+  // check if available and enabled in settings
+  virtual bool detect();
+  // connect to DISPLAY and other stuff
+  virtual bool initialize();
+  virtual bool shutdown();
+
+  // console-specific
+};
+
+}  // namespace conky
+
+#endif /* DISPLAY_CONSOLE_HH */

--- a/src/display-file.cc
+++ b/src/display-file.cc
@@ -49,6 +49,7 @@ namespace {
 conky::display_output_file file_output("file");
 
 }  // namespace
+extern void init_file_output() {}
 
 namespace priv {}  // namespace priv
 

--- a/src/display-file.cc
+++ b/src/display-file.cc
@@ -61,8 +61,7 @@ display_output_file::display_output_file(const std::string &name_)
 bool display_output_file::detect() {
   if (static_cast<unsigned int>(!overwrite_file.get(*state).empty()) != 0u ||
       static_cast<unsigned int>(!append_file.get(*state).empty()) != 0u) {
-    std::cerr << "Display output '" << name << "' enabled in config."
-              << std::endl;
+    DBGP2("Display output '%s' enabled in config.", name.c_str());
     return true;
   }
   return false;

--- a/src/display-file.cc
+++ b/src/display-file.cc
@@ -71,7 +71,7 @@ bool display_output_file::initialize() { return true; }
 
 bool display_output_file::shutdown() { return true; }
 
-void display_output_file::draw_string(const char *s, int w) {
+void display_output_file::draw_string(const char *s, int) {
   if (overwrite_fpointer != nullptr) { fprintf(overwrite_fpointer, "%s\n", s); }
   if (append_fpointer != nullptr) { fprintf(append_fpointer, "%s\n", s); }
 }

--- a/src/display-file.cc
+++ b/src/display-file.cc
@@ -1,0 +1,106 @@
+/*
+ *
+ * Conky, a system monitor, based on torsmo
+ *
+ * Please see COPYING for details
+ *
+ * Copyright (C) 2018 François Revol et al.
+ * Copyright (c) 2004, Hannu Saransaari and Lauri Hakkarainen
+ * Copyright (c) 2005-2019 Brenden Matthews, Philip Kovacs, et. al.
+ *	(see AUTHORS)
+ * All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <config.h>
+
+#include "conky.h"
+#include "display-file.hh"
+#include "nc.h"
+
+#include <iostream>
+#include <sstream>
+#include <unordered_map>
+
+/* filenames for output */
+static conky::simple_config_setting<std::string> overwrite_file(
+    "overwrite_file", std::string(), true);
+static FILE *overwrite_fpointer = nullptr;
+static conky::simple_config_setting<std::string> append_file("append_file",
+                                                             std::string(),
+                                                             true);
+static FILE *append_fpointer = nullptr;
+
+namespace conky {
+namespace {
+
+conky::display_output_file file_output("file");
+
+}  // namespace
+
+namespace priv {}  // namespace priv
+
+display_output_file::display_output_file(const std::string &name_)
+    : display_output_base(name_) {
+  // lowest priority, it's a fallback
+  priority = 0;
+}
+
+bool display_output_file::detect() {
+  if (static_cast<unsigned int>(!overwrite_file.get(*state).empty()) != 0u ||
+      static_cast<unsigned int>(!append_file.get(*state).empty()) != 0u) {
+    std::cerr << "Display output '" << name << "' enabled in config."
+              << std::endl;
+    return true;
+  }
+  return false;
+}
+
+bool display_output_file::initialize() { return true; }
+
+bool display_output_file::shutdown() { return true; }
+
+void display_output_file::draw_string(const char *s, int w) {
+  if (overwrite_fpointer != nullptr) { fprintf(overwrite_fpointer, "%s\n", s); }
+  if (append_fpointer != nullptr) { fprintf(append_fpointer, "%s\n", s); }
+}
+
+void display_output_file::begin_draw_stuff() {
+  if (static_cast<unsigned int>(!overwrite_file.get(*state).empty()) != 0u) {
+    overwrite_fpointer = fopen(overwrite_file.get(*state).c_str(), "we");
+    if (overwrite_fpointer == nullptr) {
+      NORM_ERR("Cannot overwrite '%s'", overwrite_file.get(*state).c_str());
+    }
+  }
+  if (static_cast<unsigned int>(!append_file.get(*state).empty()) != 0u) {
+    append_fpointer = fopen(append_file.get(*state).c_str(), "ae");
+    if (append_fpointer == nullptr) {
+      NORM_ERR("Cannot append to '%s'", append_file.get(*state).c_str());
+    }
+  }
+}
+
+void display_output_file::end_draw_stuff() {
+  if (overwrite_fpointer != nullptr) {
+    fclose(overwrite_fpointer);
+    overwrite_fpointer = nullptr;
+  }
+  if (append_fpointer != nullptr) {
+    fclose(append_fpointer);
+    append_fpointer = nullptr;
+  }
+}
+
+}  // namespace conky

--- a/src/display-file.cc
+++ b/src/display-file.cc
@@ -6,7 +6,7 @@
  *
  * Copyright (C) 2018 François Revol et al.
  * Copyright (c) 2004, Hannu Saransaari and Lauri Hakkarainen
- * Copyright (c) 2005-2019 Brenden Matthews, Philip Kovacs, et. al.
+ * Copyright (c) 2005-2021 Brenden Matthews, Philip Kovacs, et. al.
  *	(see AUTHORS)
  * All rights reserved.
  *

--- a/src/display-file.hh
+++ b/src/display-file.hh
@@ -1,0 +1,60 @@
+/*
+ *
+ * Conky, a system monitor, based on torsmo
+ *
+ * Please see COPYING for details
+ *
+ * Copyright (C) 2018 François Revol et al.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DISPLAY_FILE_HH
+#define DISPLAY_FILE_HH
+
+#include <limits>
+#include <string>
+#include <type_traits>
+
+#include "display-output.hh"
+#include "luamm.hh"
+
+namespace conky {
+
+/*
+ * A base class for file display output.
+ */
+class display_output_file : public display_output_base {
+ public:
+  explicit display_output_file(const std::string &name_);
+
+  virtual ~display_output_file() {}
+
+  // check if available and enabled in settings
+  virtual bool detect();
+  // connect to DISPLAY and other stuff
+  virtual bool initialize();
+  virtual bool shutdown();
+
+  virtual void draw_string(const char *s, int w);
+
+  virtual void begin_draw_stuff();
+  virtual void end_draw_stuff();
+
+  // file-specific
+};
+
+}  // namespace conky
+
+#endif /* DISPLAY_FILE_HH */

--- a/src/display-http.cc
+++ b/src/display-http.cc
@@ -173,7 +173,7 @@ void display_output_http::begin_draw_text() {
 
 void display_output_http::end_draw_text() { webpage.append(WEBPAGE_END); }
 
-void display_output_http::draw_string(const char *s, int w) {
+void display_output_http::draw_string(const char *s, int) {
   std::string::size_type origlen = webpage.length();
   webpage.append(s);
   webpage = string_replace_all(webpage, "\n", "<br />", origlen);

--- a/src/display-http.cc
+++ b/src/display-http.cc
@@ -47,6 +47,7 @@ conky::disabled_display_output http_output_disabled("http", "BUILD_HTTP");
 #endif
 
 }  // namespace
+extern void init_http_output() {}
 
 // TODO: cleanup namespace
 // namespace priv {

--- a/src/display-http.cc
+++ b/src/display-http.cc
@@ -4,7 +4,11 @@
  *
  * Please see COPYING for details
  *
- * Copyright (C) 2010 Pavel Labath et al.
+ * Copyright (C) 2018 François Revol et al.
+ * Copyright (c) 2004, Hannu Saransaari and Lauri Hakkarainen
+ * Copyright (c) 2005-2019 Brenden Matthews, Philip Kovacs, et. al.
+ *	(see AUTHORS)
+ * All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,6 +33,10 @@
 #include <sstream>
 #include <unordered_map>
 
+#ifdef BUILD_HTTP
+#include <microhttpd.h>
+#endif /* BUILD_HTTP */
+
 namespace conky {
 namespace {
 
@@ -40,27 +48,147 @@ conky::disabled_display_output http_output_disabled("http", "BUILD_HTTP");
 
 }  // namespace
 
-namespace priv {}  // namespace priv
+// TODO: cleanup namespace
+// namespace priv {
+
+#ifdef BUILD_HTTP
+#ifdef MHD_YES
+/* older API */
+#define MHD_Result int
+#endif /* MHD_YES */
+std::string webpage;
+struct MHD_Daemon *httpd;
+static conky::simple_config_setting<bool> http_refresh("http_refresh", false,
+                                                       true);
+
+MHD_Result sendanswer(void *cls, struct MHD_Connection *connection,
+                      const char *url, const char *method, const char *version,
+                      const char *upload_data, size_t *upload_data_size,
+                      void **con_cls) {
+  struct MHD_Response *response = MHD_create_response_from_buffer(
+      webpage.length(), (void *)webpage.c_str(), MHD_RESPMEM_PERSISTENT);
+  MHD_Result ret = MHD_queue_response(connection, MHD_HTTP_OK, response);
+  MHD_destroy_response(response);
+  if (cls || url || method || version || upload_data || upload_data_size ||
+      con_cls) {}  // make compiler happy
+  return ret;
+}
+
+class out_to_http_setting : public conky::simple_config_setting<bool> {
+  typedef conky::simple_config_setting<bool> Base;
+
+ protected:
+  virtual void lua_setter(lua::state &l, bool init) {
+    lua::stack_sentry s(l, -2);
+
+    Base::lua_setter(l, init);
+
+    if (init && do_convert(l, -1).first) {
+      httpd = MHD_start_daemon(MHD_USE_SELECT_INTERNALLY, HTTPPORT, nullptr,
+                               NULL, &sendanswer, nullptr, MHD_OPTION_END);
+    }
+
+    ++s;
+  }
+
+  virtual void cleanup(lua::state &l) {
+    lua::stack_sentry s(l, -1);
+
+    if (do_convert(l, -1).first) {
+      MHD_stop_daemon(httpd);
+      httpd = nullptr;
+    }
+
+    l.pop();
+  }
+
+ public:
+  out_to_http_setting() : Base("out_to_http", false, false) {}
+};
+static out_to_http_setting out_to_http;
+
+std::string string_replace_all(std::string original, const std::string &oldpart,
+                               const std::string &newpart,
+                               std::string::size_type start) {
+  std::string::size_type i = start;
+  int oldpartlen = oldpart.length();
+  while (1) {
+    i = original.find(oldpart, i);
+    if (i == std::string::npos) { break; }
+    original.replace(i, oldpartlen, newpart);
+  }
+  return original;
+}
+
+#endif /* BUILD_HTTP */
+
+//}  // namespace priv
 
 #ifdef BUILD_HTTP
 
 display_output_http::display_output_http() : display_output_base("http") {
   priority = 1;
+  httpd = NULL;
 }
 
 bool display_output_http::detect() {
-  /* TODO:
-  if (out_to_http.get(*state)) {
-    std::cerr << "Display output '" << name << "' enabled in config." <<
-  std::endl; return true;
+  if (/*priv::*/ out_to_http.get(*state)) {
+    std::cerr << "Display output '" << name << "' enabled in config."
+              << std::endl;
+    return true;
   }
-  */
   return false;
 }
 
-bool display_output_http::initialize() { return false; }
+bool display_output_http::initialize() {
+  if (/*priv::*/ out_to_http.get(*state)) {
+    is_active = true;
+    return true;
+  }
+  return false;
+}
 
-bool display_output_http::shutdown() { return false; }
+bool display_output_http::shutdown() { return true; }
+
+bool display_output_http::begin_draw_text() {
+#ifdef BUILD_HTTP
+#define WEBPAGE_START1                                             \
+  "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" "    \
+  "\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n<html " \
+  "xmlns=\"http://www.w3.org/1999/xhtml\"><head><meta "            \
+  "http-equiv=\"Content-type\" content=\"text/html;charset=UTF-8\" />"
+#define WEBPAGE_START2 \
+  "<title>Conky</title></head><body style=\"font-family: monospace\"><p>"
+#define WEBPAGE_END "</p></body></html>"
+  if (out_to_http.get(*state)) {
+    webpage = WEBPAGE_START1;
+    if (http_refresh.get(*state)) {
+      webpage.append("<meta http-equiv=\"refresh\" content=\"");
+      std::stringstream update_interval_str;
+      update_interval_str << update_interval.get(*state);
+      webpage.append(update_interval_str.str());
+      webpage.append("\" />");
+    }
+    webpage.append(WEBPAGE_START2);
+  }
+#endif /* BUILD_HTTP */
+  return true;
+}
+
+bool display_output_http::end_draw_text() {
+  webpage.append(WEBPAGE_END);
+  return true;
+}
+
+bool display_output_http::draw_string(const char *s, int w) {
+  std::string::size_type origlen = webpage.length();
+  webpage.append(s);
+  webpage = string_replace_all(webpage, "\n", "<br />", origlen);
+  webpage = string_replace_all(webpage, "  ", "&nbsp;&nbsp;", origlen);
+  webpage = string_replace_all(webpage, "&nbsp; ", "&nbsp;&nbsp;", origlen);
+  webpage.append("<br />");
+  return true;
+}
 
 #endif
 

--- a/src/display-http.cc
+++ b/src/display-http.cc
@@ -150,8 +150,7 @@ bool display_output_http::initialize() {
 
 bool display_output_http::shutdown() { return true; }
 
-bool display_output_http::begin_draw_text() {
-#ifdef BUILD_HTTP
+void display_output_http::begin_draw_text() {
 #define WEBPAGE_START1                                             \
   "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" "    \
   "\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n<html " \
@@ -171,25 +170,19 @@ bool display_output_http::begin_draw_text() {
     }
     webpage.append(WEBPAGE_START2);
   }
-#endif /* BUILD_HTTP */
-  return true;
 }
 
-bool display_output_http::end_draw_text() {
-  webpage.append(WEBPAGE_END);
-  return true;
-}
+void display_output_http::end_draw_text() { webpage.append(WEBPAGE_END); }
 
-bool display_output_http::draw_string(const char *s, int w) {
+void display_output_http::draw_string(const char *s, int w) {
   std::string::size_type origlen = webpage.length();
   webpage.append(s);
   webpage = string_replace_all(webpage, "\n", "<br />", origlen);
   webpage = string_replace_all(webpage, "  ", "&nbsp;&nbsp;", origlen);
   webpage = string_replace_all(webpage, "&nbsp; ", "&nbsp;&nbsp;", origlen);
   webpage.append("<br />");
-  return true;
 }
 
-#endif
+#endif /* BUILD_HTTP */
 
 }  // namespace conky

--- a/src/display-http.cc
+++ b/src/display-http.cc
@@ -1,0 +1,67 @@
+/*
+ *
+ * Conky, a system monitor, based on torsmo
+ *
+ * Please see COPYING for details
+ *
+ * Copyright (C) 2010 Pavel Labath et al.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <config.h>
+
+#include "conky.h"
+#include "display-http.hh"
+
+#include <iostream>
+#include <sstream>
+#include <unordered_map>
+
+namespace conky {
+namespace {
+
+#ifdef BUILD_HTTP
+conky::display_output_http http_output;
+#else
+conky::disabled_display_output http_output_disabled("http", "BUILD_HTTP");
+#endif
+
+}  // namespace
+
+namespace priv {}  // namespace priv
+
+#ifdef BUILD_HTTP
+
+display_output_http::display_output_http() : display_output_base("http") {
+  priority = 1;
+}
+
+bool display_output_http::detect() {
+  /* TODO:
+  if (out_to_http.get(*state)) {
+    std::cerr << "Display output '" << name << "' enabled in config." <<
+  std::endl; return true;
+  }
+  */
+  return false;
+}
+
+bool display_output_http::initialize() { return false; }
+
+bool display_output_http::shutdown() { return false; }
+
+#endif
+
+}  // namespace conky

--- a/src/display-http.cc
+++ b/src/display-http.cc
@@ -133,8 +133,7 @@ display_output_http::display_output_http() : display_output_base("http") {
 
 bool display_output_http::detect() {
   if (/*priv::*/ out_to_http.get(*state)) {
-    std::cerr << "Display output '" << name << "' enabled in config."
-              << std::endl;
+    DBGP2("Display output '%s' enabled in config.", name.c_str());
     return true;
   }
   return false;

--- a/src/display-http.cc
+++ b/src/display-http.cc
@@ -127,7 +127,7 @@ std::string string_replace_all(std::string original, const std::string &oldpart,
 #ifdef BUILD_HTTP
 
 display_output_http::display_output_http() : display_output_base("http") {
-  priority = 1;
+  priority = 0;
   httpd = NULL;
 }
 

--- a/src/display-http.cc
+++ b/src/display-http.cc
@@ -6,7 +6,7 @@
  *
  * Copyright (C) 2018 François Revol et al.
  * Copyright (c) 2004, Hannu Saransaari and Lauri Hakkarainen
- * Copyright (c) 2005-2019 Brenden Matthews, Philip Kovacs, et. al.
+ * Copyright (c) 2005-2021 Brenden Matthews, Philip Kovacs, et. al.
  *	(see AUTHORS)
  * All rights reserved.
  *

--- a/src/display-http.hh
+++ b/src/display-http.hh
@@ -4,7 +4,7 @@
  *
  * Please see COPYING for details
  *
- * Copyright (C) 2010 Pavel Labath et al.
+ * Copyright (C) 2018 François Revol et al.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/display-http.hh
+++ b/src/display-http.hh
@@ -1,0 +1,55 @@
+/*
+ *
+ * Conky, a system monitor, based on torsmo
+ *
+ * Please see COPYING for details
+ *
+ * Copyright (C) 2010 Pavel Labath et al.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DISPLAY_HTTP_HH
+#define DISPLAY_HTTP_HH
+
+#include <limits>
+#include <string>
+#include <type_traits>
+
+#include "display-output.hh"
+#include "luamm.hh"
+
+namespace conky {
+
+/*
+ * A base class for HTTP display output.
+ */
+class display_output_http : public display_output_base {
+ public:
+  explicit display_output_http();
+
+  virtual ~display_output_http() {}
+
+  // check if available and enabled in settings
+  virtual bool detect();
+  // connect to DISPLAY and other stuff
+  virtual bool initialize();
+  virtual bool shutdown();
+
+  // HTTP-specific
+};
+
+}  // namespace conky
+
+#endif /* DISPLAY_HTTP_HH */

--- a/src/display-http.hh
+++ b/src/display-http.hh
@@ -4,7 +4,7 @@
  *
  * Please see COPYING for details
  *
- * Copyright (C) 2018 François Revol et al.
+ * Copyright (C) 2018-2021 François Revol et al.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/display-http.hh
+++ b/src/display-http.hh
@@ -47,7 +47,15 @@ class display_output_http : public display_output_base {
   virtual bool initialize();
   virtual bool shutdown();
 
+  // drawing primitives
+  virtual bool begin_draw_text();
+  virtual bool end_draw_text();
+  virtual bool draw_string(const char *s, int w);
+
   // HTTP-specific
+ private:
+  // std::string webpage;
+  // struct MHD_Daemon *httpd;
 };
 
 }  // namespace conky

--- a/src/display-http.hh
+++ b/src/display-http.hh
@@ -48,10 +48,10 @@ class display_output_http : public display_output_base {
   virtual bool shutdown();
 
   // drawing primitives
-  virtual void set_foreground_color(long c) {}
+  virtual void set_foreground_color(long) {}
   virtual void begin_draw_text();
   virtual void end_draw_text();
-  virtual void draw_string(const char *s, int w);
+  virtual void draw_string(const char *, int);
 
   // HTTP-specific
  private:

--- a/src/display-http.hh
+++ b/src/display-http.hh
@@ -48,9 +48,10 @@ class display_output_http : public display_output_base {
   virtual bool shutdown();
 
   // drawing primitives
-  virtual bool begin_draw_text();
-  virtual bool end_draw_text();
-  virtual bool draw_string(const char *s, int w);
+  virtual void set_foreground_color(long c) {}
+  virtual void begin_draw_text();
+  virtual void end_draw_text();
+  virtual void draw_string(const char *s, int w);
 
   // HTTP-specific
  private:

--- a/src/display-ncurses.cc
+++ b/src/display-ncurses.cc
@@ -1,0 +1,69 @@
+/*
+ *
+ * Conky, a system monitor, based on torsmo
+ *
+ * Please see COPYING for details
+ *
+ * Copyright (C) 2010 Pavel Labath et al.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <config.h>
+
+#include "conky.h"
+#include "display-ncurses.hh"
+#include "nc.h"
+
+#include <iostream>
+#include <sstream>
+#include <unordered_map>
+
+namespace conky {
+namespace {
+
+#ifdef BUILD_NCURSES
+conky::display_output_ncurses ncurses_output;
+#else
+conky::disabled_display_output ncurses_output_disabled("ncurses",
+                                                       "BUILD_NCURSES");
+#endif
+
+}  // namespace
+
+namespace priv {}  // namespace priv
+
+#ifdef BUILD_NCURSES
+
+display_output_ncurses::display_output_ncurses()
+    : display_output_console("ncurses") {
+  priority = 1;
+}
+
+bool display_output_ncurses::detect() {
+  if (out_to_ncurses.get(*state)) {
+    std::cerr << "Display output '" << name << "' enabled in config."
+              << std::endl;
+    return true;
+  }
+  return false;
+}
+
+bool display_output_ncurses::initialize() { return false; }
+
+bool display_output_ncurses::shutdown() { return false; }
+
+#endif /* BUILD_NCURSES */
+
+}  // namespace conky

--- a/src/display-ncurses.cc
+++ b/src/display-ncurses.cc
@@ -90,7 +90,7 @@ void display_output_ncurses::begin_draw_text() {
 
 void display_output_ncurses::end_draw_text() {}
 
-void display_output_ncurses::draw_string(const char *s, int w) {
+void display_output_ncurses::draw_string(const char *s, int) {
   printw("%s", s);
 }
 
@@ -99,24 +99,28 @@ void display_output_ncurses::line_inner_done() { printw("\n"); }
 int display_output_ncurses::getx() {
   int x, y;
   getyx(ncurses_window, y, x);
+  (void)y;
   return x;
 }
 
 int display_output_ncurses::gety() {
   int x, y;
   getyx(ncurses_window, y, x);
+  (void)x;
   return y;
 }
 
 void display_output_ncurses::gotox(int x) {
   int y, old_x;
   getyx(ncurses_window, y, old_x);
+  (void)old_x;
   move(y, x);
 }
 
 void display_output_ncurses::gotoy(int y) {
   int x, old_y;
   getyx(ncurses_window, old_y, x);
+  (void)old_y;
   move(y, x);
 }
 

--- a/src/display-ncurses.cc
+++ b/src/display-ncurses.cc
@@ -29,6 +29,13 @@
 #include <iostream>
 #include <sstream>
 #include <unordered_map>
+#ifdef BUILD_NCURSES
+#include <ncurses.h>
+#endif
+
+#ifdef BUILD_NCURSES
+extern WINDOW *ncurses_window;
+#endif
 
 namespace conky {
 namespace {
@@ -42,7 +49,9 @@ conky::disabled_display_output ncurses_output_disabled("ncurses",
 
 }  // namespace
 
-namespace priv {}  // namespace priv
+// namespace priv {
+
+//}  // namespace priv
 
 #ifdef BUILD_NCURSES
 
@@ -60,9 +69,68 @@ bool display_output_ncurses::detect() {
   return false;
 }
 
-bool display_output_ncurses::initialize() { return false; }
+bool display_output_ncurses::initialize() {
+  return (ncurses_window != nullptr);
+}
 
 bool display_output_ncurses::shutdown() { return false; }
+
+bool display_output_ncurses::set_foreground_color(long c) {
+  attron(COLOR_PAIR(c));
+  return true;
+}
+
+bool display_output_ncurses::begin_draw_text() {
+  init_pair(COLOR_WHITE, COLOR_WHITE, COLOR_BLACK);
+  attron(COLOR_PAIR(COLOR_WHITE));
+  return true;
+}
+
+bool display_output_ncurses::end_draw_text() { return true; }
+
+bool display_output_ncurses::draw_string(const char *s, int w) {
+  printw("%s", s);
+  return true;
+}
+
+void display_output_ncurses::line_inner_done() { printw("\n"); }
+
+int display_output_ncurses::getx() {
+  int x, y;
+  getyx(ncurses_window, y, x);
+  return x;
+}
+
+int display_output_ncurses::gety() {
+  int x, y;
+  getyx(ncurses_window, y, x);
+  return y;
+}
+
+bool display_output_ncurses::gotox(int x) {
+  int y, old_x;
+  getyx(ncurses_window, y, old_x);
+  move(y, x);
+  return true;
+}
+
+bool display_output_ncurses::gotoy(int y) {
+  int x, old_y;
+  getyx(ncurses_window, old_y, x);
+  move(y, x);
+  return true;
+}
+
+bool display_output_ncurses::gotoxy(int x, int y) {
+  move(y, x);
+  return true;
+}
+
+bool display_output_ncurses::flush() {
+  refresh();
+  clear();
+  return true;
+}
 
 #endif /* BUILD_NCURSES */
 

--- a/src/display-ncurses.cc
+++ b/src/display-ncurses.cc
@@ -4,7 +4,11 @@
  *
  * Please see COPYING for details
  *
- * Copyright (C) 2010 Pavel Labath et al.
+ * Copyright (C) 2018 François Revol et al.
+ * Copyright (c) 2004, Hannu Saransaari and Lauri Hakkarainen
+ * Copyright (c) 2005-2019 Brenden Matthews, Philip Kovacs, et. al.
+ *	(see AUTHORS)
+ * All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/display-ncurses.cc
+++ b/src/display-ncurses.cc
@@ -74,27 +74,25 @@ bool display_output_ncurses::detect() {
 }
 
 bool display_output_ncurses::initialize() {
-  return (ncurses_window != nullptr);
+  is_active = ncurses_window != nullptr;
+  return is_active;
 }
 
 bool display_output_ncurses::shutdown() { return false; }
 
-bool display_output_ncurses::set_foreground_color(long c) {
+void display_output_ncurses::set_foreground_color(long c) {
   attron(COLOR_PAIR(c));
-  return true;
 }
 
-bool display_output_ncurses::begin_draw_text() {
+void display_output_ncurses::begin_draw_text() {
   init_pair(COLOR_WHITE, COLOR_WHITE, COLOR_BLACK);
   attron(COLOR_PAIR(COLOR_WHITE));
-  return true;
 }
 
-bool display_output_ncurses::end_draw_text() { return true; }
+void display_output_ncurses::end_draw_text() {}
 
-bool display_output_ncurses::draw_string(const char *s, int w) {
+void display_output_ncurses::draw_string(const char *s, int w) {
   printw("%s", s);
-  return true;
 }
 
 void display_output_ncurses::line_inner_done() { printw("\n"); }
@@ -111,29 +109,23 @@ int display_output_ncurses::gety() {
   return y;
 }
 
-bool display_output_ncurses::gotox(int x) {
+void display_output_ncurses::gotox(int x) {
   int y, old_x;
   getyx(ncurses_window, y, old_x);
   move(y, x);
-  return true;
 }
 
-bool display_output_ncurses::gotoy(int y) {
+void display_output_ncurses::gotoy(int y) {
   int x, old_y;
   getyx(ncurses_window, old_y, x);
   move(y, x);
-  return true;
 }
 
-bool display_output_ncurses::gotoxy(int x, int y) {
-  move(y, x);
-  return true;
-}
+void display_output_ncurses::gotoxy(int x, int y) { move(y, x); }
 
-bool display_output_ncurses::flush() {
+void display_output_ncurses::flush() {
   refresh();
   clear();
-  return true;
 }
 
 #endif /* BUILD_NCURSES */

--- a/src/display-ncurses.cc
+++ b/src/display-ncurses.cc
@@ -52,6 +52,7 @@ conky::disabled_display_output ncurses_output_disabled("ncurses",
 #endif
 
 }  // namespace
+extern void init_ncurses_output() {}
 
 // namespace priv {
 

--- a/src/display-ncurses.cc
+++ b/src/display-ncurses.cc
@@ -66,8 +66,7 @@ display_output_ncurses::display_output_ncurses()
 
 bool display_output_ncurses::detect() {
   if (out_to_ncurses.get(*state)) {
-    std::cerr << "Display output '" << name << "' enabled in config."
-              << std::endl;
+    DBGP2("Display output '%s' enabled in config.", name.c_str());
     return true;
   }
   return false;

--- a/src/display-ncurses.cc
+++ b/src/display-ncurses.cc
@@ -6,7 +6,7 @@
  *
  * Copyright (C) 2018 François Revol et al.
  * Copyright (c) 2004, Hannu Saransaari and Lauri Hakkarainen
- * Copyright (c) 2005-2019 Brenden Matthews, Philip Kovacs, et. al.
+ * Copyright (c) 2005-2021 Brenden Matthews, Philip Kovacs, et. al.
  *	(see AUTHORS)
  * All rights reserved.
  *

--- a/src/display-ncurses.hh
+++ b/src/display-ncurses.hh
@@ -47,6 +47,22 @@ class display_output_ncurses : public display_output_console {
   virtual bool initialize();
   virtual bool shutdown();
 
+  // drawing primitives
+  virtual bool set_foreground_color(long c);
+
+  virtual bool begin_draw_text();
+  virtual bool end_draw_text();
+  virtual bool draw_string(const char *s, int w);
+  virtual void line_inner_done();
+
+  virtual int getx();
+  virtual int gety();
+  virtual bool gotox(int x);
+  virtual bool gotoy(int y);
+  virtual bool gotoxy(int x, int y);
+
+  virtual bool flush();
+
   // ncurses-specific
 };
 

--- a/src/display-ncurses.hh
+++ b/src/display-ncurses.hh
@@ -46,22 +46,23 @@ class display_output_ncurses : public display_output_console {
   // connect to DISPLAY and other stuff
   virtual bool initialize();
   virtual bool shutdown();
+  virtual bool draw_line_inner_required() { return true; }
 
   // drawing primitives
-  virtual bool set_foreground_color(long c);
+  virtual void set_foreground_color(long c);
 
-  virtual bool begin_draw_text();
-  virtual bool end_draw_text();
-  virtual bool draw_string(const char *s, int w);
+  virtual void begin_draw_text();
+  virtual void end_draw_text();
+  virtual void draw_string(const char *s, int w);
   virtual void line_inner_done();
 
   virtual int getx();
   virtual int gety();
-  virtual bool gotox(int x);
-  virtual bool gotoy(int y);
-  virtual bool gotoxy(int x, int y);
+  virtual void gotox(int x);
+  virtual void gotoy(int y);
+  virtual void gotoxy(int x, int y);
 
-  virtual bool flush();
+  virtual void flush();
 
   // ncurses-specific
 };

--- a/src/display-ncurses.hh
+++ b/src/display-ncurses.hh
@@ -4,7 +4,7 @@
  *
  * Please see COPYING for details
  *
- * Copyright (C) 2010 Pavel Labath et al.
+ * Copyright (C) 2018 François Revol et al.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/display-ncurses.hh
+++ b/src/display-ncurses.hh
@@ -1,0 +1,55 @@
+/*
+ *
+ * Conky, a system monitor, based on torsmo
+ *
+ * Please see COPYING for details
+ *
+ * Copyright (C) 2010 Pavel Labath et al.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DISPLAY_NCURSES_HH
+#define DISPLAY_NCURSES_HH
+
+#include <limits>
+#include <string>
+#include <type_traits>
+
+#include "display-console.hh"
+#include "luamm.hh"
+
+namespace conky {
+
+/*
+ * A base class for ncurses display output.
+ */
+class display_output_ncurses : public display_output_console {
+ public:
+  explicit display_output_ncurses();
+
+  virtual ~display_output_ncurses() {}
+
+  // check if available and enabled in settings
+  virtual bool detect();
+  // connect to DISPLAY and other stuff
+  virtual bool initialize();
+  virtual bool shutdown();
+
+  // ncurses-specific
+};
+
+}  // namespace conky
+
+#endif /* DISPLAY_NCURSES_HH */

--- a/src/display-output.cc
+++ b/src/display-output.cc
@@ -1,0 +1,120 @@
+/*
+ *
+ * Conky, a system monitor, based on torsmo
+ *
+ * Please see COPYING for details
+ *
+ * Copyright (C) 2010 Pavel Labath et al.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <config.h>
+
+#include "display-output.hh"
+
+#include <iostream>
+#include <sstream>
+#include <unordered_map>
+
+namespace conky {
+namespace {
+
+typedef std::unordered_map<std::string, display_output_base *>
+    display_outputs_t;
+
+/*
+ * We cannot construct this object statically, because order of object
+ * construction in different modules is not defined, so register_source could be
+ * called before this object is constructed. Therefore, we create it on the
+ * first call to register_source.
+ */
+display_outputs_t *display_outputs;
+
+}  // namespace
+
+/*
+ * The selected and active display output.
+ * XXX: do we want to support multiple outputs???
+ */
+display_output_base *active_display_output = nullptr;
+
+namespace priv {
+void do_register_display_output(const std::string &name,
+                                display_output_base *output) {
+  struct display_output_constructor {
+    display_output_constructor() { display_outputs = new display_outputs_t(); }
+    ~display_output_constructor() {
+      delete display_outputs;
+      display_outputs = nullptr;
+    }
+  };
+  static display_output_constructor constructor;
+
+  bool inserted = display_outputs->insert({name, output}).second;
+  if (!inserted) {
+    throw std::logic_error("Display output with name '" + name +
+                           "' already registered");
+  }
+}
+
+}  // namespace priv
+
+display_output_base::display_output_base(const std::string &name_)
+    : name(name_), is_active(false), priority(-1) {
+  priv::do_register_display_output(name, this);
+}
+
+disabled_display_output::disabled_display_output(const std::string &name,
+                                                 const std::string &define)
+    : display_output_base(name) {
+  priority = -2;
+  // XXX some generic way of reporting errors? NORM_ERR?
+  std::cerr << "Support for display output '" << name
+            << "' has been disabled during compilation. Please recompile with '"
+            << define << "'" << std::endl;
+}
+
+bool initialize_display_outputs() {
+  std::vector<display_output_base *> outputs;
+  outputs.reserve(display_outputs->size());
+
+  for (auto &output : *display_outputs) { outputs.push_back(output.second); }
+  sort(outputs.begin(), outputs.end(), &display_output_base::priority_compare);
+
+  for (auto output : outputs) {
+    std::cerr << "Testing display output '" << output->name << "'... "
+              << std::endl;
+    if (output->detect()) {
+      std::cerr << "Detected display output '" << output->name << "'... "
+                << std::endl;
+      if (output->initialize()) {
+        std::cerr << "Initialized display output '" << output->name << "'... "
+                  << std::endl;
+        output->is_active = true;
+        active_display_output = output;
+        return true;
+      }
+    }
+  }
+  std::cerr << "Unable to find a usable display output." << std::endl;
+  return true;  // false;
+}
+
+bool shutdown_display_outputs() {
+  if (active_display_output) { return active_display_output->shutdown(); }
+  return false;
+}
+
+}  // namespace conky

--- a/src/display-output.cc
+++ b/src/display-output.cc
@@ -72,7 +72,7 @@ void do_register_display_output(const std::string &name,
 }  // namespace priv
 
 display_output_base::display_output_base(const std::string &name_)
-    : name(name_), is_active(false), priority(-1) {
+    : name(name_), is_active(false), is_graphical(false), priority(-1) {
   priv::do_register_display_output(name, this);
 }
 

--- a/src/display-output.cc
+++ b/src/display-output.cc
@@ -4,7 +4,11 @@
  *
  * Please see COPYING for details
  *
- * Copyright (C) 2010 Pavel Labath et al.
+ * Copyright (C) 2018 François Revol et al.
+ * Copyright (c) 2004, Hannu Saransaari and Lauri Hakkarainen
+ * Copyright (c) 2005-2019 Brenden Matthews, Philip Kovacs, et. al.
+ *	(see AUTHORS)
+ * All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/display-output.cc
+++ b/src/display-output.cc
@@ -54,6 +54,12 @@ display_outputs_t *display_outputs;
  */
 std::vector<display_output_base *> active_display_outputs;
 
+/*
+ * the list of the only current output, when inside draw_text,
+ * else we iterate over each active outputs.
+ */
+std::vector<conky::display_output_base *> current_display_outputs;
+
 namespace priv {
 void do_register_display_output(const std::string &name,
                                 display_output_base *output) {

--- a/src/display-output.cc
+++ b/src/display-output.cc
@@ -27,6 +27,7 @@
 #include <config.h>
 
 #include "display-output.hh"
+#include "logging.h"
 
 #include <algorithm>
 #include <iostream>
@@ -91,9 +92,10 @@ disabled_display_output::disabled_display_output(const std::string &name,
     : display_output_base(name) {
   priority = -2;
   // XXX some generic way of reporting errors? NORM_ERR?
-  std::cerr << "Support for display output '" << name
-            << "' has been disabled during compilation. Please recompile with '"
-            << define << "'" << std::endl;
+  DBGP(
+      "Support for display output '%s' has been disabled during compilation. "
+      "Please recompile with '%s'",
+      name.c_str(), define.c_str());
 }
 
 bool initialize_display_outputs() {
@@ -108,11 +110,9 @@ bool initialize_display_outputs() {
 
   for (auto output : outputs) {
     if (output->priority < 0) continue;
-    std::cerr << "Testing display output '" << output->name << "'... "
-              << std::endl;
+    DBGP2("Testing display output '%s'... ", output->name.c_str());
     if (output->detect()) {
-      std::cerr << "Detected display output '" << output->name << "'... "
-                << std::endl;
+      DBGP2("Detected display output '%s'... ", output->name.c_str());
 
       if (graphical_count && output->graphical()) continue;
 
@@ -120,8 +120,7 @@ bool initialize_display_outputs() {
       active_display_outputs.push_back(output);
 
       if (output->initialize()) {
-        std::cerr << "Initialized display output '" << output->name << "'... "
-                  << std::endl;
+        DBGP("Initialized display output '%s'... ", output->name.c_str());
 
         output->is_active = true;
         if (output->graphical()) graphical_count++;

--- a/src/display-output.cc
+++ b/src/display-output.cc
@@ -50,6 +50,13 @@ display_outputs_t *display_outputs;
 
 }  // namespace
 
+// HACK: force the linker to link all the objects in with test enabled
+extern void init_console_output();
+extern void init_ncurses_output();
+extern void init_file_output();
+extern void init_http_output();
+extern void init_x11_output();
+
 /*
  * The selected and active display output.
  */
@@ -99,6 +106,12 @@ disabled_display_output::disabled_display_output(const std::string &name,
 }
 
 bool initialize_display_outputs() {
+  init_console_output();
+  init_ncurses_output();
+  init_file_output();
+  init_http_output();
+  init_x11_output();
+
   std::vector<display_output_base *> outputs;
   outputs.reserve(display_outputs->size());
 

--- a/src/display-output.cc
+++ b/src/display-output.cc
@@ -28,10 +28,10 @@
 
 #include "display-output.hh"
 
+#include <algorithm>
 #include <iostream>
 #include <sstream>
 #include <unordered_map>
-#include <vector>
 
 namespace conky {
 namespace {
@@ -101,7 +101,10 @@ bool initialize_display_outputs() {
   outputs.reserve(display_outputs->size());
 
   for (auto &output : *display_outputs) { outputs.push_back(output.second); }
+  // Sort display outputs by descending priority, to try graphical ones first.
   sort(outputs.begin(), outputs.end(), &display_output_base::priority_compare);
+
+  int graphical_count = 0;
 
   for (auto output : outputs) {
     if (output->priority < 0) continue;
@@ -110,23 +113,43 @@ bool initialize_display_outputs() {
     if (output->detect()) {
       std::cerr << "Detected display output '" << output->name << "'... "
                 << std::endl;
+
+      if (graphical_count && output->graphical()) continue;
+
+      // X11 init needs to draw, so we must add it to the list first.
+      active_display_outputs.push_back(output);
+
       if (output->initialize()) {
         std::cerr << "Initialized display output '" << output->name << "'... "
                   << std::endl;
+
         output->is_active = true;
-        active_display_outputs.push_back(output);
+        if (output->graphical()) graphical_count++;
+        /*
+         * We only support a single graphical display for now.
+         * More than one text display (ncurses + http, ...) should be ok.
+         */
+        // if (graphical_count)
+        // return true;
+      } else {
+        // failed, so remove from list
+        active_display_outputs.pop_back();
       }
     }
   }
   if (active_display_outputs.size()) return true;
 
   std::cerr << "Unable to find a usable display output." << std::endl;
-  return true;  // false;
+  return false;
 }
 
 bool shutdown_display_outputs() {
   bool ret = true;
-  for (auto output : active_display_outputs) ret = output->shutdown();
+  for (auto output : active_display_outputs) {
+    output->is_active = false;
+    ret = output->shutdown();
+  }
+  active_display_outputs.clear();
   return ret;
 }
 

--- a/src/display-output.cc
+++ b/src/display-output.cc
@@ -27,6 +27,7 @@
 #include <iostream>
 #include <sstream>
 #include <unordered_map>
+#include <vector>
 
 namespace conky {
 namespace {
@@ -46,9 +47,8 @@ display_outputs_t *display_outputs;
 
 /*
  * The selected and active display output.
- * XXX: do we want to support multiple outputs???
  */
-display_output_base *active_display_output = nullptr;
+std::vector<display_output_base *> active_display_outputs;
 
 namespace priv {
 void do_register_display_output(const std::string &name,
@@ -94,6 +94,7 @@ bool initialize_display_outputs() {
   sort(outputs.begin(), outputs.end(), &display_output_base::priority_compare);
 
   for (auto output : outputs) {
+    if (output->priority < 0) continue;
     std::cerr << "Testing display output '" << output->name << "'... "
               << std::endl;
     if (output->detect()) {
@@ -103,18 +104,20 @@ bool initialize_display_outputs() {
         std::cerr << "Initialized display output '" << output->name << "'... "
                   << std::endl;
         output->is_active = true;
-        active_display_output = output;
-        return true;
+        active_display_outputs.push_back(output);
       }
     }
   }
+  if (active_display_outputs.size()) return true;
+
   std::cerr << "Unable to find a usable display output." << std::endl;
   return true;  // false;
 }
 
 bool shutdown_display_outputs() {
-  if (active_display_output) { return active_display_output->shutdown(); }
-  return false;
+  bool ret = true;
+  for (auto output : active_display_outputs) ret = output->shutdown();
+  return ret;
 }
 
 }  // namespace conky

--- a/src/display-output.cc
+++ b/src/display-output.cc
@@ -6,7 +6,7 @@
  *
  * Copyright (C) 2018 François Revol et al.
  * Copyright (c) 2004, Hannu Saransaari and Lauri Hakkarainen
- * Copyright (c) 2005-2019 Brenden Matthews, Philip Kovacs, et. al.
+ * Copyright (c) 2005-2021 Brenden Matthews, Philip Kovacs, et. al.
  *	(see AUTHORS)
  * All rights reserved.
  *

--- a/src/display-output.hh
+++ b/src/display-output.hh
@@ -4,7 +4,7 @@
  *
  * Please see COPYING for details
  *
- * Copyright (C) 2010 Pavel Labath et al.
+ * Copyright (C) 2018 François Revol et al.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/display-output.hh
+++ b/src/display-output.hh
@@ -131,6 +131,12 @@ class display_output_base {
 extern std::vector<display_output_base *> active_display_outputs;
 
 /*
+ * the list of the only current output, when inside draw_text,
+ * else we iterate over each active outputs.
+ */
+extern std::vector<conky::display_output_base *> current_display_outputs;
+
+/*
  * Use this to declare a display output that has been disabled during
  * compilation. We can then print a nice error message telling the used which
  * setting to enable.
@@ -142,5 +148,30 @@ class disabled_display_output : public display_output_base {
 };
 
 }  // namespace conky
+
+// XXX: move to namespace?
+
+static inline std::vector<conky::display_output_base *> &display_outputs() {
+  if (conky::current_display_outputs.size())
+    return conky::current_display_outputs;
+  return conky::active_display_outputs;
+}
+
+static inline conky::display_output_base *display_output() {
+  if (conky::current_display_outputs.size())
+    return conky::current_display_outputs[0];
+  // XXX; not really what intended yet...
+  return conky::active_display_outputs[0];
+  // return nullptr;
+}
+
+static inline void unset_display_output() {
+  conky::current_display_outputs.clear();
+}
+
+static inline void set_display_output(conky::display_output_base *output) {
+  conky::current_display_outputs.clear();
+  conky::current_display_outputs.push_back(output);
+}
 
 #endif /* DISPLAY_OUTPUT_HH */

--- a/src/display-output.hh
+++ b/src/display-output.hh
@@ -78,52 +78,54 @@ class display_output_base {
   virtual bool graphical() { return is_graphical; };
   virtual bool draw_line_inner_required() { return is_graphical; }
 
-  virtual bool main_loop_wait(double t) { return false; }
+  virtual bool main_loop_wait(double /*t*/) { return false; }
 
   virtual void sigterm_cleanup() {}
   virtual void cleanup() {}
 
   // drawing primitives
-  virtual void set_foreground_color(long c) {}
+  virtual void set_foreground_color(long /*c*/) {}
 
   virtual int calc_text_width(const char *s) { return strlen(s); }
 
   virtual void begin_draw_text() {}
   virtual void end_draw_text() {}
-  virtual void draw_string(const char *s, int w) {}
+  virtual void draw_string(const char * /*s*/, int /*w*/) {}
   virtual void line_inner_done() {}
 
   // GUI interface
-  virtual void draw_string_at(int x, int y, const char *s, int w) {}
+  virtual void draw_string_at(int /*x*/, int /*y*/, const char * /*s*/,
+                              int /*w*/) {}
   // X11 lookalikes
-  virtual void set_line_style(int w, bool solid) {}
-  virtual void set_dashes(char *s) {}
-  virtual void draw_line(int x1, int y1, int x2, int y2) {}
-  virtual void draw_rect(int x, int y, int w, int h) {}
-  virtual void fill_rect(int x, int y, int w, int h) {}
-  virtual void draw_arc(int x, int y, int w, int h, int a1, int a2) {}
-  virtual void move_win(int x, int y) {}
+  virtual void set_line_style(int /*w*/, bool /*solid*/) {}
+  virtual void set_dashes(char * /*s*/) {}
+  virtual void draw_line(int /*x1*/, int /*y1*/, int /*x2*/, int /*y2*/) {}
+  virtual void draw_rect(int /*x*/, int /*y*/, int /*w*/, int /*h*/) {}
+  virtual void fill_rect(int /*x*/, int /*y*/, int /*w*/, int /*h*/) {}
+  virtual void draw_arc(int /*x*/, int /*y*/, int /*w*/, int /*h*/, int /*a1*/,
+                        int /*a2*/) {}
+  virtual void move_win(int /*x*/, int /*y*/) {}
   virtual int dpi_scale(int value) { return value; }
 
   virtual void begin_draw_stuff() {}
   virtual void end_draw_stuff() {}
-  virtual void clear_text(int exposures) {}
+  virtual void clear_text(int /*exposures*/) {}
 
   // font stuff
-  virtual int font_height(int) { return 0; }
-  virtual int font_ascent(int) { return 0; }
-  virtual int font_descent(int) { return 0; }
+  virtual int font_height(unsigned int) { return 0; }
+  virtual int font_ascent(unsigned int) { return 0; }
+  virtual int font_descent(unsigned int) { return 0; }
   virtual void setup_fonts(void) {}
-  virtual void set_font(int) {}
-  virtual void free_fonts(bool utf8) {}
-  virtual void load_fonts(bool utf8) {}
+  virtual void set_font(unsigned int) {}
+  virtual void free_fonts(bool /*utf8*/) {}
+  virtual void load_fonts(bool /*utf8*/) {}
 
   // tty interface
   virtual int getx() { return 0; }
   virtual int gety() { return 0; }
-  virtual void gotox(int x) {}
-  virtual void gotoy(int y) {}
-  virtual void gotoxy(int x, int y) {}
+  virtual void gotox(int /*x*/) {}
+  virtual void gotoy(int /*y*/) {}
+  virtual void gotoxy(int /*x*/, int /*y*/) {}
 
   virtual void flush() {}
 

--- a/src/display-output.hh
+++ b/src/display-output.hh
@@ -1,0 +1,95 @@
+/*
+ *
+ * Conky, a system monitor, based on torsmo
+ *
+ * Please see COPYING for details
+ *
+ * Copyright (C) 2010 Pavel Labath et al.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DISPLAY_OUTPUT_HH
+#define DISPLAY_OUTPUT_HH
+
+#include <limits>
+#include <string>
+#include <type_traits>
+
+#include "luamm.hh"
+
+namespace conky {
+
+bool initialize_display_outputs();
+
+bool shutdown_display_outputs();
+
+/*
+ * A base class for all display outputs.
+ * API consists of two functions:
+ * - get_number should return numeric representation of the data (if available).
+ * This can then be used when drawing graphs, bars, ... The default
+ * implementation returns NaN.
+ * - get_text should return textual representation of the data. This is used
+ * when simple displaying the value of the data source. The default
+ * implementation converts get_number() to a string, but you can override to
+ * return anything (e.g. add units)
+ */
+class display_output_base {
+ private:
+  // copying is a REALLY bad idea
+  display_output_base(const display_output_base &) = delete;
+  display_output_base &operator=(const display_output_base &) = delete;
+
+ public:
+  const std::string name;
+  bool is_active;
+  int priority;
+
+  explicit display_output_base(const std::string &name_);
+
+  virtual ~display_output_base() {}
+
+  static bool priority_compare(const display_output_base *a,
+                               const display_output_base *b) {
+    return a->priority > b->priority;
+  }
+
+  // check if available and enabled in settings
+  virtual bool detect() { return false; };
+  // connect to DISPLAY and other stuff
+  virtual bool initialize() { return false; };
+  virtual bool shutdown() { return false; };
+
+  friend bool conky::initialize_display_outputs();
+  friend bool conky::shutdown_display_outputs();
+
+ protected:
+  virtual bool active() { return is_active; };
+};
+
+/*
+ * Use this to declare a display output that has been disabled during
+ * compilation. We can then print a nice error message telling the used which
+ * setting to enable.
+ */
+class disabled_display_output : public display_output_base {
+ public:
+  const std::string define;
+  disabled_display_output(const std::string &name, const std::string &define);
+};
+
+}  // namespace conky
+
+#endif /* DISPLAY_OUTPUT_HH */

--- a/src/display-output.hh
+++ b/src/display-output.hh
@@ -55,6 +55,7 @@ class display_output_base {
  public:
   const std::string name;
   bool is_active;
+  bool is_graphical;
   int priority;
 
   explicit display_output_base(const std::string &name_);
@@ -82,6 +83,7 @@ class display_output_base {
 
  protected:
   virtual bool active() { return is_active; };
+  virtual bool graphical() { return is_graphical; };
 };
 
 /*

--- a/src/display-output.hh
+++ b/src/display-output.hh
@@ -108,6 +108,14 @@ class display_output_base {
   virtual void begin_draw_stuff() {}
   virtual void end_draw_stuff() {}
   virtual void clear_text(int exposures) {}
+
+  // font stuff
+  virtual int font_height(int) { return 0; }
+  virtual int font_ascent(int) { return 0; }
+  virtual int font_descent(int) { return 0; }
+  virtual void setup_fonts(void) {}
+  virtual void set_font(int) {}
+  virtual void free_fonts(bool utf8) {}
   virtual void load_fonts(bool utf8) {}
 
   // tty interface

--- a/src/display-output.hh
+++ b/src/display-output.hh
@@ -27,6 +27,7 @@
 #include <limits>
 #include <string>
 #include <type_traits>
+#include <vector>
 
 #include "luamm.hh"
 
@@ -102,10 +103,10 @@ class display_output_base {
   virtual void fill_rect(int x, int y, int w, int h) {}
   virtual void draw_arc(int x, int y, int w, int h, int a1, int a2) {}
   virtual void move_win(int x, int y) {}
+  virtual int dpi_scale(int value) { return value; }
 
   virtual void begin_draw_stuff() {}
   virtual void end_draw_stuff() {}
-  virtual void swap_buffers() {}
   virtual void clear_text(int exposures) {}
   virtual void load_fonts(bool utf8) {}
 

--- a/src/display-output.hh
+++ b/src/display-output.hh
@@ -72,12 +72,23 @@ class display_output_base {
   virtual bool initialize() { return false; };
   virtual bool shutdown() { return false; };
 
+  // drawing primitives
+  virtual bool begin_draw_text() { return false; };
+  virtual bool end_draw_text() { return false; };
+  virtual bool draw_string(const char *s, int w) { return false; };
+
   friend bool conky::initialize_display_outputs();
   friend bool conky::shutdown_display_outputs();
 
  protected:
   virtual bool active() { return is_active; };
 };
+
+/*
+ * The selected and active display output.
+ * XXX: do we want to support multiple outputs???
+ */
+extern display_output_base *active_display_output;
 
 /*
  * Use this to declare a display output that has been disabled during

--- a/src/display-output.hh
+++ b/src/display-output.hh
@@ -172,8 +172,9 @@ static inline conky::display_output_base *display_output() {
   if (conky::current_display_outputs.size())
     return conky::current_display_outputs[0];
   // XXX; not really what intended yet...
-  return conky::active_display_outputs[0];
-  // return nullptr;
+  if (conky::active_display_outputs.size())
+    return conky::active_display_outputs[0];
+  return nullptr;
 }
 
 static inline void unset_display_output() {

--- a/src/display-output.hh
+++ b/src/display-output.hh
@@ -23,6 +23,7 @@
 #ifndef DISPLAY_OUTPUT_HH
 #define DISPLAY_OUTPUT_HH
 
+#include <string.h>
 #include <limits>
 #include <string>
 #include <type_traits>
@@ -68,33 +69,60 @@ class display_output_base {
   }
 
   // check if available and enabled in settings
-  virtual bool detect() { return false; };
+  virtual bool detect() { return false; }
   // connect to DISPLAY and other stuff
-  virtual bool initialize() { return false; };
-  virtual bool shutdown() { return false; };
+  virtual bool initialize() { return false; }
+  virtual bool shutdown() { return false; }
+
+  virtual bool graphical() { return is_graphical; };
+  virtual bool draw_line_inner_required() { return is_graphical; }
+
+  virtual bool main_loop_wait(double t) { return false; }
+
+  virtual void sigterm_cleanup() {}
+  virtual void cleanup() {}
 
   // drawing primitives
-  virtual bool set_foreground_color(long c) { return false; }
+  virtual void set_foreground_color(long c) {}
 
-  virtual bool begin_draw_text() { return false; };
-  virtual bool end_draw_text() { return false; };
-  virtual bool draw_string(const char *s, int w) { return false; };
+  virtual int calc_text_width(const char *s) { return strlen(s); }
+
+  virtual void begin_draw_text() {}
+  virtual void end_draw_text() {}
+  virtual void draw_string(const char *s, int w) {}
   virtual void line_inner_done() {}
 
-  virtual int getx() { return 0; };
-  virtual int gety() { return 0; };
-  virtual bool gotox(int x) { return false; };
-  virtual bool gotoy(int y) { return false; };
-  virtual bool gotoxy(int x, int y) { return false; };
+  // GUI interface
+  virtual void draw_string_at(int x, int y, const char *s, int w) {}
+  // X11 lookalikes
+  virtual void set_line_style(int w, bool solid) {}
+  virtual void set_dashes(char *s) {}
+  virtual void draw_line(int x1, int y1, int x2, int y2) {}
+  virtual void draw_rect(int x, int y, int w, int h) {}
+  virtual void fill_rect(int x, int y, int w, int h) {}
+  virtual void draw_arc(int x, int y, int w, int h, int a1, int a2) {}
+  virtual void move_win(int x, int y) {}
 
-  virtual bool flush() { return false; };
+  virtual void begin_draw_stuff() {}
+  virtual void end_draw_stuff() {}
+  virtual void swap_buffers() {}
+  virtual void clear_text(int exposures) {}
+  virtual void load_fonts(bool utf8) {}
+
+  // tty interface
+  virtual int getx() { return 0; }
+  virtual int gety() { return 0; }
+  virtual void gotox(int x) {}
+  virtual void gotoy(int y) {}
+  virtual void gotoxy(int x, int y) {}
+
+  virtual void flush() {}
 
   friend bool conky::initialize_display_outputs();
   friend bool conky::shutdown_display_outputs();
 
  protected:
-  virtual bool active() { return is_active; };
-  virtual bool graphical() { return is_graphical; };
+  virtual bool active() { return is_active; }
 };
 
 /*

--- a/src/display-output.hh
+++ b/src/display-output.hh
@@ -85,10 +85,9 @@ class display_output_base {
 };
 
 /*
- * The selected and active display output.
- * XXX: do we want to support multiple outputs???
+ * The selected and active display outputs.
  */
-extern display_output_base *active_display_output;
+extern std::vector<display_output_base *> active_display_outputs;
 
 /*
  * Use this to declare a display output that has been disabled during

--- a/src/display-output.hh
+++ b/src/display-output.hh
@@ -74,9 +74,20 @@ class display_output_base {
   virtual bool shutdown() { return false; };
 
   // drawing primitives
+  virtual bool set_foreground_color(long c) { return false; }
+
   virtual bool begin_draw_text() { return false; };
   virtual bool end_draw_text() { return false; };
   virtual bool draw_string(const char *s, int w) { return false; };
+  virtual void line_inner_done() {}
+
+  virtual int getx() { return 0; };
+  virtual int gety() { return 0; };
+  virtual bool gotox(int x) { return false; };
+  virtual bool gotoy(int y) { return false; };
+  virtual bool gotoxy(int x, int y) { return false; };
+
+  virtual bool flush() { return false; };
 
   friend bool conky::initialize_display_outputs();
   friend bool conky::shutdown_display_outputs();

--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -4,7 +4,11 @@
  *
  * Please see COPYING for details
  *
- * Copyright (C) 2010 Pavel Labath et al.
+ * Copyright (C) 2018-2020 François Revol et al.
+ * Copyright (c) 2004, Hannu Saransaari and Lauri Hakkarainen
+ * Copyright (c) 2005-2020 Brenden Matthews, Philip Kovacs, et. al.
+ *	(see AUTHORS)
+ * All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -661,7 +661,9 @@ void display_output_x11::draw_arc(int x, int y, int w, int h, int a1, int a2) {
 }
 
 void display_output_x11::move_win(int x, int y) {
-  XMoveWindow(display, window.window, window.x, window.y);
+  window.x = x;
+  window.y = y;
+  XMoveWindow(display, window.window, x, y);
 }
 
 int display_output_x11::dpi_scale(int value) {
@@ -708,7 +710,7 @@ void display_output_x11::clear_text(int exposures) {
 
 #ifdef BUILD_XFT
 
-int display_output_x11::font_height(int f) {
+int display_output_x11::font_height(unsigned int f) {
   assert(f < x_fonts.size());
   if (use_xft.get(*state)) {
     return x_fonts[f].xftfont->ascent + x_fonts[f].xftfont->descent;
@@ -718,7 +720,7 @@ int display_output_x11::font_height(int f) {
   }
 }
 
-int display_output_x11::font_ascent(int f) {
+int display_output_x11::font_ascent(unsigned int f) {
   assert(f < x_fonts.size());
   if (use_xft.get(*state)) {
     return x_fonts[f].xftfont->ascent;
@@ -727,7 +729,7 @@ int display_output_x11::font_ascent(int f) {
   }
 }
 
-int display_output_x11::font_descent(int f) {
+int display_output_x11::font_descent(unsigned int f) {
   assert(f < x_fonts.size());
   if (use_xft.get(*state)) {
     return x_fonts[f].xftfont->descent;
@@ -738,18 +740,18 @@ int display_output_x11::font_descent(int f) {
 
 #else
 
-int display_output_x11::font_height(int f) {
+int display_output_x11::font_height(unsigned int f) {
   assert(f < x_fonts.size());
   return x_fonts[f].font->max_bounds.ascent +
          x_fonts[f].font->max_bounds.descent;
 }
 
-int display_output_x11::font_ascent(int f) {
+int display_output_x11::font_ascent(unsigned int f) {
   assert(f < x_fonts.size());
   return x_fonts[f].font->max_bounds.ascent;
 }
 
-int display_output_x11::font_descent(int f) {
+int display_output_x11::font_descent(unsigned int f) {
   assert(f < x_fonts.size());
   return x_fonts[f].font->max_bounds.descent;
 }
@@ -769,7 +771,8 @@ void display_output_x11::setup_fonts(void) {
 #endif /* BUILD_XFT */
 }
 
-void display_output_x11::set_font(int f) {
+void display_output_x11::set_font(unsigned int f) {
+  assert(f < x_fonts.size());
 #ifdef BUILD_XFT
   if (use_xft.get(*state)) { return; }
 #endif /* BUILD_XFT */
@@ -809,7 +812,7 @@ void display_output_x11::free_fonts(bool utf8) {
 }
 void display_output_x11::load_fonts(bool utf8) {
   x_fonts.resize(fonts.size());
-  for (int i = 0; i < fonts.size(); i++) {
+  for (unsigned int i = 0; i < fonts.size(); i++) {
     auto &font = fonts[i];
     auto &xfont = x_fonts[i];
 #ifdef BUILD_XFT

--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -193,6 +193,7 @@ conky::disabled_display_output x11_output_disabled("x11", "BUILD_X11");
 #endif
 
 }  // namespace
+extern void init_x11_output() {}
 
 namespace priv {}  // namespace priv
 

--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -205,8 +205,7 @@ display_output_x11::display_output_x11() : display_output_base("x11") {
 
 bool display_output_x11::detect() {
   if (out_to_x.get(*state)) {
-    std::cerr << "Display output '" << name << "' enabled in config."
-              << std::endl;
+    DBGP2("Display output '%s' enabled in config.", name.c_str());
     return true;
   }
   return false;

--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -26,11 +26,111 @@
 
 #include <config.h>
 
-#include "display-x11.hh"
+#ifdef BUILD_X11
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvariadic-macros"
+#include <X11/Xutil.h>
+#ifdef BUILD_XFT
+#include <X11/Xlib.h>
+#endif /* BUILD_XFT */
+#pragma GCC diagnostic pop
+#include "x11.h"
+#ifdef BUILD_XDAMAGE
+#include <X11/extensions/Xdamage.h>
+#endif
+#ifdef BUILD_IMLIB2
+#include "imlib2.h"
+#endif /* BUILD_IMLIB2 */
+#endif /* BUILD_X11 */
 
 #include <iostream>
 #include <sstream>
 #include <unordered_map>
+
+#include "conky.h"
+#include "display-x11.hh"
+#include "llua.h"
+#include "x11.h"
+#ifdef BUILD_X11
+#include "fonts.h"
+#endif
+
+/* TODO: cleanup global namespace */
+#ifdef BUILD_X11
+
+// TODO: cleanup externs (move to conky.h ?)
+#ifdef OWN_WINDOW
+extern int fixed_size, fixed_pos;
+#endif
+extern int text_start_x, text_start_y;   /* text start position in window */
+extern int text_offset_x, text_offset_y; /* offset for start position */
+extern int text_width,
+    text_height; /* initially 1 so no zero-sized window is created */
+extern double current_update_time, next_update_time, last_update_time;
+void update_text();
+extern int need_to_update;
+int get_border_total();
+extern conky::range_config_setting<int> maximum_width;
+extern long current_color;
+#ifdef BUILD_XFT
+static int xft_dpi = -1;
+#endif /* BUILD_XFT */
+
+static void X11_create_window();
+
+struct _x11_stuff_s {
+  Region region;
+#ifdef BUILD_XDAMAGE
+  Damage damage;
+  XserverRegion region2, part;
+  int event_base, error_base;
+#endif
+} x11_stuff;
+
+static void X11_create_window() {
+  setup_fonts();
+  load_fonts(utf8_mode.get(*state));
+#ifdef BUILD_XFT
+  if (use_xft.get(*state)) {
+    auto dpi = XGetDefault(display, "Xft", "dpi");
+    if (dpi) { xft_dpi = atoi(dpi); }
+  }
+#endif                /* BUILD_XFT */
+  update_text_area(); /* to position text/window on screen */
+
+#ifdef OWN_WINDOW
+  if (own_window.get(*state)) {
+    if (fixed_pos == 0) {
+      XMoveWindow(display, window.window, window.x, window.y);
+    }
+
+    set_transparent_background(window.window);
+  }
+#endif
+
+  create_gc();
+
+  draw_stuff();
+
+  x11_stuff.region = XCreateRegion();
+#ifdef BUILD_XDAMAGE
+  if (XDamageQueryExtension(display, &x11_stuff.event_base,
+                            &x11_stuff.error_base) == 0) {
+    NORM_ERR("Xdamage extension unavailable");
+    x11_stuff.damage = 0;
+  } else {
+    x11_stuff.damage =
+        XDamageCreate(display, window.window, XDamageReportNonEmpty);
+    x11_stuff.region2 = XFixesCreateRegionFromWindow(display, window.window, 0);
+    x11_stuff.part = XFixesCreateRegionFromWindow(display, window.window, 0);
+  }
+#endif /* BUILD_XDAMAGE */
+
+  selected_font = 0;
+  update_text_area(); /* to get initial size of the window */
+}
+
+#endif /* BUILD_X11 */
 
 namespace conky {
 namespace {
@@ -48,6 +148,7 @@ namespace priv {}  // namespace priv
 #ifdef BUILD_X11
 
 display_output_x11::display_output_x11() : display_output_base("x11") {
+  is_graphical = true;
   priority = 2;
 }
 
@@ -60,9 +161,502 @@ bool display_output_x11::detect() {
   return false;
 }
 
-bool display_output_x11::initialize() { return false; }
+bool display_output_x11::initialize() {
+  X11_create_window();
+  return true;
+}
 
 bool display_output_x11::shutdown() { return false; }
+
+bool display_output_x11::main_loop_wait(double t) {
+  /* wait for X event or timeout */
+
+  if (XPending(display) == 0) {
+    fd_set fdsr;
+    struct timeval tv {};
+    int s;
+    // t = next_update_time - get_time();
+
+    t = std::min(std::max(t, 0.0), active_update_interval());
+
+    tv.tv_sec = static_cast<long>(t);
+    tv.tv_usec = static_cast<long>(t * 1000000) % 1000000;
+    FD_ZERO(&fdsr);
+    FD_SET(ConnectionNumber(display), &fdsr);
+
+    s = select(ConnectionNumber(display) + 1, &fdsr, nullptr, nullptr, &tv);
+    if (s == -1) {
+      if (errno != EINTR) { NORM_ERR("can't select(): %s", strerror(errno)); }
+    } else {
+      /* timeout */
+      if (s == 0) { update_text(); }
+    }
+  }
+
+  if (need_to_update != 0) {
+#ifdef OWN_WINDOW
+    int wx = window.x, wy = window.y;
+#endif
+
+    need_to_update = 0;
+    selected_font = 0;
+    update_text_area();
+
+#ifdef OWN_WINDOW
+    if (own_window.get(*state)) {
+      int changed = 0;
+      int border_total = get_border_total();
+
+      /* resize window if it isn't right size */
+      if ((fixed_size == 0) &&
+          (text_width + 2 * border_total != window.width ||
+           text_height + 2 * border_total != window.height)) {
+        window.width = text_width + 2 * border_total;
+        window.height = text_height + 2 * border_total;
+        draw_stuff(); /* redraw everything in our newly sized window */
+        XResizeWindow(display, window.window, window.width,
+                      window.height); /* resize window */
+        set_transparent_background(window.window);
+#ifdef BUILD_XDBE
+        /* swap buffers */
+        xdbe_swap_buffers();
+#else
+        if (use_xpmdb.get(*state)) {
+          XFreePixmap(display, window.back_buffer);
+          window.back_buffer =
+              XCreatePixmap(display, window.window, window.width, window.height,
+                            DefaultDepth(display, screen));
+
+          if (window.back_buffer != None) {
+            window.drawable = window.back_buffer;
+          } else {
+            // this is probably reallllly bad
+            NORM_ERR("Failed to allocate back buffer");
+          }
+          XSetForeground(display, window.gc, 0);
+          XFillRectangle(display, window.drawable, window.gc, 0, 0,
+                         window.width, window.height);
+        }
+#endif
+
+        changed++;
+        /* update lua window globals */
+        llua_update_window_table(text_start_x, text_start_y, text_width,
+                                 text_height);
+      }
+
+      /* move window if it isn't in right position */
+      if ((fixed_pos == 0) && (window.x != wx || window.y != wy)) {
+        XMoveWindow(display, window.window, window.x, window.y);
+        changed++;
+      }
+
+      /* update struts */
+      if ((changed != 0) && own_window_type.get(*state) == TYPE_PANEL) {
+        int sidenum = -1;
+
+        DBGP("%s", _(PACKAGE_NAME ": defining struts\n"));
+        fflush(stderr);
+
+        switch (text_alignment.get(*state)) {
+          case TOP_LEFT:
+          case TOP_RIGHT:
+          case TOP_MIDDLE: {
+            sidenum = 2;
+            break;
+          }
+          case BOTTOM_LEFT:
+          case BOTTOM_RIGHT:
+          case BOTTOM_MIDDLE: {
+            sidenum = 3;
+            break;
+          }
+          case MIDDLE_LEFT: {
+            sidenum = 0;
+            break;
+          }
+          case MIDDLE_RIGHT: {
+            sidenum = 1;
+            break;
+          }
+
+          case NONE:
+          case MIDDLE_MIDDLE: /* XXX What about these? */;
+        }
+
+        set_struts(sidenum);
+      }
+    }
+#endif
+
+    clear_text(1);
+
+#if defined(BUILD_XDBE)
+    if (use_xdbe.get(*state)) {
+#else
+    if (use_xpmdb.get(*state)) {
+#endif
+      XRectangle r;
+      int border_total = get_border_total();
+
+      r.x = text_start_x - border_total;
+      r.y = text_start_y - border_total;
+      r.width = text_width + 2 * border_total;
+      r.height = text_height + 2 * border_total;
+      XUnionRectWithRegion(&r, x11_stuff.region, x11_stuff.region);
+    }
+  }
+
+  /* handle X events */
+  while (XPending(display) != 0) {
+    XEvent ev;
+
+    XNextEvent(display, &ev);
+    switch (ev.type) {
+      case Expose: {
+        XRectangle r;
+        r.x = ev.xexpose.x;
+        r.y = ev.xexpose.y;
+        r.width = ev.xexpose.width;
+        r.height = ev.xexpose.height;
+        XUnionRectWithRegion(&r, x11_stuff.region, x11_stuff.region);
+        XSync(display, False);
+        break;
+      }
+
+      case PropertyNotify: {
+        if (ev.xproperty.state == PropertyNewValue) {
+          get_x11_desktop_info(ev.xproperty.display, ev.xproperty.atom);
+        }
+#ifdef USE_ARGB
+        if (!have_argb_visual) {
+#endif
+          if (ev.xproperty.atom == ATOM(_XROOTPMAP_ID) ||
+              ev.xproperty.atom == ATOM(_XROOTMAP_ID)) {
+            if (forced_redraw.get(*state)) {
+              draw_stuff();
+              next_update_time = get_time();
+              need_to_update = 1;
+            }
+          }
+#ifdef USE_ARGB
+        }
+#endif
+        break;
+      }
+
+#ifdef OWN_WINDOW
+      case ReparentNotify:
+        /* make background transparent */
+        if (own_window.get(*state)) {
+          set_transparent_background(window.window);
+        }
+        break;
+
+      case ConfigureNotify:
+        if (own_window.get(*state)) {
+          /* if window size isn't what expected, set fixed size */
+          if (ev.xconfigure.width != window.width ||
+              ev.xconfigure.height != window.height) {
+            if (window.width != 0 && window.height != 0) { fixed_size = 1; }
+
+            /* clear old stuff before screwing up
+             * size and pos */
+            clear_text(1);
+
+            {
+              XWindowAttributes attrs;
+              if (XGetWindowAttributes(display, window.window, &attrs) != 0) {
+                window.width = attrs.width;
+                window.height = attrs.height;
+              }
+            }
+
+            int border_total = get_border_total();
+
+            text_width = window.width - 2 * border_total;
+            text_height = window.height - 2 * border_total;
+            int mw = this->dpi_scale(maximum_width.get(*state));
+            if (text_width > mw && mw > 0) { text_width = mw; }
+          }
+
+          /* if position isn't what expected, set fixed pos
+           * total_updates avoids setting fixed_pos when window
+           * is set to weird locations when started */
+          /* // this is broken
+          if (total_updates >= 2 && !fixed_pos
+              && (window.x != ev.xconfigure.x
+              || window.y != ev.xconfigure.y)
+              && (ev.xconfigure.x != 0
+              || ev.xconfigure.y != 0)) {
+            fixed_pos = 1;
+          } */
+        }
+        break;
+
+      case ButtonPress:
+        if (own_window.get(*state)) {
+          /* if an ordinary window with decorations */
+          if ((own_window_type.get(*state) == TYPE_NORMAL &&
+               !TEST_HINT(own_window_hints.get(*state), HINT_UNDECORATED)) ||
+              own_window_type.get(*state) == TYPE_DESKTOP) {
+            /* allow conky to hold input focus. */
+            break;
+          }
+          /* forward the click to the desktop window */
+          XUngrabPointer(display, ev.xbutton.time);
+          ev.xbutton.window = window.desktop;
+          ev.xbutton.x = ev.xbutton.x_root;
+          ev.xbutton.y = ev.xbutton.y_root;
+          XSendEvent(display, ev.xbutton.window, False, ButtonPressMask, &ev);
+          XSetInputFocus(display, ev.xbutton.window, RevertToParent,
+                         ev.xbutton.time);
+        }
+        break;
+
+      case ButtonRelease:
+        if (own_window.get(*state)) {
+          /* if an ordinary window with decorations */
+          if ((own_window_type.get(*state) == TYPE_NORMAL) &&
+              !TEST_HINT(own_window_hints.get(*state), HINT_UNDECORATED)) {
+            /* allow conky to hold input focus. */
+            break;
+          }
+          /* forward the release to the desktop window */
+          ev.xbutton.window = window.desktop;
+          ev.xbutton.x = ev.xbutton.x_root;
+          ev.xbutton.y = ev.xbutton.y_root;
+          XSendEvent(display, ev.xbutton.window, False, ButtonReleaseMask, &ev);
+        }
+        break;
+
+#endif
+
+      default:
+#ifdef BUILD_XDAMAGE
+        if (ev.type == x11_stuff.event_base + XDamageNotify) {
+          auto *dev = reinterpret_cast<XDamageNotifyEvent *>(&ev);
+
+          XFixesSetRegion(display, x11_stuff.part, &dev->area, 1);
+          XFixesUnionRegion(display, x11_stuff.region2, x11_stuff.region2,
+                            x11_stuff.part);
+        }
+#endif /* BUILD_XDAMAGE */
+        break;
+    }
+  }
+
+#ifdef BUILD_XDAMAGE
+  if (x11_stuff.damage) {
+    XDamageSubtract(display, x11_stuff.damage, x11_stuff.region2, None);
+    XFixesSetRegion(display, x11_stuff.region2, nullptr, 0);
+  }
+#endif /* BUILD_XDAMAGE */
+
+  /* XDBE doesn't seem to provide a way to clear the back buffer
+   * without interfering with the front buffer, other than passing
+   * XdbeBackground to XdbeSwapBuffers. That means that if we're
+   * using XDBE, we need to redraw the text even if it wasn't part of
+   * the exposed area. OTOH, if we're not going to call draw_stuff at
+   * all, then no swap happens and we can safely do nothing. */
+
+  if (XEmptyRegion(x11_stuff.region) == 0) {
+#if defined(BUILD_XDBE)
+    if (use_xdbe.get(*state)) {
+#else
+    if (use_xpmdb.get(*state)) {
+#endif
+      XRectangle r;
+      int border_total = get_border_total();
+
+      r.x = text_start_x - border_total;
+      r.y = text_start_y - border_total;
+      r.width = text_width + 2 * border_total;
+      r.height = text_height + 2 * border_total;
+      XUnionRectWithRegion(&r, x11_stuff.region, x11_stuff.region);
+    }
+    XSetRegion(display, window.gc, x11_stuff.region);
+#ifdef BUILD_XFT
+    if (use_xft.get(*state)) {
+      XftDrawSetClip(window.xftdraw, x11_stuff.region);
+    }
+#endif
+    draw_stuff();
+    XDestroyRegion(x11_stuff.region);
+    x11_stuff.region = XCreateRegion();
+  }
+
+  // handled
+  return true;
+}
+
+void display_output_x11::sigterm_cleanup() {
+  XDestroyRegion(x11_stuff.region);
+  x11_stuff.region = nullptr;
+#ifdef BUILD_XDAMAGE
+  if (x11_stuff.damage) {
+    XDamageDestroy(display, x11_stuff.damage);
+    XFixesDestroyRegion(display, x11_stuff.region2);
+    XFixesDestroyRegion(display, x11_stuff.part);
+  }
+#endif /* BUILD_XDAMAGE */
+}
+
+void display_output_x11::cleanup() {
+  if (window_created == 1) {
+    int border_total = get_border_total();
+
+    XClearArea(display, window.window, text_start_x - border_total,
+               text_start_y - border_total, text_width + 2 * border_total,
+               text_height + 2 * border_total, 0);
+  }
+  destroy_window();
+  free_fonts(utf8_mode.get(*state));
+  if (x11_stuff.region != nullptr) {
+    XDestroyRegion(x11_stuff.region);
+    x11_stuff.region = nullptr;
+  }
+}
+
+void display_output_x11::set_foreground_color(long c) {
+#ifdef BUILD_ARGB
+  if (have_argb_visual) {
+    current_color = c | (own_window_argb_value.get(*state) << 24);
+  } else {
+#endif /* BUILD_ARGB */
+    current_color = c;
+#ifdef BUILD_ARGB
+  }
+#endif /* BUILD_ARGB */
+  XSetForeground(display, window.gc, current_color);
+}
+
+int display_output_x11::calc_text_width(const char *s) {
+  size_t slen = strlen(s);
+#ifdef BUILD_XFT
+  if (use_xft.get(*state)) {
+    XGlyphInfo gi;
+
+    if (utf8_mode.get(*state)) {
+      XftTextExtentsUtf8(display, fonts[selected_font].xftfont,
+                         reinterpret_cast<const FcChar8 *>(s), slen, &gi);
+    } else {
+      XftTextExtents8(display, fonts[selected_font].xftfont,
+                      reinterpret_cast<const FcChar8 *>(s), slen, &gi);
+    }
+    return gi.xOff;
+  }
+#endif /* BUILD_XFT */
+
+  return XTextWidth(fonts[selected_font].font, s, slen);
+}
+
+void display_output_x11::draw_string_at(int x, int y, const char *s, int w) {
+#ifdef BUILD_XFT
+  if (use_xft.get(*state)) {
+    XColor c;
+    XftColor c2;
+
+    c.pixel = current_color;
+    // query color on custom colormap
+    XQueryColor(display, window.colourmap, &c);
+
+    c2.pixel = c.pixel;
+    c2.color.red = c.red;
+    c2.color.green = c.green;
+    c2.color.blue = c.blue;
+    c2.color.alpha = fonts[selected_font].font_alpha;
+    if (utf8_mode.get(*state)) {
+      XftDrawStringUtf8(window.xftdraw, &c2, fonts[selected_font].xftfont, x, y,
+                        reinterpret_cast<const XftChar8 *>(s), w);
+    } else {
+      XftDrawString8(window.xftdraw, &c2, fonts[selected_font].xftfont, x, y,
+                     reinterpret_cast<const XftChar8 *>(s), w);
+    }
+  } else
+#endif
+  {
+    if (utf8_mode.get(*state)) {
+      Xutf8DrawString(display, window.drawable, fonts[selected_font].fontset,
+                      window.gc, x, y, s, w);
+    } else {
+      XDrawString(display, window.drawable, window.gc, x, y, s, w);
+    }
+  }
+}
+
+void display_output_x11::set_line_style(int w, bool solid) {
+  XSetLineAttributes(display, window.gc, w, solid ? LineSolid : LineOnOffDash,
+                     CapButt, JoinMiter);
+}
+
+void display_output_x11::set_dashes(char *s) {
+  XSetDashes(display, window.gc, 0, s, 2);
+}
+
+void display_output_x11::draw_line(int x1, int y1, int x2, int y2) {
+  XDrawLine(display, window.drawable, window.gc, x1, y1, x2, y2);
+}
+
+void display_output_x11::draw_rect(int x, int y, int w, int h) {
+  XDrawRectangle(display, window.drawable, window.gc, x, y, w, h);
+}
+
+void display_output_x11::fill_rect(int x, int y, int w, int h) {
+  XFillRectangle(display, window.drawable, window.gc, x, y, w, h);
+}
+
+void display_output_x11::draw_arc(int x, int y, int w, int h, int a1, int a2) {
+  XDrawArc(display, window.drawable, window.gc, x, y, w, h, a1, a2);
+}
+
+void display_output_x11::move_win(int x, int y) {
+  XMoveWindow(display, window.window, window.x, window.y);
+}
+
+int display_output_x11::dpi_scale(int value) {
+#if defined(BUILD_XFT)
+  if (use_xft.get(*state) && xft_dpi > 0) {
+    return (value * xft_dpi + (value > 0 ? 48 : -48)) / 96;
+  } else {
+    return value;
+  }
+#else  /* defined(BUILD_XFT) */
+  return value;
+#endif /* defined(BUILD_XFT) */
+}
+
+void display_output_x11::end_draw_stuff() {
+#if defined(BUILD_XDBE)
+  xdbe_swap_buffers();
+#else
+  xpmdb_swap_buffers();
+#endif
+}
+
+void display_output_x11::clear_text(int exposures) {
+#ifdef BUILD_XDBE
+  if (use_xdbe.get(*state)) {
+    /* The swap action is XdbeBackground, which clears */
+    return;
+  }
+#else
+  if (use_xpmdb.get(*state)) {
+    return;
+  } else
+#endif
+  if ((display != nullptr) &&
+      (window.window != 0u)) {  // make sure these are !null
+    /* there is some extra space for borders and outlines */
+    int border_total = get_border_total();
+
+    XClearArea(display, window.window, text_start_x - border_total,
+               text_start_y - border_total, text_width + 2 * border_total,
+               text_height + 2 * border_total, exposures != 0 ? True : 0);
+  }
+}
+
+void display_output_x11::load_fonts(bool utf8) { ::load_fonts(utf8); }
 
 #endif /* BUILD_X11 */
 

--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -1,0 +1,65 @@
+/*
+ *
+ * Conky, a system monitor, based on torsmo
+ *
+ * Please see COPYING for details
+ *
+ * Copyright (C) 2010 Pavel Labath et al.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <config.h>
+
+#include "display-x11.hh"
+
+#include <iostream>
+#include <sstream>
+#include <unordered_map>
+
+namespace conky {
+namespace {
+
+#ifdef BUILD_X11
+conky::display_output_x11 x11_output;
+#else
+conky::disabled_display_output x11_output_disabled("x11", "BUILD_X11");
+#endif
+
+}  // namespace
+
+namespace priv {}  // namespace priv
+
+#ifdef BUILD_X11
+
+display_output_x11::display_output_x11() : display_output_base("x11") {
+  priority = 2;
+}
+
+bool display_output_x11::detect() {
+  if (out_to_x.get(*state)) {
+    std::cerr << "Display output '" << name << "' enabled in config."
+              << std::endl;
+    return true;
+  }
+  return false;
+}
+
+bool display_output_x11::initialize() { return false; }
+
+bool display_output_x11::shutdown() { return false; }
+
+#endif /* BUILD_X11 */
+
+}  // namespace conky

--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -4,9 +4,9 @@
  *
  * Please see COPYING for details
  *
- * Copyright (C) 2018-2020 François Revol et al.
+ * Copyright (C) 2018-2021 François Revol et al.
  * Copyright (c) 2004, Hannu Saransaari and Lauri Hakkarainen
- * Copyright (c) 2005-2020 Brenden Matthews, Philip Kovacs, et. al.
+ * Copyright (c) 2005-2021 Brenden Matthews, Philip Kovacs, et. al.
  *	(see AUTHORS)
  * All rights reserved.
  *

--- a/src/display-x11.hh
+++ b/src/display-x11.hh
@@ -4,7 +4,7 @@
  *
  * Please see COPYING for details
  *
- * Copyright (C) 2010 Pavel Labath et al.
+ * Copyright (C) 2018 François Revol et al.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/display-x11.hh
+++ b/src/display-x11.hh
@@ -71,6 +71,13 @@ class display_output_x11 : public display_output_base {
 
   virtual void end_draw_stuff();
   virtual void clear_text(int exposures);
+
+  virtual int font_height(int);
+  virtual int font_ascent(int);
+  virtual int font_descent(int);
+  virtual void setup_fonts(void);
+  virtual void set_font(int);
+  virtual void free_fonts(bool utf8);
   virtual void load_fonts(bool utf8);
 
   // X11-specific

--- a/src/display-x11.hh
+++ b/src/display-x11.hh
@@ -47,38 +47,38 @@ class display_output_x11 : public display_output_base {
   virtual bool initialize();
   virtual bool shutdown();
 
-  virtual bool main_loop_wait(double t);
+  virtual bool main_loop_wait(double);
 
   virtual void sigterm_cleanup();
   virtual void cleanup();
 
   // drawing primitives
-  virtual void set_foreground_color(long c);
+  virtual void set_foreground_color(long);
 
-  virtual int calc_text_width(const char *s);
+  virtual int calc_text_width(const char *);
 
   // GUI interface
-  virtual void draw_string_at(int x, int y, const char *s, int w);
+  virtual void draw_string_at(int, int, const char *, int);
   // X11 lookalikes
-  virtual void set_line_style(int w, bool solid);
-  virtual void set_dashes(char *s);
-  virtual void draw_line(int x1, int y1, int x2, int y2);
-  virtual void draw_rect(int x, int y, int w, int h);
-  virtual void fill_rect(int x, int y, int w, int h);
-  virtual void draw_arc(int x, int y, int w, int h, int a1, int a2);
-  virtual void move_win(int x, int y);
-  virtual int dpi_scale(int value);
+  virtual void set_line_style(int, bool);
+  virtual void set_dashes(char *);
+  virtual void draw_line(int, int, int, int);
+  virtual void draw_rect(int, int, int, int);
+  virtual void fill_rect(int, int, int, int);
+  virtual void draw_arc(int, int, int, int, int, int);
+  virtual void move_win(int, int);
+  virtual int dpi_scale(int);
 
   virtual void end_draw_stuff();
-  virtual void clear_text(int exposures);
+  virtual void clear_text(int);
 
-  virtual int font_height(int);
-  virtual int font_ascent(int);
-  virtual int font_descent(int);
+  virtual int font_height(unsigned int);
+  virtual int font_ascent(unsigned int);
+  virtual int font_descent(unsigned int);
   virtual void setup_fonts(void);
-  virtual void set_font(int);
-  virtual void free_fonts(bool utf8);
-  virtual void load_fonts(bool utf8);
+  virtual void set_font(unsigned int);
+  virtual void free_fonts(bool);
+  virtual void load_fonts(bool);
 
   // X11-specific
 };

--- a/src/display-x11.hh
+++ b/src/display-x11.hh
@@ -4,7 +4,7 @@
  *
  * Please see COPYING for details
  *
- * Copyright (C) 2018 François Revol et al.
+ * Copyright (C) 2018-2021 François Revol et al.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/display-x11.hh
+++ b/src/display-x11.hh
@@ -47,6 +47,32 @@ class display_output_x11 : public display_output_base {
   virtual bool initialize();
   virtual bool shutdown();
 
+  virtual bool main_loop_wait(double t);
+
+  virtual void sigterm_cleanup();
+  virtual void cleanup();
+
+  // drawing primitives
+  virtual void set_foreground_color(long c);
+
+  virtual int calc_text_width(const char *s);
+
+  // GUI interface
+  virtual void draw_string_at(int x, int y, const char *s, int w);
+  // X11 lookalikes
+  virtual void set_line_style(int w, bool solid);
+  virtual void set_dashes(char *s);
+  virtual void draw_line(int x1, int y1, int x2, int y2);
+  virtual void draw_rect(int x, int y, int w, int h);
+  virtual void fill_rect(int x, int y, int w, int h);
+  virtual void draw_arc(int x, int y, int w, int h, int a1, int a2);
+  virtual void move_win(int x, int y);
+  virtual int dpi_scale(int value);
+
+  virtual void end_draw_stuff();
+  virtual void clear_text(int exposures);
+  virtual void load_fonts(bool utf8);
+
   // X11-specific
 };
 

--- a/src/display-x11.hh
+++ b/src/display-x11.hh
@@ -1,0 +1,55 @@
+/*
+ *
+ * Conky, a system monitor, based on torsmo
+ *
+ * Please see COPYING for details
+ *
+ * Copyright (C) 2010 Pavel Labath et al.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DISPLAY_X11_HH
+#define DISPLAY_X11_HH
+
+#include <limits>
+#include <string>
+#include <type_traits>
+
+#include "display-output.hh"
+#include "luamm.hh"
+
+namespace conky {
+
+/*
+ * A base class for X11 display output.
+ */
+class display_output_x11 : public display_output_base {
+ public:
+  explicit display_output_x11();
+
+  virtual ~display_output_x11() {}
+
+  // check if available and enabled in settings
+  virtual bool detect();
+  // connect to DISPLAY and other stuff
+  virtual bool initialize();
+  virtual bool shutdown();
+
+  // X11-specific
+};
+
+}  // namespace conky
+
+#endif /* DISPLAY_X11_HH */

--- a/src/exec.cc
+++ b/src/exec.cc
@@ -270,7 +270,7 @@ void scan_exec_arg(struct text_object *obj, const char *arg,
   /* parse any special options for the graphical exec types */
   if ((execflag & EF_BAR) != 0u) {
     cmd = scan_bar(obj, cmd, 100);
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   } else if ((execflag & EF_GAUGE) != 0u) {
     cmd = scan_gauge(obj, cmd, 100);
   } else if ((execflag & EF_GRAPH) != 0u) {
@@ -278,7 +278,7 @@ void scan_exec_arg(struct text_object *obj, const char *arg,
     if (cmd == nullptr) {
       NORM_ERR("error parsing arguments to execgraph object");
     }
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
   }
 
   /* finally, store the resulting command, or an empty string if something went

--- a/src/fonts.h
+++ b/src/fonts.h
@@ -37,25 +37,8 @@
 /* for fonts */
 struct font_list {
   std::string name;
-  XFontStruct *font;
-  XFontSet fontset;
 
-#ifdef BUILD_XFT
-  XftFont *xftfont;
-  int font_alpha;
-#endif
-
-  font_list()
-      : name(),
-        font(nullptr),
-        fontset(nullptr)
-#ifdef BUILD_XFT
-        ,
-        xftfont(nullptr),
-        font_alpha(0xffff)
-#endif
-  {
-  }
+  font_list() : name() {}
 };
 
 /* direct access to registered fonts (FIXME: bad encapsulation) */

--- a/src/imlib2.cc
+++ b/src/imlib2.cc
@@ -133,19 +133,15 @@ void cimlib_add_image(const char *args) {
   if (tmp != nullptr) {
     tmp += 3;
     sscanf(tmp, "%i,%i", &cur->x, &cur->y);
-#ifdef BUILD_XFT
-    cur->x = xft_dpi_scale(cur->x);
-    cur->y = xft_dpi_scale(cur->y);
-#endif /* BUILD_XFT */
+    cur->x = dpi_scale(cur->x);
+    cur->y = dpi_scale(cur->y);
   }
   tmp = strstr(args, "-s ");
   if (tmp != nullptr) {
     tmp += 3;
     if (sscanf(tmp, "%ix%i", &cur->w, &cur->h) != 0) { cur->wh_set = 1; }
-#ifdef BUILD_XFT
-    cur->w = xft_dpi_scale(cur->w);
-    cur->h = xft_dpi_scale(cur->h);
-#endif /* BUILD_XFT */
+    cur->w = dpi_scale(cur->w);
+    cur->h = dpi_scale(cur->h);
   }
 
   tmp = strstr(args, "-n");
@@ -208,8 +204,8 @@ static void cimlib_draw_image(struct image_list_s *cur, int *clip_x,
   w = imlib_image_get_width();
   h = imlib_image_get_height();
   if (cur->wh_set == 0) {
-    cur->w = xft_dpi_scale(w);
-    cur->h = xft_dpi_scale(h);
+    cur->w = dpi_scale(w);
+    cur->h = dpi_scale(h);
   }
   imlib_context_set_image(buffer);
   imlib_blend_image_onto_image(image, 1, 0, 0, w, h, cur->x, cur->y, cur->w,

--- a/src/llua.cc
+++ b/src/llua.cc
@@ -92,7 +92,7 @@ conky::simple_config_setting<std::string> lua_startup_hook("lua_startup_hook",
 conky::simple_config_setting<std::string> lua_shutdown_hook("lua_shutdown_hook",
                                                             std::string(),
                                                             true);
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
 conky::simple_config_setting<std::string> lua_draw_hook_pre("lua_draw_hook_pre",
                                                             std::string(),
                                                             true);
@@ -464,7 +464,7 @@ void llua_shutdown_hook() {
   llua_do_call(lua_shutdown_hook.get(*state).c_str(), 0);
 }
 
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
 void llua_draw_pre_hook() {
   if ((lua_L == nullptr) || lua_draw_hook_pre.get(*state).empty()) { return; }
   llua_do_call(lua_draw_hook_pre.get(*state).c_str(), 0);
@@ -526,7 +526,7 @@ void llua_update_window_table(int text_start_x, int text_start_y,
 
   lua_setglobal(lua_L, "conky_window");
 }
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 
 void llua_setup_info(struct information *i, double u_interval) {
   if (lua_L == nullptr) { return; }

--- a/src/llua.h
+++ b/src/llua.h
@@ -46,7 +46,7 @@ void llua_inotify_query(int wd, int mask);
 void llua_startup_hook(void);
 void llua_shutdown_hook(void);
 
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
 void llua_draw_pre_hook(void);
 void llua_draw_post_hook(void);
 
@@ -54,7 +54,7 @@ void llua_setup_window_table(int text_start_x, int text_start_y, int text_width,
                              int text_height);
 void llua_update_window_table(int text_start_x, int text_start_y,
                               int text_width, int text_height);
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 
 void llua_setup_info(struct information *i, double u_interval);
 void llua_update_info(struct information *i, double u_interval);

--- a/src/main.cc
+++ b/src/main.cc
@@ -33,6 +33,7 @@
 #include "build.h"
 #include "config.h"
 #include "conky.h"
+#include "display-output.hh"
 #include "lua-config.hh"
 
 #ifdef BUILD_X11
@@ -367,6 +368,8 @@ int main(int argc, char **argv) {
     std::cerr << PACKAGE_NAME ": " << e.what() << std::endl;
     return EXIT_FAILURE;
   }
+
+  conky::shutdown_display_outputs();
 
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
   kvm_close(kd);

--- a/src/net_stat.cc
+++ b/src/net_stat.cc
@@ -319,7 +319,7 @@ void print_v6addrs(struct text_object *obj, char *p, unsigned int p_max_size) {
 
 #endif /* __linux__ */
 
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
 
 /**
  * This function is called periodically to update the download and upload graphs
@@ -370,7 +370,7 @@ double upspeedgraphval(struct text_object *obj) {
 
   return (ns != nullptr ? ns->trans_speed : 0);
 }
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 
 #ifdef BUILD_WLAN
 void print_wireless_essid(struct text_object *obj, char *p,

--- a/src/net_stat.h
+++ b/src/net_stat.h
@@ -102,11 +102,11 @@ void print_addrs(struct text_object *, char *, unsigned int);
 void print_v6addrs(struct text_object *, char *, unsigned int);
 #endif /* BUILD_IPV6 */
 #endif /* __linux__ */
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
 void parse_net_stat_graph_arg(struct text_object *, const char *, void *);
 double downspeedgraphval(struct text_object *);
 double upspeedgraphval(struct text_object *);
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 #ifdef BUILD_WLAN
 void print_wireless_essid(struct text_object *, char *, unsigned int);
 void print_wireless_channel(struct text_object *, char *, unsigned int);

--- a/src/scroll.cc
+++ b/src/scroll.cc
@@ -39,7 +39,7 @@
  * @param c first byte of the character
  */
 inline int scroll_character_length(char c) {
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   if (utf8_mode.get(*state)) {
     auto uc = static_cast<unsigned char>(c);
     int len = 0;
@@ -64,7 +64,7 @@ inline int scroll_character_length(char c) {
  * right.
  */
 inline bool scroll_check_skip_byte(char c) {
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   // Check if byte matches UTF-8 continuation byte pattern (0b10xxxxxx)
   if (utf8_mode.get(*state) && (c & 0xC0) == 0x80) { return true; }
 #endif
@@ -157,7 +157,7 @@ void parse_scroll_arg(struct text_object *obj, const char *arg,
 
   if ((arg == nullptr) || sscanf(arg + n1, "%u %n", &sd->show, &n2) <= 0) {
     free(sd);
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
     free(obj->next);
 #endif
     free(free_at_crash2);
@@ -199,9 +199,9 @@ void parse_scroll_arg(struct text_object *obj, const char *arg,
 
   obj->data.opaque = sd;
 
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   /* add a color object right after scroll to reset any color changes */
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 }
 
 void print_scroll(struct text_object *obj, char *p, unsigned int p_max_size) {
@@ -321,7 +321,7 @@ void print_scroll(struct text_object *obj, char *p, unsigned int p_max_size) {
     scroll_scroll_right(sd, buf, sd->step);
   }
 
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   // reset color when scroll is finished
   if (out_to_x.get(*state)) {
     new_special(p + strlen(p), FG)->arg = sd->resetcolor;

--- a/src/specials.cc
+++ b/src/specials.cc
@@ -396,8 +396,8 @@ void new_gauge_in_x11(struct text_object *obj, char *buf, double usage) {
   s = new_special(buf, GAUGE);
 
   s->arg = usage;
-  s->width = xft_dpi_scale(g->width);
-  s->height = xft_dpi_scale(g->height);
+  s->width = dpi_scale(g->width);
+  s->height = dpi_scale(g->height);
   s->scale = g->scale;
 }
 #endif /* BUILD_GUI */
@@ -551,7 +551,7 @@ void new_graph(struct text_object *obj, char *buf, int buf_max_size,
   s = new_special(buf, GRAPH);
 
   /* set graph (special) width to width in obj */
-  s->width = xft_dpi_scale(g->width);
+  s->width = dpi_scale(g->width);
   if (s->width != 0) { s->graph_width = s->width; }
 
   if (s->graph_width != s->graph_allocated) {
@@ -576,7 +576,7 @@ void new_graph(struct text_object *obj, char *buf, int buf_max_size,
     s->graph_allocated = s->graph_width;
     graphs[g->id] = graph;
   }
-  s->height = xft_dpi_scale(g->height);
+  s->height = dpi_scale(g->height);
   s->first_colour = adjust_colours(g->first_colour);
   s->last_colour = adjust_colours(g->last_colour);
   if (g->scale != 0) {
@@ -610,7 +610,7 @@ void new_hr(struct text_object *obj, char *p, unsigned int p_max_size) {
 
   if (p_max_size == 0) { return; }
 
-  new_special(p, HORIZONTAL_LINE)->height = xft_dpi_scale(obj->data.l);
+  new_special(p, HORIZONTAL_LINE)->height = dpi_scale(obj->data.l);
 }
 
 void scan_stippled_hr(struct text_object *obj, const char *arg) {
@@ -642,8 +642,8 @@ void new_stippled_hr(struct text_object *obj, char *p,
 
   s = new_special(p, STIPPLED_HR);
 
-  s->height = xft_dpi_scale(sh->height);
-  s->arg = xft_dpi_scale(sh->arg);
+  s->height = dpi_scale(sh->height);
+  s->arg = dpi_scale(sh->arg);
 }
 #endif /* BUILD_GUI */
 
@@ -704,8 +704,8 @@ static void new_bar_in_x11(struct text_object *obj, char *buf, double usage) {
   s = new_special(buf, BAR);
 
   s->arg = usage;
-  s->width = xft_dpi_scale(b->width);
-  s->height = xft_dpi_scale(b->height);
+  s->width = dpi_scale(b->width);
+  s->height = dpi_scale(b->height);
   s->scale = b->scale;
 }
 #endif /* BUILD_GUI */
@@ -740,12 +740,12 @@ void new_outline(struct text_object *obj, char *p, unsigned int p_max_size) {
 
 void new_offset(struct text_object *obj, char *p, unsigned int p_max_size) {
   if (p_max_size == 0) { return; }
-  new_special(p, OFFSET)->arg = xft_dpi_scale(obj->data.l);
+  new_special(p, OFFSET)->arg = dpi_scale(obj->data.l);
 }
 
 void new_voffset(struct text_object *obj, char *p, unsigned int p_max_size) {
   if (p_max_size == 0) { return; }
-  new_special(p, VOFFSET)->arg = xft_dpi_scale(obj->data.l);
+  new_special(p, VOFFSET)->arg = dpi_scale(obj->data.l);
 }
 
 void new_save_coordinates(struct text_object *obj, char *p,
@@ -756,18 +756,18 @@ void new_save_coordinates(struct text_object *obj, char *p,
 
 void new_alignr(struct text_object *obj, char *p, unsigned int p_max_size) {
   if (p_max_size == 0) { return; }
-  new_special(p, ALIGNR)->arg = xft_dpi_scale(obj->data.l);
+  new_special(p, ALIGNR)->arg = dpi_scale(obj->data.l);
 }
 
 // A positive offset pushes the text further left
 void new_alignc(struct text_object *obj, char *p, unsigned int p_max_size) {
   if (p_max_size == 0) { return; }
-  new_special(p, ALIGNC)->arg = xft_dpi_scale(obj->data.l);
+  new_special(p, ALIGNC)->arg = dpi_scale(obj->data.l);
 }
 
 void new_goto(struct text_object *obj, char *p, unsigned int p_max_size) {
   if (p_max_size == 0) { return; }
-  new_special(p, GOTO)->arg = xft_dpi_scale(obj->data.l);
+  new_special(p, GOTO)->arg = dpi_scale(obj->data.l);
 }
 
 void scan_tab(struct text_object *obj, const char *arg) {
@@ -795,8 +795,8 @@ void new_tab(struct text_object *obj, char *p, unsigned int p_max_size) {
   if ((t == nullptr) || (p_max_size == 0)) { return; }
 
   s = new_special(p, TAB);
-  s->width = xft_dpi_scale(t->width);
-  s->arg = xft_dpi_scale(t->arg);
+  s->width = dpi_scale(t->width);
+  s->arg = dpi_scale(t->arg);
 }
 
 void clear_stored_graphs() {

--- a/src/specials.cc
+++ b/src/specials.cc
@@ -27,9 +27,9 @@
  *
  */
 #include "conky.h"
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
 #include "fonts.h"
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 #include <cmath>
 #include "logging.h"
 #include "nc.h"
@@ -57,7 +57,7 @@ conky::range_config_setting<int> default_bar_width(
 conky::range_config_setting<int> default_bar_height(
     "default_bar_height", 0, std::numeric_limits<int>::max(), 6, false);
 
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
 conky::range_config_setting<int> default_graph_width(
     "default_graph_width", 0, std::numeric_limits<int>::max(), 0, false);
 conky::range_config_setting<int> default_graph_height(
@@ -67,7 +67,7 @@ conky::range_config_setting<int> default_gauge_width(
     "default_gauge_width", 0, std::numeric_limits<int>::max(), 40, false);
 conky::range_config_setting<int> default_gauge_height(
     "default_gauge_height", 0, std::numeric_limits<int>::max(), 25, false);
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 
 conky::simple_config_setting<std::string> console_graph_ticks(
     "console_graph_ticks", " ,_,=,#", false);
@@ -114,7 +114,7 @@ struct tab {
  * Scanning arguments to various special text objects
  */
 
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
 const char *scan_gauge(struct text_object *obj, const char *args,
                        double scale) {
   struct gauge *g;
@@ -179,7 +179,7 @@ const char *scan_bar(struct text_object *obj, const char *args, double scale) {
   return args;
 }
 
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
 void scan_font(struct text_object *obj, const char *args) {
   if ((args != nullptr) && (*args != 0)) {
     obj->data.s = strndup(args, DEFAULT_TEXT_BUFFER_SIZE);
@@ -337,7 +337,7 @@ char *scan_graph(struct text_object *obj, const char *args, double defscale) {
 
   return nullptr;
 }
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 
 /*
  * Printing various special text objects
@@ -384,7 +384,7 @@ void new_gauge_in_shell(struct text_object *obj, char *p,
            gaugevals[round_to_positive_int(usage * 4 / g->scale)]);
 }
 
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
 void new_gauge_in_x11(struct text_object *obj, char *buf, double usage) {
   struct special_t *s = nullptr;
   auto *g = static_cast<struct gauge *>(obj->special_data);
@@ -400,7 +400,7 @@ void new_gauge_in_x11(struct text_object *obj, char *buf, double usage) {
   s->height = xft_dpi_scale(g->height);
   s->scale = g->scale;
 }
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 
 void new_gauge(struct text_object *obj, char *p, unsigned int p_max_size,
                double usage) {
@@ -414,17 +414,17 @@ void new_gauge(struct text_object *obj, char *p, unsigned int p_max_size,
     usage = std::min(g->scale, usage);
   }
 
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   if (out_to_x.get(*state)) { new_gauge_in_x11(obj, p, usage); }
   if (out_to_stdout.get(*state)) {
     new_gauge_in_shell(obj, p, p_max_size, usage);
   }
-#else  /* BUILD_X11 */
+#else /* BUILD_GUI */
   new_gauge_in_shell(obj, p, p_max_size, usage);
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 }
 
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
 void new_font(struct text_object *obj, char *p, unsigned int p_max_size) {
   struct special_t *s;
   unsigned int tmp = selected_font;
@@ -645,12 +645,12 @@ void new_stippled_hr(struct text_object *obj, char *p,
   s->height = xft_dpi_scale(sh->height);
   s->arg = xft_dpi_scale(sh->arg);
 }
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 
 void new_fg(struct text_object *obj, char *p, unsigned int p_max_size) {
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   if (out_to_x.get(*state)) { new_special(p, FG)->arg = obj->data.l; }
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 #ifdef BUILD_NCURSES
   if (out_to_ncurses.get(*state)) { new_special(p, FG)->arg = obj->data.l; }
 #endif /* BUILD_NCURSES */
@@ -659,7 +659,7 @@ void new_fg(struct text_object *obj, char *p, unsigned int p_max_size) {
   UNUSED(p_max_size);
 }
 
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
 void new_bg(struct text_object *obj, char *p, unsigned int p_max_size) {
   if (!out_to_x.get(*state)) { return; }
 
@@ -667,7 +667,7 @@ void new_bg(struct text_object *obj, char *p, unsigned int p_max_size) {
 
   new_special(p, BG)->arg = obj->data.l;
 }
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 
 static void new_bar_in_shell(struct text_object *obj, char *buffer,
                              unsigned int buf_max_size, double usage) {
@@ -692,7 +692,7 @@ static void new_bar_in_shell(struct text_object *obj, char *buffer,
   buffer[i] = 0;
 }
 
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
 static void new_bar_in_x11(struct text_object *obj, char *buf, double usage) {
   struct special_t *s = nullptr;
   auto *b = static_cast<struct bar *>(obj->special_data);
@@ -708,7 +708,7 @@ static void new_bar_in_x11(struct text_object *obj, char *buf, double usage) {
   s->height = xft_dpi_scale(b->height);
   s->scale = b->scale;
 }
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 
 /* usage is in range [0,255] */
 void new_bar(struct text_object *obj, char *p, unsigned int p_max_size,
@@ -723,14 +723,14 @@ void new_bar(struct text_object *obj, char *p, unsigned int p_max_size,
     usage = std::min(b->scale, usage);
   }
 
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
   if (out_to_x.get(*state)) { new_bar_in_x11(obj, p, usage); }
   if (out_to_stdout.get(*state)) {
     new_bar_in_shell(obj, p, p_max_size, usage);
   }
-#else  /* BUILD_X11 */
+#else /* BUILD_GUI */
   new_bar_in_shell(obj, p, p_max_size, usage);
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 }
 
 void new_outline(struct text_object *obj, char *p, unsigned int p_max_size) {

--- a/src/specials.h
+++ b/src/specials.h
@@ -87,7 +87,7 @@ struct text_object;
 /* scanning special arguments */
 const char *scan_bar(struct text_object *, const char *, double);
 const char *scan_gauge(struct text_object *, const char *, double);
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
 void scan_font(struct text_object *, const char *);
 char *scan_graph(struct text_object *, const char *, double);
 void scan_tab(struct text_object *, const char *);
@@ -98,7 +98,7 @@ void new_font(struct text_object *, char *, unsigned int);
 void new_graph(struct text_object *, char *, int, double);
 void new_hr(struct text_object *, char *, unsigned int);
 void new_stippled_hr(struct text_object *, char *, unsigned int);
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 void new_gauge(struct text_object *, char *, unsigned int, double);
 void new_bar(struct text_object *, char *, unsigned int, double);
 void new_fg(struct text_object *, char *, unsigned int);


### PR DESCRIPTION
This is my first attempt at trying to sort out the X11-specific code from the rest, and allow implementing other display backends, to help with Haiku port, Wayland (#56), or Metal (OSX)…

It's mostly working but not really finished. The last commit kept the original code around with changed ifdefs for easier comparison until it's done, and I'll keep amending it for now.

I'm not used much to templating in C++ so maybe the classes look a bit naive, but I believe it's a reasonable implementation (maybe using templates would avoid RTTI and speed things up, I don't know, but I'm not confident enough to try it).
I'm not used to non CamelCase class names, but oh well.

I'm open to comments and suggestions.

Some details:
- the `BUILD_GUI` define is declared when either `BUILD_X11` or any later added GUI backend is enabled.
- Each backend has a priority (0 for text ones, 1 for ncurses, 2 for graphical ones), and they are sorted to try the more interesting ones first (hmm, maybe I should just use a sorted vector right away?).
- The display accessors added to `conky.cc` are a bit uncertain. First I wanted to just loop over each of the displays, but then part of the code actually assume graphical output, or not. So it's still a mixture of `for` loop on `current_display_outputs` and calls to `display_output()`. In `draw_stuff()` I call `[un]set_display_output()` to make sure the display we're drawing to is the graphical one. Although in theory it's the highest priority, so the first on the list, so always the "current" one. So this part can probably be simplified.
- I'm not entirely sure how to handle settings reloading, currently it breaks. I noticed the X11 window is actually created in the settings class, and not really closed between reloads. I'll have to think about this. On platforms where we would support more than one GUI displays (like, X11, SDL, Wayland…) having two enabled in the settings would cause trouble as even though only the first found would be `initialize()d`, the other one would still have the settings on and so the window created…
- In theory we could display to many outputs at once, but I believe some parts of the code just isn't designed for this. For multiple text outputs it's ok, not for others. For example X11+ncurses didn't work already. Is it desirable? I don't think it's worth it.
- the interface mimics the few X11 calls that are used in the drawing code, I believe they shouldn't be too hard to implement on other platforms (except maybe the stipple patterns on Haiku but well).
- I believe most of the X11 settings are perfectly valid for other GUIs, except maybe -w.
- I added messages about backends disabled at compile-time, but they are probably useless (and X11 on Haiku wouldn't make much sense anyway). Probably I should use the logging interface instead of cerr?
- the lua scripting interface is concerning: it exposes X11 stuff for no particular reason, I believe it should rather provide a GUI-agnostic `cairo_surface_create()` call. Else it means having to fix all scripts for other platforms. We'll likely have to provide fake calls on other platforms to mimic the X11 API for compatibility anyway.
- ~~I think most backend methods should just return void actually, the bool is useless.~~ DONE
- I noticed I used the American "initialize" instead of British, easy to change.
- the `fonts.clear()` call when not using X11 is a bit weird, and not easy to do properly from a backend that's not been initialised. Why initialize fonts if we won't use them…