### PR TITLE
Fix an FD leak in APCUPSD.

### DIFF
--- a/src/apcupsd.cc
+++ b/src/apcupsd.cc
@@ -234,10 +234,8 @@ int update_apcupsd() {
     //
     // read the lines of output and put them into the info structure
     //
-    if (fill_items(sock, &apc) == 0) {
-      close(sock);
-      break;
-    }
+    fill_items(sock, &apc);
+    close(sock);
 
   } while (0);
 


### PR DESCRIPTION
In some cases the socket FD may have not been closed in the APCUPSD
update function.

This fixes #725.