### PR TITLE
Include draw_blended in convert.lua

### DIFF
--- a/extras/convert.lua
+++ b/extras/convert.lua
@@ -39,7 +39,8 @@ local bool_setting = {
     out_to_ncurses = true, out_to_stderr = true, out_to_x = true, override_utf8_locale = true,
     own_window = true, own_window_argb_visual = true, own_window_transparent = true,
     short_units = true, show_graph_range = true, show_graph_scale = true,
-    times_in_seconds = true, top_cpu_separate = true, uppercase = true, use_xft = true
+    times_in_seconds = true, top_cpu_separate = true, uppercase = true, use_xft = true,
+    draw_blended = true
 };
 
 local num_setting = {


### PR DESCRIPTION
A followup to #682 , the new `draw_blended` configuration option needs to be included in `extras/convert.lua` in order for it to be converted to boolean correctly.

Without this change, if `draw_blended` is including in an old-style configuration file, on start up it will fail to use the option with the message:
`conky: Invalid value of type 'string' for setting 'draw_blended'. Expected value of type 'boolean'.`

Adding this and rebuilding conky allows it to be converted correctly on start up.