### PR TITLE
nvidia.cc: add nvidia patch

### DIFF
--- a/src/nvidia.cc
+++ b/src/nvidia.cc
@@ -91,7 +91,9 @@
  */
 
 #include "nvidia.h"
-#include <NVCtrl/NVCtrlLib.h>
+#include <X11/Xlib.h>
+#include "NVCtrl/NVCtrl.h"
+#include "NVCtrl/NVCtrlLib.h"
 #include "conky.h"
 #include "logging.h"
 #include "temphelper.h"


### PR DESCRIPTION
I can't compile `BUILD_NVIDIA=ON` without this patch https://github.com/brndnmtthws/conky/issues/520#issuecomment-411203776. 

This does not address #520. Adding this patch permit users to compile conky with NVIDIA support and not stopping others with path issue. Hopefully this will lead to somebody looking into the real issue.