### PR TITLE
Add config option to disable blending

### DIFF
--- a/doc/config_settings.xml
+++ b/doc/config_settings.xml
@@ -918,6 +918,18 @@
     <varlistentry>
         <term>
             <command>
+                <option>render_draw_blended</option>
+            </command>
+        </term>
+        <listitem>Boolean, blend when rendering drawn image?
+        Some images blend incorrectly breaking alpha with ARBG visuals. This
+        provides a possible work around by disabling blending. Defaults to
+        true.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
                 <option>short_units</option>
             </command>
         </term>
@@ -950,18 +962,6 @@
             </command>
         </term>
         <listitem>Border stippling (dashing) in pixels
-        <para /></listitem>
-    </varlistentry>
-    <varlistentry>
-        <term>
-            <command>
-                <option>render_draw_blended</option>
-            </command>
-        </term>
-        <listitem>Boolean, blend when rendering drawn image?
-        Some images blend incorrectly breaking alpha with ARBG visuals. This
-        provides a possible work around by disabling blending. Defaults to
-        true.
         <para /></listitem>
     </varlistentry>
     <varlistentry>

--- a/doc/config_settings.xml
+++ b/doc/config_settings.xml
@@ -257,6 +257,18 @@
     <varlistentry>
         <term>
             <command>
+                <option>draw_blended</option>
+            </command>
+        </term>
+        <listitem>Boolean, blend when rendering drawn image?
+        Some images blend incorrectly breaking alpha with ARBG visuals. This
+        provides a possible work around by disabling blending. Defaults to
+        true.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
                 <option>draw_borders</option>
             </command>
         </term>
@@ -913,18 +925,6 @@
         minutes, and default number of retries before giving up is
         5. If the password is supplied as '*', you will be prompted
         to enter the password when Conky starts.
-        <para /></listitem>
-    </varlistentry>
-    <varlistentry>
-        <term>
-            <command>
-                <option>render_draw_blended</option>
-            </command>
-        </term>
-        <listitem>Boolean, blend when rendering drawn image?
-        Some images blend incorrectly breaking alpha with ARBG visuals. This
-        provides a possible work around by disabling blending. Defaults to
-        true.
         <para /></listitem>
     </varlistentry>
     <varlistentry>

--- a/doc/config_settings.xml
+++ b/doc/config_settings.xml
@@ -955,6 +955,18 @@
     <varlistentry>
         <term>
             <command>
+                <option>render_draw_blended</option>
+            </command>
+        </term>
+        <listitem>Boolean, blend when rendering drawn image?
+        Some images blend incorrectly breaking alpha with ARBG visuals. This
+        provides a possible work around by disabling blending. Defaults to
+        true.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
                 <option>temperature_unit</option>
             </command>
         </term>

--- a/src/imlib2.cc
+++ b/src/imlib2.cc
@@ -115,7 +115,7 @@ void cimlib_add_image(const char *args) {
   struct image_list_s *cur = nullptr;
   const char *tmp;
 
-  cur = static_cast<struct image_list_s *>(malloc(sizeof(struct image_list_s)));
+  cur = new struct image_list_s[sizeof(struct image_list_s)];
   memset(cur, 0, sizeof(struct image_list_s));
 
   if (sscanf(args, "%1023s", cur->name) == 0) {

--- a/src/imlib2.cc
+++ b/src/imlib2.cc
@@ -123,7 +123,7 @@ void cimlib_add_image(const char *args) {
         "Invalid args for $image.  Format is: '<path to image> (-p"
         "x,y) (-s WxH) (-n) (-f interval)' (got '%s')",
         args);
-    free(cur);
+    delete [] cur;
     return;
   }
   strncpy(cur->name, to_real_path(cur->name).c_str(), 1024);

--- a/src/imlib2.cc
+++ b/src/imlib2.cc
@@ -61,6 +61,9 @@ conky::range_config_setting<unsigned int> imlib_cache_flush_interval(
     0, true);
 
 unsigned int cimlib_cache_flush_last = 0;
+
+conky::simple_config_setting<bool> render_draw_blended(
+    "render_draw_blended", true, true);
 }  // namespace
 
 void imlib_cache_size_setting::lua_setter(lua::state &l, bool init) {
@@ -259,8 +262,15 @@ void cimlib_render(int x, int y, int width, int height) {
   /* clear our buffer */
   imlib_context_set_image(buffer);
   imlib_image_clear();
-  /* we can blend stuff now */
-  imlib_context_set_blend(1);
+
+  /* check if we should blend when rendering */
+  if (render_draw_blended.get(*state)) {
+    /* we can blend stuff now */
+    imlib_context_set_blend(1);
+  } else {
+    imlib_context_set_blend(0);
+  }
+
   /* turn alpha channel on */
   imlib_image_set_has_alpha(1);
 

--- a/src/imlib2.cc
+++ b/src/imlib2.cc
@@ -62,8 +62,8 @@ conky::range_config_setting<unsigned int> imlib_cache_flush_interval(
 
 unsigned int cimlib_cache_flush_last = 0;
 
-conky::simple_config_setting<bool> render_draw_blended(
-    "render_draw_blended", true, true);
+conky::simple_config_setting<bool> draw_blended(
+    "draw_blended", true, true);
 }  // namespace
 
 void imlib_cache_size_setting::lua_setter(lua::state &l, bool init) {
@@ -264,7 +264,7 @@ void cimlib_render(int x, int y, int width, int height) {
   imlib_image_clear();
 
   /* check if we should blend when rendering */
-  if (render_draw_blended.get(*state)) {
+  if (draw_blended.get(*state)) {
     /* we can blend stuff now */
     imlib_context_set_blend(1);
   } else {


### PR DESCRIPTION
This is intended to work around issues with some images blending incorrectly with ARGB visuals.

This is a follow up for #84 , intended as a work around for #51 and #123 .

I've tried to find a fix that works for all images, but haven't been able to. For example, this image with blending disabled on ARGB ends up with a white background instead of alpha:
![tango-arch](https://user-images.githubusercontent.com/403277/48979593-8064a500-f08b-11e8-95c2-2b97efae4b86.png)

While this image ends up being invisible entirely unless blending is disabled:
![lsd-black](https://user-images.githubusercontent.com/403277/48979594-8490c280-f08b-11e8-832f-490aa512fb05.png)

I ended up adding a config option so that themes can choose whether or not to blend based on their image as a way of working around this issue. I've named the config option `render_draw_blended` and it defaults to `true` to maintain how rendering is done now by default. Setting it to `false` fixes the issue with the second image above.

I'd like to hear from other users who have run into this bug on whether this helps them work around the problem, whether it helps with recent Gnome versions, and I'm open to feedback on the name of the config value and whether it should be tied to ARGB or not (it currently isn't).
