### PR TITLE
Include draw_blended in convert.lua

### DIFF
--- a/doc/config_settings.xml
+++ b/doc/config_settings.xml
@@ -918,6 +918,18 @@
     <varlistentry>
         <term>
             <command>
+                <option>render_draw_blended</option>
+            </command>
+        </term>
+        <listitem>Boolean, blend when rendering drawn image?
+        Some images blend incorrectly breaking alpha with ARBG visuals. This
+        provides a possible work around by disabling blending. Defaults to
+        true.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
                 <option>short_units</option>
             </command>
         </term>
@@ -950,18 +962,6 @@
             </command>
         </term>
         <listitem>Border stippling (dashing) in pixels
-        <para /></listitem>
-    </varlistentry>
-    <varlistentry>
-        <term>
-            <command>
-                <option>render_draw_blended</option>
-            </command>
-        </term>
-        <listitem>Boolean, blend when rendering drawn image?
-        Some images blend incorrectly breaking alpha with ARBG visuals. This
-        provides a possible work around by disabling blending. Defaults to
-        true.
         <para /></listitem>
     </varlistentry>
     <varlistentry>

--- a/doc/config_settings.xml
+++ b/doc/config_settings.xml
@@ -257,6 +257,18 @@
     <varlistentry>
         <term>
             <command>
+                <option>draw_blended</option>
+            </command>
+        </term>
+        <listitem>Boolean, blend when rendering drawn image?
+        Some images blend incorrectly breaking alpha with ARBG visuals. This
+        provides a possible work around by disabling blending. Defaults to
+        true.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
                 <option>draw_borders</option>
             </command>
         </term>
@@ -913,18 +925,6 @@
         minutes, and default number of retries before giving up is
         5. If the password is supplied as '*', you will be prompted
         to enter the password when Conky starts.
-        <para /></listitem>
-    </varlistentry>
-    <varlistentry>
-        <term>
-            <command>
-                <option>render_draw_blended</option>
-            </command>
-        </term>
-        <listitem>Boolean, blend when rendering drawn image?
-        Some images blend incorrectly breaking alpha with ARBG visuals. This
-        provides a possible work around by disabling blending. Defaults to
-        true.
         <para /></listitem>
     </varlistentry>
     <varlistentry>

--- a/doc/config_settings.xml
+++ b/doc/config_settings.xml
@@ -955,6 +955,18 @@
     <varlistentry>
         <term>
             <command>
+                <option>render_draw_blended</option>
+            </command>
+        </term>
+        <listitem>Boolean, blend when rendering drawn image?
+        Some images blend incorrectly breaking alpha with ARBG visuals. This
+        provides a possible work around by disabling blending. Defaults to
+        true.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
                 <option>temperature_unit</option>
             </command>
         </term>

--- a/extras/convert.lua
+++ b/extras/convert.lua
@@ -39,7 +39,8 @@ local bool_setting = {
     out_to_ncurses = true, out_to_stderr = true, out_to_x = true, override_utf8_locale = true,
     own_window = true, own_window_argb_visual = true, own_window_transparent = true,
     short_units = true, show_graph_range = true, show_graph_scale = true,
-    times_in_seconds = true, top_cpu_separate = true, uppercase = true, use_xft = true
+    times_in_seconds = true, top_cpu_separate = true, uppercase = true, use_xft = true,
+    draw_blended = true
 };
 
 local num_setting = {

--- a/src/imlib2.cc
+++ b/src/imlib2.cc
@@ -115,7 +115,7 @@ void cimlib_add_image(const char *args) {
   struct image_list_s *cur = nullptr;
   const char *tmp;
 
-  cur = static_cast<struct image_list_s *>(malloc(sizeof(struct image_list_s)));
+  cur = new struct image_list_s[sizeof(struct image_list_s)];
   memset(cur, 0, sizeof(struct image_list_s));
 
   if (sscanf(args, "%1023s", cur->name) == 0) {

--- a/src/imlib2.cc
+++ b/src/imlib2.cc
@@ -123,7 +123,7 @@ void cimlib_add_image(const char *args) {
         "Invalid args for $image.  Format is: '<path to image> (-p"
         "x,y) (-s WxH) (-n) (-f interval)' (got '%s')",
         args);
-    free(cur);
+    delete [] cur;
     return;
   }
   strncpy(cur->name, to_real_path(cur->name).c_str(), 1024);

--- a/src/imlib2.cc
+++ b/src/imlib2.cc
@@ -61,6 +61,9 @@ conky::range_config_setting<unsigned int> imlib_cache_flush_interval(
     0, true);
 
 unsigned int cimlib_cache_flush_last = 0;
+
+conky::simple_config_setting<bool> render_draw_blended(
+    "render_draw_blended", true, true);
 }  // namespace
 
 void imlib_cache_size_setting::lua_setter(lua::state &l, bool init) {
@@ -259,8 +262,15 @@ void cimlib_render(int x, int y, int width, int height) {
   /* clear our buffer */
   imlib_context_set_image(buffer);
   imlib_image_clear();
-  /* we can blend stuff now */
-  imlib_context_set_blend(1);
+
+  /* check if we should blend when rendering */
+  if (render_draw_blended.get(*state)) {
+    /* we can blend stuff now */
+    imlib_context_set_blend(1);
+  } else {
+    imlib_context_set_blend(0);
+  }
+
   /* turn alpha channel on */
   imlib_image_set_has_alpha(1);
 

--- a/src/imlib2.cc
+++ b/src/imlib2.cc
@@ -62,8 +62,8 @@ conky::range_config_setting<unsigned int> imlib_cache_flush_interval(
 
 unsigned int cimlib_cache_flush_last = 0;
 
-conky::simple_config_setting<bool> render_draw_blended(
-    "render_draw_blended", true, true);
+conky::simple_config_setting<bool> draw_blended(
+    "draw_blended", true, true);
 }  // namespace
 
 void imlib_cache_size_setting::lua_setter(lua::state &l, bool init) {
@@ -264,7 +264,7 @@ void cimlib_render(int x, int y, int width, int height) {
   imlib_image_clear();
 
   /* check if we should blend when rendering */
-  if (render_draw_blended.get(*state)) {
+  if (draw_blended.get(*state)) {
     /* we can blend stuff now */
     imlib_context_set_blend(1);
   } else {


### PR DESCRIPTION
A followup to #682 , the new `draw_blended` configuration option needs to be included in `extras/convert.lua` in order for it to be converted to boolean correctly.

Without this change, if `draw_blended` is including in an old-style configuration file, on start up it will fail to use the option with the message:
`conky: Invalid value of type 'string' for setting 'draw_blended'. Expected value of type 'boolean'.`

Adding this and rebuilding conky allows it to be converted correctly on start up.