### PR TITLE
doc/lua.xml: add missing lua apis

### DIFF
--- a/doc/lua.xml
+++ b/doc/lua.xml
@@ -190,9 +190,12 @@
             <option>function</option>
         </term>
         <listitem>
-			<para>
-				Call this function to return a new cairo_text_extents_t structure.  A creation function for this structure is not provided by the cairo API.  After calling this, you should use tolua.takeownership() on the return value to ensure ownership is passed properly.
-			</para>
+            <para>Call this function to return a new
+            cairo_text_extents_t structure. A creation function for
+            this structure is not provided by the cairo API. After
+            calling this, you should use tolua.takeownership() on
+            the return value to ensure ownership is passed
+            properly.</para>
         </listitem>
     </varlistentry>
     <varlistentry>
@@ -203,9 +206,12 @@
             <option>function</option>
         </term>
         <listitem>
-			<para>
-				Call this function to return a new cairo_font_extents_t structure.  A creation function for this structure is not provided by the cairo API.  After calling this, you should use tolua.takeownership() on the return value to ensure ownership is passed properly.
-			</para>
+            <para>Call this function to return a new
+            cairo_font_extents_t structure. A creation function for
+            this structure is not provided by the cairo API. After
+            calling this, you should use tolua.takeownership() on
+            the return value to ensure ownership is passed
+            properly.</para>
         </listitem>
     </varlistentry>
     <varlistentry>
@@ -216,9 +222,11 @@
             <option>function</option>
         </term>
         <listitem>
-			<para>
-				Call this function to return a new cairo_matrix_t structure.  A creation function for this structure is not provided by the cairo API.  After calling this, you should use tolua.takeownership() on the return value to ensure ownership is passed properly.
-			</para>
+            <para>Call this function to return a new cairo_matrix_t
+            structure. A creation function for this structure is
+            not provided by the cairo API. After calling this, you
+            should use tolua.takeownership() on the return value to
+            ensure ownership is passed properly.</para>
         </listitem>
     </varlistentry>
     <varlistentry>

--- a/doc/lua.xml
+++ b/doc/lua.xml
@@ -221,4 +221,42 @@
 			</para>
         </listitem>
     </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>
+                cairo_text_extents_t:destroy(structure)</option>
+            </command>
+            <option>function</option>
+        </term>
+        <listitem>
+            <para>Call this function to free memory allocated by
+            cairo_text_extents_t:create.</para>
+        </listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>
+                cairo_font_extents_t:destroy(structure)</option>
+            </command>
+            <option>function</option>
+        </term>
+        <listitem>
+            <para>Call this function to free memory allocated by
+            cairo_font_extents_t:create.</para>
+        </listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>cairo_matrix_t:destroy(structure)</option>
+            </command>
+            <option>function</option>
+        </term>
+        <listitem>
+            <para>Call this function to free memory allocated by
+            cairo_matrix_t:create.</para>
+        </listitem>
+    </varlistentry>
 </variablelist>


### PR DESCRIPTION
I wanted to destroy the [LUA-API](https://github.com/brndnmtthws/conky/wiki/Lua-API) table in favor of `man -P "less -p 'LUA API'" conky`.

The last three options were not included so I was wondering if that was an unfortunate oversight or if it was omitted on purpose. I tidy up the same file on next commit to kill long lines.

EDIT: Please confirm if such apis exists. Thanks.