### PR TITLE
Fix goto in ncurses mode when compiled without BUILD_X11

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1749,6 +1749,7 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
             if (draw_mode == BG) { cur_x++; }
 #endif /* BUILD_X11 */
 #ifdef BUILD_NCURSES
+            cur_x = static_cast<int>(current->arg);
             if (out_to_ncurses.get(*state)) {
               int x, y;
               getyx(ncurses_window, y, x);


### PR DESCRIPTION
The ncurses version of `${goto x}` does not work when compiled without BUILD_X11, because `cur_x` is set in the `#ifdef BUILD_X11` block. A simple fix is to set `cur_x` in the `#ifdef BUILD_NCURSES` block as well.