### PR TITLE
conky.cc: fix short_units = False

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -753,7 +753,7 @@ void human_readable(long long num, char *buf, int size) {
     format = "%.*f%.1s";
   } else {
     width = 7;
-    format = "%.*f%-3s";
+    format = "%.*f%-.3s";
   }
 
   if (llabs(num) < 1000LL) {

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -741,7 +741,7 @@ void human_readable(long long num, char *buf, int size) {
   float fnum;
   int precision;
   int width;
-  static const char *const format = "%.*f%.1s";
+  const char *format;
 
   /* Possibly just output as usual, for example for stdout usage */
   if (!format_human_readable.get(*state)) {
@@ -750,8 +750,10 @@ void human_readable(long long num, char *buf, int size) {
   }
   if (short_units.get(*state)) {
     width = 5;
+    format = "%.*f%.1s";
   } else {
     width = 7;
+    format = "%.*f%-3s";
   }
 
   if (llabs(num) < 1000LL) {


### PR DESCRIPTION
>Since Conky v1.11.0, units are always short, whatever short_units.

Resolves #703. 