### PR TITLE
doc: tidy/documentation cleanup

### DIFF
--- a/doc/command_options.xml
+++ b/doc/command_options.xml
@@ -30,7 +30,7 @@
             <option>FILE</option>
         </term>
         <listitem>Config file to load instead of
-        ~/.config/conky/conky.conf.
+        <filename>~/.config/conky/conky.conf</filename>.
         <para></para></listitem>
     </varlistentry>
     <varlistentry>

--- a/doc/command_options.xml
+++ b/doc/command_options.xml
@@ -7,9 +7,9 @@
             <option>ALIGNMENT</option>
         </term>
         <listitem>Text alignment on screen,
-        {top,bottom,middle}_{left,right,middle} or none. Can also
-        be abbreviated with first chars of position, ie. tr for
-        top_right. Only available with build flag BUILD_X11 enabled.
+        {top,bottom,middle}_{left,right,middle} or none. Can also be
+        abbreviated with first chars of position, ie. tr for top_right. Only
+        available with build flag BUILD_X11 enabled.
         <para></para></listitem>
     </varlistentry>
     <varlistentry>
@@ -18,7 +18,8 @@
                 <option>-b | --double-buffer</option>
             </command>
         </term>
-        <listitem>Use double buffering (eliminates "flicker"). Only available with build flag BUILD_X11 enabled.
+        <listitem>Use double buffering (eliminates "flicker"). Only available
+        with build flag BUILD_X11 enabled.
         <para></para></listitem>
     </varlistentry>
     <varlistentry>
@@ -28,7 +29,8 @@
             </command>
             <option>FILE</option>
         </term>
-        <listitem>Config file to load instead of $HOME/.config/conky/conky.conf 
+        <listitem>Config file to load instead of
+        $HOME/.config/conky/conky.conf
         <para></para></listitem>
     </varlistentry>
     <varlistentry>
@@ -37,8 +39,9 @@
                 <option>-C | --print-config</option>
             </command>
         </term>
-        <listitem>Print builtin default config to stdout. See also
-        the section EXAMPLES for more information. Only available with build flag BUILD_BUILTIN_CONFIG enabled.
+        <listitem>Print builtin default config to stdout. See also the section
+        EXAMPLES for more information. Only available with build flag
+        BUILD_BUILTIN_CONFIG enabled.
         <para></para></listitem>
     </varlistentry>
     <varlistentry>
@@ -47,7 +50,7 @@
                 <option>-d | --daemonize</option>
             </command>
         </term>
-        <listitem>Daemonize Conky, aka fork to background. 
+        <listitem>Daemonize Conky, aka fork to background.
         <para></para></listitem>
     </varlistentry>
     <varlistentry>
@@ -56,8 +59,7 @@
                 <option>-D | --debug</option>
             </command>
         </term>
-        <listitem>Increase debugging output, ie. -DD for more
-        debugging. 
+        <listitem>Increase debugging output, ie. -DD for more debugging.
         <para></para></listitem>
     </varlistentry>
     <varlistentry>
@@ -67,7 +69,8 @@
             </command>
             <option>FONT</option>
         </term>
-        <listitem>Font to use. Only available with build flag BUILD_X11 enabled. 
+        <listitem>Font to use. Only available with build flag BUILD_X11
+        enabled.
         <para></para></listitem>
     </varlistentry>
     <varlistentry>
@@ -76,7 +79,7 @@
                 <option>-h | --help</option>
             </command>
         </term>
-        <listitem>Prints command line help and exits. 
+        <listitem>Prints command line help and exits.
         <para></para></listitem>
     </varlistentry>
     <varlistentry>
@@ -86,7 +89,7 @@
             </command>
             <option>COUNT</option>
         </term>
-        <listitem>Number of times to update Conky (and quit). 
+        <listitem>Number of times to update Conky (and quit).
         <para></para></listitem>
     </varlistentry>
     <varlistentry>
@@ -95,7 +98,8 @@
                 <option>-o | --own-window</option>
             </command>
         </term>
-        <listitem>Create own window to draw. Only available with build flag BUILD_X11 enabled.
+        <listitem>Create own window to draw. Only available with build flag
+        BUILD_X11 enabled.
         <para></para></listitem>
     </varlistentry>
     <varlistentry>
@@ -114,7 +118,7 @@
                 <option>-q | --quiet</option>
             </command>
         </term>
-        <listitem>Run Conky in 'quiet mode' (ie. no output). 
+        <listitem>Run Conky in 'quiet mode' (ie. no output).
         <para></para></listitem>
     </varlistentry>
     <varlistentry>
@@ -124,8 +128,7 @@
             </command>
             <option>TEXT</option>
         </term>
-        <listitem>Text to render, remember single quotes, like -t '
-        $uptime ' 
+        <listitem>Text to render, remember single quotes, like -t ' $uptime '
         <para></para></listitem>
     </varlistentry>
     <varlistentry>
@@ -135,7 +138,7 @@
             </command>
             <option>SECONDS</option>
         </term>
-        <listitem>Update interval. 
+        <listitem>Update interval.
         <para></para></listitem>
     </varlistentry>
     <varlistentry>
@@ -144,8 +147,8 @@
                 <option>-v | -V | --version</option>
             </command>
         </term>
-        <listitem>Prints version, build information and general info.
-        Exits after printing. 
+        <listitem>Prints version, build information and general info. Exits
+        after printing.
         <para></para></listitem>
     </varlistentry>
     <varlistentry>
@@ -155,7 +158,8 @@
             </command>
             <option>WIN_ID</option>
         </term>
-        <listitem>Window id to draw. Only available with build flag BUILD_X11 enabled.
+        <listitem>Window id to draw. Only available with build flag BUILD_X11
+        enabled.
         <para></para></listitem>
     </varlistentry>
     <varlistentry>
@@ -165,7 +169,7 @@
             </command>
             <option>X_COORDINATE</option>
         </term>
-        <listitem>X position 
+        <listitem>X position
         <para></para></listitem>
     </varlistentry>
     <varlistentry>
@@ -175,7 +179,7 @@
             </command>
             <option>X_COORDINATE</option>
         </term>
-        <listitem>X position 
+        <listitem>X position
         <para></para></listitem>
     </varlistentry>
     <varlistentry>
@@ -185,7 +189,8 @@
             </command>
             <option>DISPLAY</option>
         </term>
-        <listitem>X11 display to use. Only available with build flag BUILD_X11 enabled. 
+        <listitem>X11 display to use. Only available with build flag BUILD_X11
+        enabled.
         <para></para></listitem>
     </varlistentry>
     <varlistentry>
@@ -195,7 +200,7 @@
             </command>
             <option>Y_COORDINATE</option>
         </term>
-        <listitem>Y position 
+        <listitem>Y position
         <para></para></listitem>
     </varlistentry>
 </variablelist>

--- a/doc/command_options.xml
+++ b/doc/command_options.xml
@@ -30,7 +30,7 @@
             <option>FILE</option>
         </term>
         <listitem>Config file to load instead of
-        $HOME/.config/conky/conky.conf
+        ~/.config/conky/conky.conf.
         <para></para></listitem>
     </varlistentry>
     <varlistentry>
@@ -128,7 +128,7 @@
             </command>
             <option>TEXT</option>
         </term>
-        <listitem>Text to render, remember single quotes, like -t ' $uptime '
+        <listitem>Text to render, remember single quotes, like -t ' $uptime '.
         <para></para></listitem>
     </varlistentry>
     <varlistentry>
@@ -169,7 +169,7 @@
             </command>
             <option>X_COORDINATE</option>
         </term>
-        <listitem>X position
+        <listitem>X position.
         <para></para></listitem>
     </varlistentry>
     <varlistentry>
@@ -179,7 +179,7 @@
             </command>
             <option>X_COORDINATE</option>
         </term>
-        <listitem>X position
+        <listitem>X position.
         <para></para></listitem>
     </varlistentry>
     <varlistentry>
@@ -200,7 +200,7 @@
             </command>
             <option>Y_COORDINATE</option>
         </term>
-        <listitem>Y position
+        <listitem>Y position.
         <para></para></listitem>
     </varlistentry>
 </variablelist>

--- a/doc/config_settings.xml
+++ b/doc/config_settings.xml
@@ -5,11 +5,10 @@
                 <option>alignment</option>
             </command>
         </term>
-        <listitem>Aligned position on screen, may be top_left,
-        top_right, top_middle, bottom_left, bottom_right,
-        bottom_middle, middle_left, middle_middle, middle_right, or
-        none (also can be abreviated as tl, tr, tm, bl, br, bm, ml,
-        mm, mr). See also gap_x and gap_y.
+        <listitem>Aligned position on screen, may be top_left, top_right,
+        top_middle, bottom_left, bottom_right, bottom_middle, middle_left,
+        middle_middle, middle_right, or none (also can be abreviated as tl,
+        tr, tm, bl, br, bm, ml, mm, mr). See also gap_x and gap_y.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -27,8 +26,8 @@
                 <option>background</option>
             </command>
         </term>
-        <listitem>Boolean value, if true, Conky will be forked to
-        background when started.
+        <listitem>Boolean value, if true, Conky will be forked to background
+        when started.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -37,8 +36,8 @@
                 <option>border_inner_margin</option>
             </command>
         </term>
-        <listitem>Inner border margin in pixels (the margin between
-        the border and text).
+        <listitem>Inner border margin in pixels (the margin between the border
+        and text).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -47,8 +46,8 @@
                 <option>border_outer_margin</option>
             </command>
         </term>
-        <listitem>Outer border margin in pixels (the margin between
-        the border and the edge of the window).
+        <listitem>Outer border margin in pixels (the margin between the border
+        and the edge of the window).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -67,9 +66,8 @@
             </command>
         </term>
         <listitem>Predefine a color for use inside conky.text segments.
-        Substitute N by a digit between 0 and 9, inclusively. When
-        specifying the color value in hex, omit the leading hash
-        (#).
+        Substitute N by a digit between 0 and 9, inclusively. When specifying
+        the color value in hex, omit the leading hash (#).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -96,9 +94,10 @@
                 <option>console_graph_ticks</option>
             </command>
         </term>
-        <listitem>A comma-separated list of strings to use as the bars of a graph output
-        to console/shell. The first list item is used for the minimum bar height and the
-        last item is used for the maximum. Example: " ,_,=,#".
+        <listitem>A comma-separated list of strings to use as the bars of a
+        graph output to console/shell. The first list item is used for the
+        minimum bar height and the last item is used for the maximum. Example:
+        " ,_,=,#".
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -107,8 +106,7 @@
                 <option>cpu_avg_samples</option>
             </command>
         </term>
-        <listitem>The number of samples to average for CPU
-        monitoring.
+        <listitem>The number of samples to average for CPU monitoring.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -117,8 +115,8 @@
                 <option>default_bar_height</option>
             </command>
         </term>
-        <listitem>Specify a default height for bars. If not specified,
-        the default value is 6.
+        <listitem>Specify a default height for bars. If not specified, the
+        default value is 6.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -127,11 +125,10 @@
                 <option>default_bar_width</option>
             </command>
         </term>
-        <listitem>Specify a default width for bars. If not specified,
-        the default value is 0, which causes the bar to expand to
-        fit the width of your Conky window. If you set
-        out_to_console = true, the default value will be 10
-        for the text version of the bar.
+        <listitem>Specify a default width for bars. If not specified, the
+        default value is 0, which causes the bar to expand to fit the width of
+        your Conky window. If you set out_to_console = true, the default value
+        will be 10 for the text version of the bar.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -149,8 +146,8 @@
                 <option>default_gauge_height</option>
             </command>
         </term>
-        <listitem>Specify a default height for gauges. If not specified,
-        the default value is 25.
+        <listitem>Specify a default height for gauges. If not specified, the
+        default value is 25.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -159,8 +156,8 @@
                 <option>default_gauge_width</option>
             </command>
         </term>
-        <listitem>Specify a default width for gauges. If not specified,
-        the default value is 40.
+        <listitem>Specify a default width for gauges. If not specified, the
+        default value is 40.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -169,8 +166,8 @@
                 <option>default_graph_height</option>
             </command>
         </term>
-        <listitem>Specify a default height for graphs. If not specified,
-        the default value is 25.
+        <listitem>Specify a default height for graphs. If not specified, the
+        default value is 25.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -179,12 +176,11 @@
                 <option>default_graph_width</option>
             </command>
         </term>
-        <listitem>Specify a default width for graphs. If not specified,
-        the default value is 0, which causes the graph to expand to
-        fit the width of your Conky window. If you set
-        out_to_console = true, the text version of the graph will
-        actually have no width and you will need to set a
-        sensible default or set the height and width of each graph
+        <listitem>Specify a default width for graphs. If not specified, the
+        default value is 0, which causes the graph to expand to fit the width
+        of your Conky window. If you set out_to_console = true, the text
+        version of the graph will actually have no width and you will need to
+        set a sensible default or set the height and width of each graph
         individually.
         <para /></listitem>
     </varlistentry>
@@ -212,7 +208,8 @@
                 <option>disable_auto_reload</option>
             </command>
         </term>
-		<listitem>Enable to disable the inotify-based auto config reload feature.
+        <listitem>Enable to disable the inotify-based auto config reload
+        feature.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -221,8 +218,7 @@
                 <option>diskio_avg_samples</option>
             </command>
         </term>
-        <listitem>The number of samples to average for disk I/O
-        monitoring.
+        <listitem>The number of samples to average for disk I/O monitoring.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -233,8 +229,8 @@
         </term>
         <listitem>Specify an X display to connect to.
         <para /></listitem>
-	</varlistentry>
-	<varlistentry>
+    </varlistentry>
+    <varlistentry>
         <term>
             <command>
                 <option>xinerama_head</option>
@@ -242,16 +238,16 @@
         </term>
         <listitem>Specify a Xinerama head.
         <para /></listitem>
-	</varlistentry>
+    </varlistentry>
     <varlistentry>
         <term>
             <command>
                 <option>double_buffer</option>
             </command>
         </term>
-        <listitem>Use the Xdbe extension? (eliminates flicker) It
-        is highly recommended to use own window with this one so
-        double buffer won't be so big.
+        <listitem>Use the Xdbe extension? (eliminates flicker) It is highly
+        recommended to use own window with this one so double buffer won't be
+        so big.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -260,10 +256,9 @@
                 <option>draw_blended</option>
             </command>
         </term>
-        <listitem>Boolean, blend when rendering drawn image?
-        Some images blend incorrectly breaking alpha with ARBG visuals. This
-        provides a possible work around by disabling blending. Defaults to
-        true.
+        <listitem>Boolean, blend when rendering drawn image? Some images blend
+        incorrectly breaking alpha with ARBG visuals. This provides a possible
+        work around by disabling blending. Defaults to true.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -308,8 +303,8 @@
                 <option>extra_newline</option>
             </command>
         </term>
-        <listitem>Put an extra newline at the end when writing to
-        stdout, useful for writing to awesome's wiboxes.
+        <listitem>Put an extra newline at the end when writing to stdout,
+        useful for writing to awesome's wiboxes.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -318,8 +313,7 @@
                 <option>font</option>
             </command>
         </term>
-        <listitem>Font name in X, xfontsel can be used to get a
-        nice font
+        <listitem>Font name in X, xfontsel can be used to get a nice font
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -333,16 +327,15 @@
         format as a font variable.
         <para /></listitem>
     </varlistentry>
-
     <varlistentry>
         <term>
             <command>
                 <option>format_human_readable</option>
             </command>
         </term>
-        <listitem>If enabled, values which are in bytes will be
-        printed in human readable format (i.e., KiB, MiB, etc). If
-        disabled, the number of bytes is printed instead.
+        <listitem>If enabled, values which are in bytes will be printed in
+        human readable format (i.e., KiB, MiB, etc). If disabled, the number
+        of bytes is printed instead.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -351,9 +344,9 @@
                 <option>gap_x</option>
             </command>
         </term>
-        <listitem>Gap, in pixels, between right or left border of
-        screen, same as passing -x at command line, e.g. gap_x 10.
-        For other position related stuff, see 'alignment'.
+        <listitem>Gap, in pixels, between right or left border of screen, same
+        as passing -x at command line, e.g. gap_x 10. For other position
+        related stuff, see 'alignment'.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -362,9 +355,9 @@
                 <option>gap_y</option>
             </command>
         </term>
-        <listitem>Gap, in pixels, between top or bottom border of
-        screen, same as passing -y at command line, e.g. gap_y 10.
-        For other position related stuff, see 'alignment'.
+        <listitem>Gap, in pixels, between top or bottom border of screen, same
+        as passing -y at command line, e.g. gap_y 10. For other position
+        related stuff, see 'alignment'.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -376,8 +369,7 @@
         <listitem>Specify API token for GitHub notifications.
         <simplelist>
             <member>
-        https://github.com/settings/tokens/new?scopes=notifications&amp;description=conky
-            </member>
+            https://github.com/settings/tokens/new?scopes=notifications&amp;description=conky</member>
         </simplelist>
         <para /></listitem>
     </varlistentry>
@@ -387,8 +379,8 @@
                 <option>hddtemp_host</option>
             </command>
         </term>
-	<listitem>Hostname to connect to for hddtemp objects. Defaults
-		to "127.0.0.1".
+        <listitem>Hostname to connect to for hddtemp objects. Defaults to
+        "127.0.0.1".
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -397,8 +389,7 @@
                 <option>hddtemp_port</option>
             </command>
         </term>
-	<listitem>Port to use for hddtemp connections. Defaults to
-		7634.
+        <listitem>Port to use for hddtemp connections. Defaults to 7634.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -407,9 +398,8 @@
                 <option>http_refresh</option>
             </command>
         </term>
-        <listitem>When this is set the page generated with
-	out_to_http will automatically refresh each interval. Default
-	value is no.
+        <listitem>When this is set the page generated with out_to_http will
+        automatically refresh each interval. Default value is no.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -418,11 +408,10 @@
                 <option>if_up_strictness</option>
             </command>
         </term>
-        <listitem>How strict should if_up be when testing an
-        interface for being up? The value is one of up, link or
-        address, to check for the interface being solely up, being
-        up and having link or being up, having link and an assigned
-        IP address.
+        <listitem>How strict should if_up be when testing an interface for
+        being up? The value is one of up, link or address, to check for the
+        interface being solely up, being up and having link or being up,
+        having link and an assigned IP address.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -431,13 +420,12 @@
                 <option>imap</option>
             </command>
         </term>
-        <listitem>Default global IMAP server. Arguments are: "host
-        user pass [-i interval (in seconds)] [-f 'folder'] [-p port]
-        [-e 'command'] [-r retries]". Default port is 143, default
-        folder is 'INBOX', default interval is 5 minutes, and
-        default number of retries before giving up is 5. If the
-        password is supplied as '*', you will be prompted to enter
-        the password when Conky starts.
+        <listitem>Default global IMAP server. Arguments are: "host user pass
+        [-i interval (in seconds)] [-f 'folder'] [-p port] [-e 'command'] [-r
+        retries]". Default port is 143, default folder is 'INBOX', default
+        interval is 5 minutes, and default number of retries before giving up
+        is 5. If the password is supplied as '*', you will be prompted to
+        enter the password when Conky starts.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -455,11 +443,10 @@
                 <option>imlib_cache_size</option>
             </command>
         </term>
-        <listitem>
-            Imlib2 image cache size, in bytes. Defaults to
-            4MiB. Increase this value if you use $image lots. Set
-            to 0 to disable the image cache.<para/>
-        </listitem>
+        <listitem>Imlib2 image cache size, in bytes. Defaults to 4MiB.
+        Increase this value if you use $image lots. Set to 0 to disable the
+        image cache.
+        <para /></listitem>
     </varlistentry>
     <varlistentry>
         <term>
@@ -468,16 +455,13 @@
             </command>
             <option>function_name [function arguments]</option>
         </term>
-        <listitem>
-            This function, if defined, will be called by
-            Conky through each iteration after drawing to the
-            window. Requires X support. Takes any number of
-            optional arguments. Use this hook for drawing things on
-            top of what Conky draws. Conky puts 'conky_' in front
-            of function_name to prevent accidental calls to the
-            wrong function unless you place 'conky_' in front of it
-            yourself.<para/>
-        </listitem>
+        <listitem>This function, if defined, will be called by Conky through
+        each iteration after drawing to the window. Requires X support. Takes
+        any number of optional arguments. Use this hook for drawing things on
+        top of what Conky draws. Conky puts 'conky_' in front of function_name
+        to prevent accidental calls to the wrong function unless you place
+        'conky_' in front of it yourself.
+        <para /></listitem>
     </varlistentry>
     <varlistentry>
         <term>
@@ -486,16 +470,13 @@
             </command>
             <option>function_name [function arguments]</option>
         </term>
-        <listitem>
-            This function, if defined, will be called by
-            Conky through each iteration before drawing to the
-            window. Requires X support. Takes any number of
-            optional arguments. Use this hook for drawing things on
-            top of what Conky draws. Conky puts 'conky_' in front
-            of function_name to prevent accidental calls to the
-            wrong function unless you place 'conky_' in front of it
-            yourself.<para/>
-        </listitem>
+        <listitem>This function, if defined, will be called by Conky through
+        each iteration before drawing to the window. Requires X support. Takes
+        any number of optional arguments. Use this hook for drawing things on
+        top of what Conky draws. Conky puts 'conky_' in front of function_name
+        to prevent accidental calls to the wrong function unless you place
+        'conky_' in front of it yourself.
+        <para /></listitem>
     </varlistentry>
     <varlistentry>
         <term>
@@ -513,16 +494,13 @@
             </command>
             <option>function_name [function arguments]</option>
         </term>
-        <listitem>
-            This function, if defined, will be called by
-            Conky at shutdown or when the configuration is
-            reloaded. Use this hook to clean up after yourself,
-            such as freeing memory which has been allocated by
-            external libraries via Lua. Conky puts 'conky_' in
-            front of function_name to prevent accidental calls to
-            the wrong function unless you place 'conky_' in
-            front of it yourself.<para/>
-        </listitem>
+        <listitem>This function, if defined, will be called by Conky at
+        shutdown or when the configuration is reloaded. Use this hook to clean
+        up after yourself, such as freeing memory which has been allocated by
+        external libraries via Lua. Conky puts 'conky_' in front of
+        function_name to prevent accidental calls to the wrong function unless
+        you place 'conky_' in front of it yourself.
+        <para /></listitem>
     </varlistentry>
     <varlistentry>
         <term>
@@ -531,15 +509,12 @@
             </command>
             <option>function_name [function arguments]</option>
         </term>
-        <listitem>
-            This function, if defined, will be called by
-            Conky at startup or when the configuration is reloaded.
-            Use this hook to initialize values, or for any run-once
-            applications. Conky puts 'conky_' in front of
-            function_name to prevent accidental calls to the wrong
-            function unless you place 'conky_' in front of
-            it yourself.<para/>
-        </listitem>
+        <listitem>This function, if defined, will be called by Conky at
+        startup or when the configuration is reloaded. Use this hook to
+        initialize values, or for any run-once applications. Conky puts
+        'conky_' in front of function_name to prevent accidental calls to the
+        wrong function unless you place 'conky_' in front of it yourself.
+        <para /></listitem>
     </varlistentry>
     <varlistentry>
         <term>
@@ -556,8 +531,8 @@
                 <option>max_port_monitor_connections</option>
             </command>
         </term>
-        <listitem>Allow each port monitor to track at most this
-        many connections (if 0 or not set, default is 256)
+        <listitem>Allow each port monitor to track at most this many
+        connections (if 0 or not set, default is 256)
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -567,10 +542,9 @@
             </command>
             <option>width</option>
         </term>
-        <listitem>When a line in the output contains 'width'
-	chars and the end isn't reached, the next char will start
-	on a new line. If you want to make sure that lines don't
-	get broken, set 'width' to 0
+        <listitem>When a line in the output contains 'width' chars and the end
+        isn't reached, the next char will start on a new line. If you want to
+        make sure that lines don't get broken, set 'width' to 0
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -581,7 +555,7 @@
             <option>bytes</option>
         </term>
         <listitem>Maximum size of user text buffer, i.e. text inside
-	conky.text section in config file (default is 16384 bytes)
+        conky.text section in config file (default is 16384 bytes)
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -665,7 +639,8 @@
                 <option>mysql_user</option>
             </command>
         </term>
-        <listitem>MySQL user name to use when connecting to the server. Defaults to your username
+        <listitem>MySQL user name to use when connecting to the server.
+        Defaults to your username
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -674,8 +649,8 @@
                 <option>mysql_password</option>
             </command>
         </term>
-        <listitem>Password of the MySQL user. Place it between "-chars. When this is not set there
-        is no password used
+        <listitem>Password of the MySQL user. Place it between "-chars. When
+        this is not set there is no password used
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -693,8 +668,8 @@
                 <option>music_player_interval</option>
             </command>
         </term>
-        <listitem>Music player thread update interval (defaults to
-        Conky's update interval)
+        <listitem>Music player thread update interval (defaults to Conky's
+        update interval)
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -713,7 +688,6 @@
             </command>
         </term>
         <listitem>Subtract (file system) buffers from used memory?
-
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -722,8 +696,8 @@
                 <option>nvidia_display</option>
             </command>
         </term>
-        <listitem>The display that the nvidia variable will use (defaults to the value of the
-            display variable)
+        <listitem>The display that the nvidia variable will use (defaults to
+        the value of the display variable)
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -750,9 +724,9 @@
                 <option>out_to_ncurses</option>
             </command>
         </term>
-        <listitem>Print text in the console, but use ncurses so
-        that conky can print the text of a new update over the old
-        text. (In the future this will provide more useful things)
+        <listitem>Print text in the console, but use ncurses so that conky can
+        print the text of a new update over the old text. (In the future this
+        will provide more useful things)
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -770,11 +744,10 @@
                 <option>out_to_x</option>
             </command>
         </term>
-        <listitem>When set to no, there will be no output in X
-        (useful when you also use things like out_to_console). If
-        you set it to no, make sure that it's placed before all
-        other X-related setting (take the first line of your
-        configfile to be sure). Default value is yes
+        <listitem>When set to no, there will be no output in X (useful when
+        you also use things like out_to_console). If you set it to no, make
+        sure that it's placed before all other X-related setting (take the
+        first line of your configfile to be sure). Default value is yes
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -810,8 +783,7 @@
                 <option>own_window_class</option>
             </command>
         </term>
-        <listitem>Manually set the WM_CLASS name. Defaults to
-        "Conky".
+        <listitem>Manually set the WM_CLASS name. Defaults to "Conky".
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -821,10 +793,10 @@
             </command>
             <option>colour</option>
         </term>
-        <listitem>If own_window_transparent no, set a specified
-            background colour (defaults to black). Takes either a hex value
-            (e.g. '#ffffff'), a shorthand hex value (e.g. '#fff'), or a valid
-            RGB name (see /usr/lib/X11/rgb.txt)
+        <listitem>If own_window_transparent no, set a specified background
+        colour (defaults to black). Takes either a hex value (e.g. '#ffffff'),
+        a shorthand hex value (e.g. '#fff'), or a valid RGB name (see
+        /usr/lib/X11/rgb.txt)
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -835,11 +807,10 @@
             <option>
             undecorated,below,above,sticky,skip_taskbar,skip_pager</option>
         </term>
-        <listitem>If own_window is yes, you may use these window
-        manager hints to affect the way Conky displays. Notes: Use
-        own_window_type desktop as another way to implement many of
-        these hints implicitly. If you use own_window_type
-        override, window manager hints have no meaning and are
+        <listitem>If own_window is yes, you may use these window manager hints
+        to affect the way Conky displays. Notes: Use own_window_type desktop
+        as another way to implement many of these hints implicitly. If you use
+        own_window_type override, window manager hints have no meaning and are
         ignored.
         <para /></listitem>
     </varlistentry>
@@ -849,8 +820,8 @@
                 <option>own_window_title</option>
             </command>
         </term>
-        <listitem>Manually set the window name. Defaults to
-        "conky (&lt;hostname&gt;)".
+        <listitem>Manually set the window name. Defaults to "conky
+        (&lt;hostname&gt;)".
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -859,10 +830,10 @@
                 <option>own_window_argb_visual</option>
             </command>
         </term>
-		<listitem>Boolean, use ARGB visual? ARGB can be used for real
-			transparency, note that a composite manager is required for real
-			transparency.  This option will not work as desired (in most cases)
-			in conjunction with 'own_window_type override'.
+        <listitem>Boolean, use ARGB visual? ARGB can be used for real
+        transparency, note that a composite manager is required for real
+        transparency. This option will not work as desired (in most cases) in
+        conjunction with 'own_window_type override'.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -871,7 +842,9 @@
                 <option>own_window_argb_value</option>
             </command>
         </term>
-		<listitem>When ARGB visuals are enabled, this use this to modify the alpha value used.  Valid range is 0-255, where 0 is 0% opacity, and 255 is 100% opacity.
+        <listitem>When ARGB visuals are enabled, this use this to modify the
+        alpha value used. Valid range is 0-255, where 0 is 0% opacity, and 255
+        is 100% opacity.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -880,8 +853,8 @@
                 <option>own_window_transparent</option>
             </command>
         </term>
-		<listitem>Boolean, set transparency? If ARGB visual is enabled, sets
-			background opacity to 0%.
+        <listitem>Boolean, set transparency? If ARGB visual is enabled, sets
+        background opacity to 0%.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -890,17 +863,16 @@
                 <option>own_window_type</option>
             </command>
         </term>
-        <listitem>if own_window is yes, you may specify type
-        normal, desktop, dock, panel or override (default: normal).
-        Desktop windows are special windows that have no window
-        decorations; are always visible on your desktop; do not
-        appear in your pager or taskbar; and are sticky across all
-        workspaces. Panel windows reserve space along a desktop
-        edge, just like panels and taskbars, preventing maximized
-        windows from overlapping them. The edge is chosen based on
-        the alignment option. Override windows are not under the
-        control of the window manager. Hints are ignored. This type
-        of window can be useful for certain situations.
+        <listitem>if own_window is yes, you may specify type normal, desktop,
+        dock, panel or override (default: normal). Desktop windows are special
+        windows that have no window decorations; are always visible on your
+        desktop; do not appear in your pager or taskbar; and are sticky across
+        all workspaces. Panel windows reserve space along a desktop edge, just
+        like panels and taskbars, preventing maximized windows from
+        overlapping them. The edge is chosen based on the alignment option.
+        Override windows are not under the control of the window manager.
+        Hints are ignored. This type of window can be useful for certain
+        situations.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -909,8 +881,7 @@
                 <option>pad_percents</option>
             </command>
         </term>
-        <listitem>Pad percentages to this many decimals (0 = no
-        padding)
+        <listitem>Pad percentages to this many decimals (0 = no padding)
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -919,12 +890,11 @@
                 <option>pop3</option>
             </command>
         </term>
-        <listitem>Default global POP3 server. Arguments are: "host
-        user pass [-i interval (in seconds)] [-p port] [-e 'command']
-        [-r retries]". Default port is 110, default interval is 5
-        minutes, and default number of retries before giving up is
-        5. If the password is supplied as '*', you will be prompted
-        to enter the password when Conky starts.
+        <listitem>Default global POP3 server. Arguments are: "host user pass
+        [-i interval (in seconds)] [-p port] [-e 'command'] [-r retries]".
+        Default port is 110, default interval is 5 minutes, and default number
+        of retries before giving up is 5. If the password is supplied as '*',
+        you will be prompted to enter the password when Conky starts.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -933,8 +903,8 @@
                 <option>short_units</option>
             </command>
         </term>
-        <listitem>Shortens units to a single character (kiB-&gt;k,
-        GiB-&gt;G, etc.). Default is off.
+        <listitem>Shortens units to a single character (kiB-&gt;k, GiB-&gt;G,
+        etc.). Default is off.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -970,9 +940,9 @@
                 <option>temperature_unit</option>
             </command>
         </term>
-        <listitem>Desired output unit of all objects displaying a
-        temperature. Parameters are either "fahrenheit" or
-        "celsius". The default unit is degree Celsius.
+        <listitem>Desired output unit of all objects displaying a temperature.
+        Parameters are either "fahrenheit" or "celsius". The default unit is
+        degree Celsius.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -981,11 +951,10 @@
                 <option>templateN</option>
             </command>
         </term>
-        <listitem>Define a template for later use inside conky.text
-        segments. Substitute N by a digit between 0 and 9,
-        inclusively. The value of the variable is being inserted
-        into the stuff inside conky.text at the corresponding position,
-        but before some substitutions are applied:
+        <listitem>Define a template for later use inside conky.text segments.
+        Substitute N by a digit between 0 and 9, inclusively. The value of the
+        variable is being inserted into the stuff inside conky.text at the
+        corresponding position, but before some substitutions are applied:
         <simplelist>
             <member>'\n' -&gt; newline</member>
             <member>'\\' -&gt; backslash</member>
@@ -1001,12 +970,11 @@
             </command>
             <option>bytes</option>
         </term>
-        <listitem>Size of the standard text buffer (default is 256
-        bytes). This buffer is used for intermediary text, such as
-        individual lines, output from $exec vars, and various other
-        variables. Increasing the size of this buffer can
-        drastically reduce Conky's performance, but will allow for
-        more text display per variable. The size of this buffer
+        <listitem>Size of the standard text buffer (default is 256 bytes).
+        This buffer is used for intermediary text, such as individual lines,
+        output from $exec vars, and various other variables. Increasing the
+        size of this buffer can drastically reduce Conky's performance, but
+        will allow for more text display per variable. The size of this buffer
         cannot be smaller than the default value of 256 bytes.
         <para /></listitem>
     </varlistentry>
@@ -1016,9 +984,8 @@
                 <option>times_in_seconds</option>
             </command>
         </term>
-        <listitem>If true, variables that output times output a number
-	that represents seconds. This doesn't affect $time, $tztime and
-	$utime
+        <listitem>If true, variables that output times output a number that
+        represents seconds. This doesn't affect $time, $tztime and $utime
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1027,9 +994,9 @@
                 <option>top_cpu_separate</option>
             </command>
         </term>
-        <listitem>If true, cpu in top will show usage of one
-        processor's power. If false, cpu in top will show the usage
-        of all processors' power combined.
+        <listitem>If true, cpu in top will show usage of one processor's
+        power. If false, cpu in top will show the usage of all processors'
+        power combined.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1039,8 +1006,8 @@
             </command>
         </term>
         <listitem>If true, top name shows the full command line of each
-        process, including arguments (whenever possible). Otherwise,
-        only the basename is displayed. Default value is false.
+        process, including arguments (whenever possible). Otherwise, only the
+        basename is displayed. Default value is false.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1049,8 +1016,7 @@
                 <option>top_name_width</option>
             </command>
         </term>
-        <listitem>Width for $top name value (defaults to 15
-        characters).
+        <listitem>Width for $top name value (defaults to 15 characters).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1059,8 +1025,8 @@
                 <option>total_run_times</option>
             </command>
         </term>
-        <listitem>Total number of times for Conky to update before
-        quitting. Zero makes Conky run forever
+        <listitem>Total number of times for Conky to update before quitting.
+        Zero makes Conky run forever
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1089,7 +1055,8 @@
                 <option>detect_battery</option>
             </command>
         </term>
-        <listitem>One or more batteries to check in order to use update_interval_on_battery (comma separated, BAT0 default)
+        <listitem>One or more batteries to check in order to use
+        update_interval_on_battery (comma separated, BAT0 default)
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1098,8 +1065,7 @@
                 <option>uppercase</option>
             </command>
         </term>
-        <listitem>Boolean value, if true, text is rendered in upper
-        case
+        <listitem>Boolean value, if true, text is rendered in upper case
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1108,12 +1074,11 @@
                 <option>use_spacer</option>
             </command>
         </term>
-        <listitem>Adds spaces around certain objects to stop them
-        from moving other things around. Arguments are left, right,
-        and none (default). The old true/false values are
-        deprecated and default to right/none respectively. Note
-        that this only helps if you are using a mono font, such as
-        Bitstream Vera Sans Mono.
+        <listitem>Adds spaces around certain objects to stop them from moving
+        other things around. Arguments are left, right, and none (default).
+        The old true/false values are deprecated and default to right/none
+        respectively. Note that this only helps if you are using a mono font,
+        such as Bitstream Vera Sans Mono.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1131,8 +1096,7 @@
                 <option>xftalpha</option>
             </command>
         </term>
-        <listitem>Alpha of Xft font. Must be a value at or between
-        1 and 0.
+        <listitem>Alpha of Xft font. Must be a value at or between 1 and 0.
         <para /></listitem>
     </varlistentry>
 </variablelist>

--- a/doc/config_settings.xml
+++ b/doc/config_settings.xml
@@ -96,7 +96,7 @@
         </term>
         <listitem>A comma-separated list of strings to use as the bars of a
         graph output to console/shell. The first list item is used for the
-        minimum bar height and the last item is used for the maximum. Example:
+        minimum bar height and the last item is used for the maximum, e.g.
         " ,_,=,#".
         <para /></listitem>
     </varlistentry>
@@ -137,7 +137,7 @@
                 <option>default_color</option>
             </command>
         </term>
-        <listitem>Default color and border color
+        <listitem>Default color and border color.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -190,7 +190,7 @@
                 <option>default_outline_color</option>
             </command>
         </term>
-        <listitem>Default outline color
+        <listitem>Default outline color.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -199,7 +199,7 @@
                 <option>default_shade_color</option>
             </command>
         </term>
-        <listitem>Default shading color and border's shading color
+        <listitem>Default shading color and border's shading color.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -267,7 +267,7 @@
                 <option>draw_borders</option>
             </command>
         </term>
-        <listitem>Draw borders around text?
+        <listitem>Draw borders around text.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -276,7 +276,7 @@
                 <option>draw_graph_borders</option>
             </command>
         </term>
-        <listitem>Draw borders around graphs?
+        <listitem>Draw borders around graphs.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -285,7 +285,7 @@
                 <option>draw_outline</option>
             </command>
         </term>
-        <listitem>Draw outlines?
+        <listitem>Draw outlines.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -294,7 +294,7 @@
                 <option>draw_shades</option>
             </command>
         </term>
-        <listitem>Draw shades?
+        <listitem>Draw shades.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -313,7 +313,7 @@
                 <option>font</option>
             </command>
         </term>
-        <listitem>Font name in X, xfontsel can be used to get a nice font
+        <listitem>Font name in X, xfontsel can be used to get a nice font.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -522,7 +522,7 @@
                 <option>mail_spool</option>
             </command>
         </term>
-        <listitem>Mail spool for mail checking
+        <listitem>Mail spool for mail checking.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -532,7 +532,7 @@
             </command>
         </term>
         <listitem>Allow each port monitor to track at most this many
-        connections (if 0 or not set, default is 256)
+        connections (if 0 or not set, default is 256).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -544,7 +544,7 @@
         </term>
         <listitem>When a line in the output contains 'width' chars and the end
         isn't reached, the next char will start on a new line. If you want to
-        make sure that lines don't get broken, set 'width' to 0
+        make sure that lines don't get broken, set 'width' to 0.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -555,7 +555,7 @@
             <option>bytes</option>
         </term>
         <listitem>Maximum size of user text buffer, i.e. text inside
-        conky.text section in config file (default is 16384 bytes)
+        conky.text section in config file (default is 16384 bytes).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -565,7 +565,7 @@
             </command>
             <option>pixels</option>
         </term>
-        <listitem>Maximum width of window
+        <listitem>Maximum width of window.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -575,7 +575,7 @@
             </command>
             <option>height</option>
         </term>
-        <listitem>Minimum height of the window
+        <listitem>Minimum height of the window.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -585,7 +585,7 @@
             </command>
             <option>width</option>
         </term>
-        <listitem>Minimum width of window
+        <listitem>Minimum width of window.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -594,7 +594,7 @@
                 <option>mpd_host</option>
             </command>
         </term>
-        <listitem>Host of MPD server
+        <listitem>Host of MPD server.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -603,7 +603,7 @@
                 <option>mpd_password</option>
             </command>
         </term>
-        <listitem>MPD server password
+        <listitem>MPD server password.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -612,7 +612,7 @@
                 <option>mpd_port</option>
             </command>
         </term>
-        <listitem>Port of MPD server
+        <listitem>Port of MPD server.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -621,7 +621,7 @@
                 <option>mysql_host</option>
             </command>
         </term>
-        <listitem>Host of MySQL server. Defaults to localhost
+        <listitem>Host of MySQL server. Defaults to localhost.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -630,7 +630,7 @@
                 <option>mysql_port</option>
             </command>
         </term>
-        <listitem>Port of MySQL server. Defaults to the default mysql port
+        <listitem>Port of MySQL server. Defaults to the default mysql port.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -640,7 +640,7 @@
             </command>
         </term>
         <listitem>MySQL user name to use when connecting to the server.
-        Defaults to your username
+        Defaults to your username.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -650,7 +650,7 @@
             </command>
         </term>
         <listitem>Password of the MySQL user. Place it between "-chars. When
-        this is not set there is no password used
+        this is not set there is no password used.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -659,7 +659,7 @@
                 <option>mysql_db</option>
             </command>
         </term>
-        <listitem>MySQL database to use. Defaults to mysql
+        <listitem>MySQL database to use. Defaults to mysql.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -669,7 +669,7 @@
             </command>
         </term>
         <listitem>Music player thread update interval (defaults to Conky's
-        update interval)
+        update interval).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -678,7 +678,7 @@
                 <option>net_avg_samples</option>
             </command>
         </term>
-        <listitem>The number of samples to average for net data
+        <listitem>The number of samples to average for net data.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -687,7 +687,7 @@
                 <option>no_buffers</option>
             </command>
         </term>
-        <listitem>Subtract (file system) buffers from used memory?
+        <listitem>Subtract (file system) buffers from used memory.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -697,7 +697,7 @@
             </command>
         </term>
         <listitem>The display that the nvidia variable will use (defaults to
-        the value of the display variable)
+        the value of the display variable).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -715,7 +715,7 @@
                 <option>out_to_http</option>
             </command>
         </term>
-        <listitem>Let conky act as a small http-server serving it's text.
+        <listitem>Let conky act as a small http-server serving its text.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -726,7 +726,7 @@
         </term>
         <listitem>Print text in the console, but use ncurses so that conky can
         print the text of a new update over the old text. (In the future this
-        will provide more useful things)
+        will provide more useful things).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -747,7 +747,7 @@
         <listitem>When set to no, there will be no output in X (useful when
         you also use things like out_to_console). If you set it to no, make
         sure that it's placed before all other X-related setting (take the
-        first line of your configfile to be sure). Default value is yes
+        first line of your configfile to be sure). Default value is yes.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -756,7 +756,7 @@
                 <option>override_utf8_locale</option>
             </command>
         </term>
-        <listitem>Force UTF8? requires XFT
+        <listitem>Force UTF8. Requires XFT.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -774,7 +774,7 @@
                 <option>own_window</option>
             </command>
         </term>
-        <listitem>Boolean, create own window to draw?
+        <listitem>Boolean, create own window to draw.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -796,7 +796,7 @@
         <listitem>If own_window_transparent no, set a specified background
         colour (defaults to black). Takes either a hex value (e.g. '#ffffff'),
         a shorthand hex value (e.g. '#fff'), or a valid RGB name (see
-        /usr/lib/X11/rgb.txt)
+        /usr/lib/X11/rgb.txt).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -881,7 +881,7 @@
                 <option>pad_percents</option>
             </command>
         </term>
-        <listitem>Pad percentages to this many decimals (0 = no padding)
+        <listitem>Pad percentages to this many decimals (0 = no padding).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -931,7 +931,7 @@
                 <option>stippled_borders</option>
             </command>
         </term>
-        <listitem>Border stippling (dashing) in pixels
+        <listitem>Border stippling (dashing) in pixels.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -985,7 +985,7 @@
             </command>
         </term>
         <listitem>If true, variables that output times output a number that
-        represents seconds. This doesn't affect $time, $tztime and $utime
+        represents seconds. This doesn't affect $time, $tztime and $utime.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1026,7 +1026,7 @@
             </command>
         </term>
         <listitem>Total number of times for Conky to update before quitting.
-        Zero makes Conky run forever
+        Zero makes Conky run forever.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1036,7 +1036,7 @@
             </command>
             <option>seconds</option>
         </term>
-        <listitem>Update interval
+        <listitem>Update interval.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1046,7 +1046,7 @@
             </command>
             <option>seconds</option>
         </term>
-        <listitem>Update interval when running on batterypower
+        <listitem>Update interval when running on battery power.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1056,7 +1056,7 @@
             </command>
         </term>
         <listitem>One or more batteries to check in order to use
-        update_interval_on_battery (comma separated, BAT0 default)
+        update_interval_on_battery (comma separated, BAT0 default).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1065,7 +1065,7 @@
                 <option>uppercase</option>
             </command>
         </term>
-        <listitem>Boolean value, if true, text is rendered in upper case
+        <listitem>Boolean value, if true, text is rendered in upper case.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1087,7 +1087,7 @@
                 <option>use_xft</option>
             </command>
         </term>
-        <listitem>Use Xft (anti-aliased font and stuff)
+        <listitem>Use Xft (anti-aliased font and stuff).
         <para /></listitem>
     </varlistentry>
     <varlistentry>

--- a/doc/config_settings.xml
+++ b/doc/config_settings.xml
@@ -96,8 +96,8 @@
         </term>
         <listitem>A comma-separated list of strings to use as the bars of a
         graph output to console/shell. The first list item is used for the
-        minimum bar height and the last item is used for the maximum, e.g.
-        " ,_,=,#".
+        minimum bar height and the last item is used for the maximum, e.g. "
+        ,_,=,#".
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -796,7 +796,7 @@
         <listitem>If own_window_transparent no, set a specified background
         colour (defaults to black). Takes either a hex value (e.g. '#ffffff'),
         a shorthand hex value (e.g. '#fff'), or a valid RGB name (see
-        /usr/lib/X11/rgb.txt).
+        <filename>/usr/lib/X11/rgb.txt</filename>).
         <para /></listitem>
     </varlistentry>
     <varlistentry>

--- a/doc/conky-howto.xml
+++ b/doc/conky-howto.xml
@@ -1,143 +1,173 @@
-<?xml version='1.0' encoding="UTF-8"?>
+<?xml version='1.0' encoding="utf-8"?>
 <!DOCTYPE guide SYSTEM "http://www.gentoo.org/dtd/guide.dtd">
-
 <guide link="/doc/en/conky-howto.xml">
-<title>Gentoo Linux Conky Howto</title>
-
-<author title="Author">
-  <mail link="admin@sdesign.us">Bill Woodford</mail>
-</author>
-
-<author title="Editor">
-  <mail link="brenden@diddyinc.com">Brenden Matthews</mail>
-</author>
-
-<abstract>
-This document describes how to install and configure the system monitor known
-as Conky.
-</abstract>
-
-<!-- The content of this document is licensed under the CC-BY-SA license -->
-<!-- See http://creativecommons.org/licenses/by-sa/2.5 -->
-<license/>
-
-<version>1.0</version>
-<date>2006-02-22</date>
-
-<chapter>
-<title>Background</title>
-<section>
-<title>Introduction to Conky</title>
-<body>
-
-<p>
-So you have a Gentoo machine, and have already learned 30 different commands to monitor different aspects of what your computer is doing at the current moment.  What do you do from here?  Isn't there an easier way to monitor system performance and see what its doing, as well as the resources its using to perform all those tasks?  This is what a system monitor, such as Conky, provides.
-</p>
-
-</body>
-</section>
-<section>
-<title>What it does</title>
-<body>
-
-<p>
-Unlike other system monitors such as top, Conky can run as a window in an X session, or by drawing to the root window (there is also an option to have Conky display information to stdout, but we won't discuss that here).  It displays the information it has gathered through the use of both text, progress bars, and graphs.  Also unlike top, the way it is formatted is completely user-configurable.  In addition to monitoring the system itself, Conky can also give you information about several music players (such as XMMS, BMPx, Music Player Daemon, and Audacious Media Player), tell you how many new messages are in your mail spool, and plenty more.  If the functionality you require isn't in Conky yet, it is a simple matter of writing a script to get the information you would like - some examples of this, which have already been done are RSS feeds, POP3 e-mail message count, local weather, boinc status, and even the status of portage.
-</p>
-
-</body>
-</section>
-</chapter>
-<chapter>
-<title>Installing Conky</title>
-<section>
-<title>Base install</title>
-<body>
-
-<p>
-Gentoo provides an ebuild to quickly and easily install Conky.  Pay particular attention to the the USE flags.  You'll most likely want X11 support (<c>X</c>), and make sure you select the USE flags for any music players (other than MPD) which you want.  XMMS (<c>xmms</c>), Audacious (<c>audacious</c>), BMPx (<c>bmpx</c>), or XMMS support via the xmms-infopipe plugin (<c>infopipe</c>).
-</p>
-
-<pre caption="/etc/portage/package.use">
-<comment># Example line to append to /etc/portage/package.use if you don't want the default USE flags.</comment>
+    <title>Gentoo Linux Conky Howto</title>
+    <author title="Author">
+        <mail link="admin@sdesign.us">Bill Woodford</mail>
+    </author>
+    <author title="Editor">
+        <mail link="brenden@diddyinc.com">Brenden Matthews</mail>
+    </author>
+    <abstract>This document describes how to install and configure the system
+    monitor known as Conky.</abstract>
+    <!-- The content of this document is licensed under the CC-BY-SA license -->
+    <!-- See http://creativecommons.org/licenses/by-sa/2.5 -->
+    <license />
+    <version>1.0</version>
+    <date>2006-02-22</date>
+    <chapter>
+        <title>Background</title>
+        <section>
+            <title>Introduction to Conky</title>
+            <body>
+                <p>So you have a Gentoo machine, and have already learned 30
+                different commands to monitor different aspects of what your
+                computer is doing at the current moment. What do you do from
+                here? Isn't there an easier way to monitor system performance
+                and see what its doing, as well as the resources its using to
+                perform all those tasks? This is what a system monitor, such
+                as Conky, provides.</p>
+            </body>
+        </section>
+        <section>
+            <title>What it does</title>
+            <body>
+                <p>Unlike other system monitors such as top, Conky can run as
+                a window in an X session, or by drawing to the root window
+                (there is also an option to have Conky display information to
+                stdout, but we won't discuss that here). It displays the
+                information it has gathered through the use of both text,
+                progress bars, and graphs. Also unlike top, the way it is
+                formatted is completely user-configurable. In addition to
+                monitoring the system itself, Conky can also give you
+                information about several music players (such as XMMS, BMPx,
+                Music Player Daemon, and Audacious Media Player), tell you how
+                many new messages are in your mail spool, and plenty more. If
+                the functionality you require isn't in Conky yet, it is a
+                simple matter of writing a script to get the information you
+                would like - some examples of this, which have already been
+                done are RSS feeds, POP3 e-mail message count, local weather,
+                boinc status, and even the status of portage.</p>
+            </body>
+        </section>
+    </chapter>
+    <chapter>
+        <title>Installing Conky</title>
+        <section>
+            <title>Base install</title>
+            <body>
+                <p>Gentoo provides an ebuild to quickly and easily install
+                Conky. Pay particular attention to the the USE flags. You'll
+                most likely want X11 support (
+                <c>X</c>), and make sure you select the USE flags for any
+                music players (other than MPD) which you want. XMMS (
+                <c>xmms</c>), Audacious (
+                <c>audacious</c>), BMPx (
+                <c>bmpx</c>), or XMMS support via the xmms-infopipe plugin (
+                <c>infopipe</c>).</p>
+                <pre caption="/etc/portage/package.use">
+<comment># Example line to append to /etc/portage/package.use if you don't
+want the
+default USE flags.</comment>
 <i>app-admin/conky xmms infopipe -ipv6</i>
 </pre>
-
-<p>
-In addition, the <c>truetype</c> USE flag compiles support for TrueType fonts with the use of Xft.  Most users will want this as well.
-</p>
-
-<p>
-Once you have your USE flags correctly set up, it's time to install Conky!
-</p>
-
-<pre caption="Installing Conky">
+                <p>In addition, the
+                <c>truetype</c>USE flag compiles support for TrueType fonts
+                with the use of Xft. Most users will want this as well.</p>
+                <p>Once you have your USE flags correctly set up, it's time to
+                install Conky!</p>
+                <pre caption="Installing Conky">
 <i>emerge -av conky</i>
 </pre>
-
-<p>
-You can test Conky to see how it will look by running the command <c>conky</c> in a terminal.  This will likely give you a good reference to how it will look and what you want to change, add or even remove.
-</p>
-
-<pre caption="Running Conky for the first time">
-$ <i>conky</i>
+                <p>You can test Conky to see how it will look by running the
+                command
+                <c>conky</c>in a terminal. This will likely give you a good
+                reference to how it will look and what you want to change, add
+                or even remove.</p>
+                <pre caption="Running Conky for the first time">
+$
+<i>conky</i>
 </pre>
-
-<p>
-Once you have an idea of how Conky looks, you can now move on to configuring it!
-</p>
-
-
-</body>
-</section>
-<section>
-<title>Configuring Conky</title>
-<body>
-
-<p>
-By default, Conky will look for a configuration file in the users home directory located at <path>~/.config/conky/conky.conf</path>  This file contains all the configuration options, and the static text, colors and other variables which control what data is shown to the user.  Conky also provides a great sample configuration, located at <path>/usr/share/doc/conky-version/Conkyrc.sample.gz</path>  Make sure to replace "version" with the specific version of Conky you have installed.
-</p>
-
-<pre caption="Copying the sample configuration to your home directory">
-$ <i>mkdir -p ~/.config/conky</i>
-$ <i>zcat /usr/share/conky-1.6.0/conkyrc.sample.gz >> ~/.config/conky/conky.conf</i>
+                <p>Once you have an idea of how Conky looks, you can now move
+                on to configuring it!</p>
+            </body>
+        </section>
+        <section>
+            <title>Configuring Conky</title>
+            <body>
+                <p>By default, Conky will look for a configuration file in the
+                users home directory located at
+                <path>~/.config/conky/conky.conf</path>This file contains all
+                the configuration options, and the static text, colors and
+                other variables which control what data is shown to the user.
+                Conky also provides a great sample configuration, located at
+                <path>
+                /usr/share/doc/conky-version/Conkyrc.sample.gz</path>Make sure
+                to replace "version" with the specific version of Conky you
+                have installed.</p>
+                <pre caption="Copying the sample configuration to your home directory">
+$
+<i>mkdir -p ~/.config/conky</i>
+$
+<i>zcat /usr/share/conky-1.6.0/conkyrc.sample.gz &gt;&gt;
+~/.config/conky/conky.conf</i>
 </pre>
-
-<note>
-Make sure to replace "1.6.0" with the specific version of Conky you have installed.
-</note>
-
-<p>
-Now, open up the sample configuration in the text editor of your choice.  You may notice that there are two seperate sections of the configuration file.  The first section of the file, contains the programs configuration options and controls how it acts.  This includes things such as the <c>update_interval</c>, or how often Conky will update the information on the screen.  The second section contains the actual text, graphs, and variables which are rendered on the screen.  This includes things such as the system uptime (<c>$uptime</c>), cpu usage (<c>$cpu</c>) and anything else you want to be shown.  The first section of the file starts right from the beginning, the second section is comprised of everything after the line which says "<c>TEXT</c>".  Comments in the file start with <c>#</c>, but keep in mind that even if a line is commented out in the second section of the file, the text will still be rendered to the screen.
-</p>
-
-<p>
-Lists of all the available configuration options and variables are kept at <uri>http://conky.sourceforge.net/config_settings.html</uri> and <uri>http://conky.sourceforge.net/variables.html</uri>.  Also, there's a few great sample configurations and screenshots of working configurations at <uri>http://conky.sourceforge.net/screenshots.html</uri>.
-</p>
-
-</body>
-</section>
-</chapter>
-<chapter>
-<title>Extending Conky</title>
-<section>
-<title>Beyond the built-in variables</title>
-<body>
-
-<p>
-So you've gotten this far, and have scoured the Conky documentation for that extra variable which Conky just doesn't seem to have...  You're in luck!  Conky provides several variables for just this reason!  <c>$exec</c> Will run a command every time Conky updates, <c>$execi</c> will run a command at a specified interval and <c>$texeci</c> will run a command in it's own thread at a specified interval.
-</p>
-
-<pre caption="Scripting examples">
+                <note>Make sure to replace "1.6.0" with the specific version
+                of Conky you have installed.</note>
+                <p>Now, open up the sample configuration in the text editor of
+                your choice. You may notice that there are two seperate
+                sections of the configuration file. The first section of the
+                file, contains the programs configuration options and controls
+                how it acts. This includes things such as the
+                <c>update_interval</c>, or how often Conky will update the
+                information on the screen. The second section contains the
+                actual text, graphs, and variables which are rendered on the
+                screen. This includes things such as the system uptime (
+                <c>$uptime</c>), cpu usage (
+                <c>$cpu</c>) and anything else you want to be shown. The first
+                section of the file starts right from the beginning, the
+                second section is comprised of everything after the line which
+                says "
+                <c>TEXT</c>". Comments in the file start with
+                <c>#</c>, but keep in mind that even if a line is commented
+                out in the second section of the file, the text will still be
+                rendered to the screen.</p>
+                <p>Lists of all the available configuration options and
+                variables are kept at
+                <uri>
+                http://conky.sourceforge.net/config_settings.html</uri>and
+                <uri>http://conky.sourceforge.net/variables.html</uri>. Also,
+                there's a few great sample configurations and screenshots of
+                working configurations at
+                <uri>http://conky.sourceforge.net/screenshots.html</uri>.</p>
+            </body>
+        </section>
+    </chapter>
+    <chapter>
+        <title>Extending Conky</title>
+        <section>
+            <title>Beyond the built-in variables</title>
+            <body>
+                <p>So you've gotten this far, and have scoured the Conky
+                documentation for that extra variable which Conky just doesn't
+                seem to have... You're in luck! Conky provides several
+                variables for just this reason!
+                <c>$exec</c>Will run a command every time Conky updates,
+                <c>$execi</c>will run a command at a specified interval and
+                <c>$texeci</c>will run a command in it's own thread at a
+                specified interval.</p>
+                <pre caption="Scripting examples">
 <i>${exec grep 'sudo' /var/log/messages | tail -n 4}</i>
 <i>${execi 30 ~/scripts/emerge-status.sh</i>
 <i>${texeci 600 ~/scripts/gmail.pl}</i>
 </pre>
-
-<note>
-While any command which works in a command shell will work in any of these variables, it is important to keep in mind that the commands must exit.  This means that commands like <c>tail -f</c> which keep running will NOT work properly.
-</note>
-
-</body>
-</section>
-</chapter>
+                <note>While any command which works in a command shell will
+                work in any of these variables, it is important to keep in
+                mind that the commands must exit. This means that commands
+                like
+                <c>tail -f</c>which keep running will NOT work
+                properly.</note>
+            </body>
+        </section>
+    </chapter>
 </guide>

--- a/doc/docs.xml
+++ b/doc/docs.xml
@@ -180,24 +180,21 @@
         <variablelist>
             <varlistentry>
                 <term>
-                    <varname>conky</varname>
-                    <option>-t '${time %D %H:%M}' -o -u 30</option>
+                    <option>conky -t '${time %D %H:%M}' -o -u 30</option>
                 </term>
                 <listitem>Start Conky in its own window with date and clock as
                 text and 30 sec update interval.</listitem>
             </varlistentry>
             <varlistentry>
                 <term>
-                    <varname>conky</varname>
-                    <option>-a top_left -x 5 -y 500 -d</option>
+                    <option>conky -a top_left -x 5 -y 500 -d</option>
                 </term>
                 <listitem>Start Conky to background at coordinates (5,
                 500).</listitem>
             </varlistentry>
             <varlistentry>
                 <term>
-                    <varname>conky</varname>
-                    <option>-C &gt; ~/.config/conky/conky.conf</option>
+                    <option>conky -C &gt; ~/.config/conky/conky.conf</option>
                 </term>
                 <listitem>Do not start Conky, but have it output the builtin
                 default config file to ~/.config/conky/conky.conf for later

--- a/doc/docs.xml
+++ b/doc/docs.xml
@@ -8,303 +8,252 @@
 <!ENTITY lua SYSTEM "lua.xml">
 ]>
 <refentry>
-	<refentryinfo>
-		<address>
-			<email>brenden1@users.sourceforge.net</email>
-		</address>
-		<author>
-			<firstname>Brenden</firstname>
-			<surname>Matthews</surname>
-		</author>
-		<date>2012-05-03</date>
-	</refentryinfo>
-	<refmeta>
-		<refentrytitle>conky</refentrytitle>
-		<manvolnum>1</manvolnum>
-	</refmeta>
-	<refnamediv>
-		<refname>conky</refname>
-		<refpurpose>A system monitor for X originally based on the
-			torsmo code, but more kickass. It just keeps on given'er.
-			Yeah.</refpurpose>
-	</refnamediv>
-	<refsynopsisdiv>
-		<cmdsynopsis>
-			<command>conky</command>
-			<arg>
-				<replaceable>options</replaceable>
-			</arg>
-		</cmdsynopsis>
-	</refsynopsisdiv>
-	<refsect1>
-		<title>Description</title>
-		<para>Conky is a system monitor for X originally based on
-			torsmo. Since its inception, Conky has changed
-			significantly from its predecessor, while maintaining
-			simplicity and configurability. Conky can display just
-			about anything, either on your root desktop or in its own
-			window. Not only does Conky have many built-in objects, it
-			can also display just about any piece of information by
-			using scripts and other external programs.
-		</para>
-		<para>Conky has more than 250 built in objects, including
-			support for a plethora of OS stats (uname, uptime, CPU
-			usage, mem usage, disk usage, "top" like process stats, and
-			network monitoring, just to name a few), built in IMAP and
-			POP3 support, built in support for many popular music
-			players (MPD, XMMS2, BMPx, Audacious), and much much more.
-			Conky can display this info either as text, or using simple
-			progress bars and graph widgets, with different fonts and
-			colours.
-		</para>
-		<para>We are always looking for help, whether its reporting
-			bugs, writing patches, or writing docs. Please use the
-			facilities at SourceForge to make bug reports, feature
-			requests, and submit patches, or stop by #conky on
-			irc.freenode.net if you have questions or want to
-			contribute.</para>
-		<para>Thanks for your interest in Conky.
-		</para>
-	</refsect1>
-	<refsect1>
-		<title>Compiling</title>
-		<para>For users compiling from source on a binary distro, make sure you
-			have the X development libraries installed (Unless you configure
-			your build without X11). This should be a package along the lines
-			of "libx11-dev" or "xorg-x11-dev" for X11 libs, and similar "-dev"
-			format for the other libs required (depending on your build
-			options). You should be able to see which extra packages you need
-			to install by reading errors that you get from running `cmake'. The
-			easiest way to view the available build options is to run `ccmake' or
-			`cmake-gui' from the source tree, but be careful when disabling
-			certain features as you may lose desired functionality.  E.g.,
-			with BUILD_MATH disabled you won't get errors but logarithmic
-			graphs will be normal graphs and gauges will miss their line.
-		</para>
-		<para>Conky has (for some time) been available in the
-			repositories of most popular distributions. Here are some
-			installation instructions for a few:
-		</para>
-		<para>Gentoo users -- Conky is in Gentoo's Portage...
-			simply use "emerge app-admin/conky" for
-			installation.
-		</para>
-		<para>Debian, etc. users -- Conky should be in your
-			repositories, and can be installed by doing "aptitude
-			install conky".
-		</para>
-		<para>Example to compile and run Conky with default
-			components (note that some build options may differ for
-			your system):
-		</para>
-		<variablelist>
-			<varlistentry>
-				<term>
-					<command>
-						<option>cmake</option>
-					</command>
-					<option>-D CMAKE_INSTALL_PREFIX:string=/usr .</option>
-				</term>
-			</varlistentry>
-			<varlistentry>
-				<term>
-					<command>
-						<option>make</option>
-					</command>
-				</term>
-			</varlistentry>
-			<varlistentry>
-				<term>
-					<command>
-						<option>make install</option>
-					</command>
-					<option># Optional</option>
-				</term>
-			</varlistentry>
-			<varlistentry>
-				<term>
-					<command>
-						<option>src/conky</option>
-					</command>
-				</term>
-			</varlistentry>
-		</variablelist>
-		<para>Conky has been tested to be compatible with C99 C and C++0x C++,
-			however it has not been tested with anything other than gcc, and is
-			not guaranteed to work with other compilers.
-		</para>
-		<para>TIP: Try configuring Conky with `ccmake' or `cmake-gui' instead of
-			just `cmake'.
-		</para>
-		<para></para>
-	</refsect1>
-	<refsect1>
-		<title>You Should Know</title>
-		<para>Conky is generally very good on resources. That said,
-			the more you try to make Conky do, the more resources it is
-			going to consume.
-		</para>
-		<para>An easy way to force Conky to reload your ~/.config/conky/conky.conf:
-			"killall -SIGUSR1 conky". Saves you the trouble of having to kill
-			and then restart.
-		</para>
-	</refsect1>
-	<refsect1>
-		<title>Options</title>
-		<para>Command line options override configurations defined in
-			configuration file.
-		</para>
-		&command_options;
-	</refsect1>
-	<refsect1>
-		<title>Configuration Settings</title>
-		<para>Default configuration file location is $HOME/.config/conky/conky.conf or
-			${sysconfdir}/conky/conky.conf. On most systems, sysconfdir is
-			/etc, and you can find the sample config file there
-			(/etc/conky/conky.conf).
-		</para>
-		<para>You might want to copy it to $HOME/.config/conky/conky.conf and then
-			start modifying it. Other configs can be found at
-			http://conky.sf.net/
-		</para>
-		&config_settings;
-	</refsect1>
-	<refsect1>
-		<title>Objects/Variables</title>
-		<para>Colours are parsed using XParsecolor(), there might be a
-			list of them: /usr/share/X11/rgb.txt.
-			Colour can be also in
-			#rrggbb format (hex).
-		</para>
-		<para>
-			Some objects may create threads, and sometimes these threads will
-			not be destroyed until Conky terminates.  There is no way to
-			destroy or clean up threads while Conky is running.  For example,
-			if you use an MPD variable, the MPD thread will keep running until
-			Conky dies.  Some threaded objects will use one of the parameters
-			as a 'key', so that you only have 1 relevant thread running (for
-			example, the $curl, $rss and $weather objects launch one thread per
-			URI).
-		</para>
-		&variables;
-	</refsect1>
-	<refsect1>
-		<title>Lua API</title>
-		<para>Conky features a Lua Programming API, and also ships with Lua
-			bindings for some useful libraries. Note that the bindings require
-			tolua++, which currently only compiles against Lua 5.1.
-		</para>
-		<para>To use Lua Conky, you first need to make sure you have a version of Conky
-			with Lua support enabled (``conky -v'' will report this). Conky defines
-			certain global functions and variables which can be accessed from Lua
-			code running in Conky. Scripts must first be loaded using the lua_load
-			configuration option. You then call functions in Lua via Conky's $lua,
-			$lua_read, and Lua hooks.
-		</para>
-		<para>
-			Be careful when creating threaded objects through the Lua API.  You
-			could wind up with a whole bunch of threads running if a thread is
-			created with each iteration.
-		</para>
-		<para>
-			At this time, the Lua API should not be considered stable and may
-			change drastically from one release to another as it matures.
-		</para>
-		<para>
-			NOTE: In order to accommodate certain features in the cairo
-			library's API, Conky will export a few additional functions for the
-			creation of certain structures.  These are documented below.
-		</para>
-		&lua;
-	</refsect1>
-	<refsect1>
-		<title>Examples</title>
-		<variablelist>
-			<varlistentry>
-				<term>
-					<varname>conky</varname>
-					<option>-t '${time %D %H:%M}' -o -u 30</option>
-				</term>
-				<listitem>Start Conky in its own window with date
-					and clock as text and 30 sec update
-					interval.</listitem>
-			</varlistentry>
-			<varlistentry>
-				<term>
-					<varname>conky</varname>
-					<option>-a top_left -x 5 -y 500 -d</option>
-				</term>
-				<listitem>Start Conky to background at coordinates
-					(5, 500).</listitem>
-			</varlistentry>
-			<varlistentry>
-				<term>
-					<varname>conky</varname>
-					<option>-C &gt; ~/.config/conky/conky.conf</option>
-				</term>
-				<listitem>Do not start Conky, but have it output
-					the builtin default config file to
-					~/.config/conky/conky.conf for later customising.</listitem>
-			</varlistentry>
-		</variablelist>
-	</refsect1>
-	<refsect1>
-		<title>Files</title>
-		<variablelist>
-			<varlistentry>
-				<term>
-					<filename>
-						${sysconfdir}/conky/conky.conf</filename>
-				</term>
-				<listitem>Default system-wide configuration file.
-					The value of ${sysconfdir} depends on the
-					compile-time options (most likely /etc).</listitem>
-			</varlistentry>
-			<varlistentry>
-				<term>
-					<filename>~/.config/conky/conky.conf</filename>
-				</term>
-				<listitem>Default personal configuration
-					file.</listitem>
-			</varlistentry>
-		</variablelist>
-	</refsect1>
-	<refsect1>
-		<title>Bugs</title>
-		<para>Drawing to root or some other desktop window directly
-			doesn't work with all window managers. Especially doesn't
-			work well with Gnome and it has been reported that it
-			doesn't work with KDE either. Nautilus can be disabled from
-			drawing to desktop with program gconf-editor. Uncheck
-			show_desktop in /apps/nautilus/preferences/. There is -w
-			switch in Conky to set some specific window id. You might
-			find xwininfo -tree useful to find the window to draw to.
-			You can also use -o argument which makes Conky to create
-			its own window. If you do try running Conky in its own
-			window, be sure to read up on the own_window_type settings
-			and experiment.</para>
-	</refsect1>
-	<refsect1>
-		<title>See Also</title>
-		<para>
-			<ulink url="https://github.com/brndnmtthws/conky">
-				https://github.com/brndnmtthws/conky</ulink>
-		</para>
-		<para>#conky on irc.freenode.net</para>
-	</refsect1>
-	<refsect1>
-		<title>Copying</title>
-		<para>Copyright (c) 2005-2018 Brenden Matthews, Philip
-			Kovacs, et. al. Any original torsmo code is licensed under
-			the BSD license (see LICENSE.BSD for a copy). All code
-			written since the fork of torsmo is licensed under the GPL
-			(see LICENSE.GPL for a copy), except where noted
-			differently (such as in portmon and audacious code which are LGPL, and
-			prss which is an MIT-style license).</para>
-	</refsect1>
-	<refsect1>
-		<title>Authors</title>
-		<para>The Conky dev team (see AUTHORS for a full list of
-			contributors).</para>
-	</refsect1>
+    <refentryinfo>
+        <address>
+            <email>brenden1@users.sourceforge.net</email>
+        </address>
+        <author>
+            <firstname>Brenden</firstname>
+            <surname>Matthews</surname>
+        </author>
+        <date>2012-05-03</date>
+    </refentryinfo>
+    <refmeta>
+        <refentrytitle>conky</refentrytitle>
+        <manvolnum>1</manvolnum>
+    </refmeta>
+    <refnamediv>
+        <refname>conky</refname>
+        <refpurpose>A system monitor for X originally based on the torsmo
+        code, but more kickass. It just keeps on given'er. Yeah.</refpurpose>
+    </refnamediv>
+    <refsynopsisdiv>
+        <cmdsynopsis>
+            <command>conky</command>
+            <arg>
+                <replaceable>options</replaceable>
+            </arg>
+        </cmdsynopsis>
+    </refsynopsisdiv>
+    <refsect1>
+        <title>Description</title>
+        <para>Conky is a system monitor for X originally based on torsmo.
+        Since its inception, Conky has changed significantly from its
+        predecessor, while maintaining simplicity and configurability. Conky
+        can display just about anything, either on your root desktop or in its
+        own window. Not only does Conky have many built-in objects, it can
+        also display just about any piece of information by using scripts and
+        other external programs.</para>
+        <para>Conky has more than 250 built in objects, including support for
+        a plethora of OS stats (uname, uptime, CPU usage, mem usage, disk
+        usage, "top" like process stats, and network monitoring, just to name
+        a few), built in IMAP and POP3 support, built in support for many
+        popular music players (MPD, XMMS2, BMPx, Audacious), and much much
+        more. Conky can display this info either as text, or using simple
+        progress bars and graph widgets, with different fonts and
+        colours.</para>
+        <para>We are always looking for help, whether its reporting bugs,
+        writing patches, or writing docs. Please use the facilities at
+        SourceForge to make bug reports, feature requests, and submit patches,
+        or stop by #conky on irc.freenode.net if you have questions or want to
+        contribute.</para>
+        <para>Thanks for your interest in Conky.</para>
+    </refsect1>
+    <refsect1>
+        <title>Compiling</title>
+        <para>For users compiling from source on a binary distro, make sure
+        you have the X development libraries installed (Unless you configure
+        your build without X11). This should be a package along the lines of
+        "libx11-dev" or "xorg-x11-dev" for X11 libs, and similar "-dev" format
+        for the other libs required (depending on your build options). You
+        should be able to see which extra packages you need to install by
+        reading errors that you get from running `cmake'. The easiest way to
+        view the available build options is to run `ccmake' or `cmake-gui'
+        from the source tree, but be careful when disabling certain features
+        as you may lose desired functionality. E.g., with BUILD_MATH disabled
+        you won't get errors but logarithmic graphs will be normal graphs and
+        gauges will miss their line.</para>
+        <para>Conky has (for some time) been available in the repositories of
+        most popular distributions. Here are some installation instructions
+        for a few:</para>
+        <para>Gentoo users -- Conky is in Gentoo's Portage... simply use
+        "emerge app-admin/conky" for installation.</para>
+        <para>Debian, etc. users -- Conky should be in your repositories, and
+        can be installed by doing "aptitude install conky".</para>
+        <para>Example to compile and run Conky with default components (note
+        that some build options may differ for your system):</para>
+        <variablelist>
+            <varlistentry>
+                <term>
+                    <command>
+                        <option>cmake</option>
+                    </command>
+                    <option>-D CMAKE_INSTALL_PREFIX:string=/usr .</option>
+                </term>
+            </varlistentry>
+            <varlistentry>
+                <term>
+                    <command>
+                        <option>make</option>
+                    </command>
+                </term>
+            </varlistentry>
+            <varlistentry>
+                <term>
+                    <command>
+                        <option>make install</option>
+                    </command>
+                    <option># Optional</option>
+                </term>
+            </varlistentry>
+            <varlistentry>
+                <term>
+                    <command>
+                        <option>src/conky</option>
+                    </command>
+                </term>
+            </varlistentry>
+        </variablelist>
+        <para>Conky has been tested to be compatible with C99 C and C++0x C++,
+        however it has not been tested with anything other than gcc, and is
+        not guaranteed to work with other compilers.</para>
+        <para>TIP: Try configuring Conky with `ccmake' or `cmake-gui' instead
+        of just `cmake'.</para>
+        <para></para>
+    </refsect1>
+    <refsect1>
+        <title>You Should Know</title>
+        <para>Conky is generally very good on resources. That said, the more
+        you try to make Conky do, the more resources it is going to
+        consume.</para>
+        <para>An easy way to force Conky to reload your
+        ~/.config/conky/conky.conf: "killall -SIGUSR1 conky". Saves you the
+        trouble of having to kill and then restart.</para>
+    </refsect1>
+    <refsect1>
+    <title>Options</title>
+    <para>Command line options override configurations defined in
+    configuration file.</para>&command_options;</refsect1>
+    <refsect1>
+    <title>Configuration Settings</title>
+    <para>Default configuration file location is
+    $HOME/.config/conky/conky.conf or ${sysconfdir}/conky/conky.conf. On most
+    systems, sysconfdir is /etc, and you can find the sample config file there
+    (/etc/conky/conky.conf).</para>
+    <para>You might want to copy it to $HOME/.config/conky/conky.conf and then
+    start modifying it. Other configs can be found at
+    http://conky.sf.net/</para>&config_settings;</refsect1>
+    <refsect1>
+    <title>Objects/Variables</title>
+    <para>Colours are parsed using XParsecolor(), there might be a list of
+    them: /usr/share/X11/rgb.txt. Colour can be also in #rrggbb format
+    (hex).</para>
+    <para>Some objects may create threads, and sometimes these threads will
+    not be destroyed until Conky terminates. There is no way to destroy or
+    clean up threads while Conky is running. For example, if you use an MPD
+    variable, the MPD thread will keep running until Conky dies. Some threaded
+    objects will use one of the parameters as a 'key', so that you only have 1
+    relevant thread running (for example, the $curl, $rss and $weather objects
+    launch one thread per URI).</para>&variables;</refsect1>
+    <refsect1>
+    <title>Lua API</title>
+    <para>Conky features a Lua Programming API, and also ships with Lua
+    bindings for some useful libraries. Note that the bindings require
+    tolua++, which currently only compiles against Lua 5.1.</para>
+    <para>To use Lua Conky, you first need to make sure you have a version of
+    Conky with Lua support enabled (``conky -v'' will report this). Conky
+    defines certain global functions and variables which can be accessed from
+    Lua code running in Conky. Scripts must first be loaded using the lua_load
+    configuration option. You then call functions in Lua via Conky's $lua,
+    $lua_read, and Lua hooks.</para>
+    <para>Be careful when creating threaded objects through the Lua API. You
+    could wind up with a whole bunch of threads running if a thread is created
+    with each iteration.</para>
+    <para>At this time, the Lua API should not be considered stable and may
+    change drastically from one release to another as it matures.</para>
+    <para>NOTE: In order to accommodate certain features in the cairo
+    library's API, Conky will export a few additional functions for the
+    creation of certain structures. These are documented
+    below.</para>&lua;</refsect1>
+    <refsect1>
+        <title>Examples</title>
+        <variablelist>
+            <varlistentry>
+                <term>
+                    <varname>conky</varname>
+                    <option>-t '${time %D %H:%M}' -o -u 30</option>
+                </term>
+                <listitem>Start Conky in its own window with date and clock as
+                text and 30 sec update interval.</listitem>
+            </varlistentry>
+            <varlistentry>
+                <term>
+                    <varname>conky</varname>
+                    <option>-a top_left -x 5 -y 500 -d</option>
+                </term>
+                <listitem>Start Conky to background at coordinates (5,
+                500).</listitem>
+            </varlistentry>
+            <varlistentry>
+                <term>
+                    <varname>conky</varname>
+                    <option>-C &gt; ~/.config/conky/conky.conf</option>
+                </term>
+                <listitem>Do not start Conky, but have it output the builtin
+                default config file to ~/.config/conky/conky.conf for later
+                customising.</listitem>
+            </varlistentry>
+        </variablelist>
+    </refsect1>
+    <refsect1>
+        <title>Files</title>
+        <variablelist>
+            <varlistentry>
+                <term>
+                    <filename>${sysconfdir}/conky/conky.conf</filename>
+                </term>
+                <listitem>Default system-wide configuration file. The value of
+                ${sysconfdir} depends on the compile-time options (most likely
+                /etc).</listitem>
+            </varlistentry>
+            <varlistentry>
+                <term>
+                    <filename>~/.config/conky/conky.conf</filename>
+                </term>
+                <listitem>Default personal configuration file.</listitem>
+            </varlistentry>
+        </variablelist>
+    </refsect1>
+    <refsect1>
+        <title>Bugs</title>
+        <para>Drawing to root or some other desktop window directly doesn't
+        work with all window managers. Especially doesn't work well with Gnome
+        and it has been reported that it doesn't work with KDE either.
+        Nautilus can be disabled from drawing to desktop with program
+        gconf-editor. Uncheck show_desktop in /apps/nautilus/preferences/.
+        There is -w switch in Conky to set some specific window id. You might
+        find xwininfo -tree useful to find the window to draw to. You can also
+        use -o argument which makes Conky to create its own window. If you do
+        try running Conky in its own window, be sure to read up on the
+        own_window_type settings and experiment.</para>
+    </refsect1>
+    <refsect1>
+        <title>See Also</title>
+        <para>https://github.com/brndnmtthws/conky</para>
+        <para>#conky on irc.freenode.net</para>
+    </refsect1>
+    <refsect1>
+        <title>Copying</title>
+        <para>Copyright (c) 2005-2018 Brenden Matthews, Philip Kovacs, et. al.
+        Any original torsmo code is licensed under the BSD license (see
+        LICENSE.BSD for a copy). All code written since the fork of torsmo is
+        licensed under the GPL (see LICENSE.GPL for a copy), except where
+        noted differently (such as in portmon and audacious code which are
+        LGPL, and prss which is an MIT-style license).</para>
+    </refsect1>
+    <refsect1>
+        <title>Authors</title>
+        <para>The Conky dev team (see AUTHORS for a full list of
+        contributors).</para>
+    </refsect1>
 </refentry>

--- a/doc/docs.xml
+++ b/doc/docs.xml
@@ -127,8 +127,9 @@
         you try to make Conky do, the more resources it is going to
         consume.</para>
         <para>An easy way to force Conky to reload your
-        ~/.config/conky/conky.conf: "killall -SIGUSR1 conky". Saves you the
-        trouble of having to kill and then restart.</para>
+        <filename>~/.config/conky/conky.conf</filename>: "killall -SIGUSR1
+        conky". Saves you the trouble of having to kill and then
+        restart.</para>
     </refsect1>
     <refsect1>
     <title>Options</title>
@@ -137,17 +138,21 @@
     <refsect1>
     <title>Configuration Settings</title>
     <para>Default configuration file location is
-    $HOME/.config/conky/conky.conf or ${sysconfdir}/conky/conky.conf. On most
-    systems, sysconfdir is /etc, and you can find the sample config file there
-    (/etc/conky/conky.conf).</para>
-    <para>You might want to copy it to $HOME/.config/conky/conky.conf and then
-    start modifying it. Other configs can be found at
-    http://conky.sf.net/</para>&config_settings;</refsect1>
+    <filename>~/.config/conky/conky.conf</filename>&#160;or
+    <filename>${sysconfdir}/conky/conky.conf</filename>. On most systems,
+    sysconfdir is /etc, and you can find the sample config file there in
+    <filename>/etc/conky/conky.conf</filename>.</para>
+    <para>You might want to copy it to
+    <filename>~/.config/conky/conky.conf</filename>&#160;and then start modifying
+    it. Other configs can be found at
+    <filename>
+    https://github.com/brndnmtthws/conky</filename>.</para>&config_settings;</refsect1>
     <refsect1>
     <title>Objects/Variables</title>
     <para>Colours are parsed using XParsecolor(), there might be a list of
-    them: /usr/share/X11/rgb.txt. Colour can be also in #rrggbb format
-    (hex).</para>
+    them:
+    <filename>/usr/share/X11/rgb.txt</filename>. Colour can be also in #rrggbb
+    format (hex).</para>
     <para>Some objects may create threads, and sometimes these threads will
     not be destroyed until Conky terminates. There is no way to destroy or
     clean up threads while Conky is running. For example, if you use an MPD
@@ -197,7 +202,8 @@
                     <option>conky -C &gt; ~/.config/conky/conky.conf</option>
                 </term>
                 <listitem>Do not start Conky, but have it output the builtin
-                default config file to ~/.config/conky/conky.conf for later
+                default config file to
+                <filename>~/.config/conky/conky.conf</filename>&#160;for later
                 customising.</listitem>
             </varlistentry>
         </variablelist>
@@ -236,7 +242,9 @@
     </refsect1>
     <refsect1>
         <title>See Also</title>
-        <para>https://github.com/brndnmtthws/conky</para>
+        <para>
+            <filename>https://github.com/brndnmtthws/conky</filename>
+        </para>
         <para>#conky on irc.freenode.net</para>
     </refsect1>
     <refsect1>

--- a/doc/lua.xml
+++ b/doc/lua.xml
@@ -7,9 +7,9 @@
             <option>function</option>
         </term>
         <listitem>
-            <para>This function takes a string that is evaluated as
-            per Conky's TEXT section, and then returns a string
-            with the result.</para>
+            <para>This function takes a string that is evaluated as per
+            Conky's TEXT section, and then returns a string with the
+            result.</para>
         </listitem>
     </varlistentry>
     <varlistentry>
@@ -32,26 +32,23 @@
             <option>table</option>
         </term>
         <listitem>
-            <para>This table contains some information about
-            Conky's window. The following table describes the
-            values contained:</para>
+            <para>This table contains some information about Conky's window.
+            The following table describes the values contained:</para>
             <simplelist>
                 <member>
                     <command>drawable</command>
-                    <option>Window's drawable (Xlib Drawable),
-                    requires Lua extras enabled at compile
-                    time.</option>
+                    <option>Window's drawable (Xlib Drawable), requires Lua
+                    extras enabled at compile time.</option>
                 </member>
                 <member>
                     <command>visual</command>
-                    <option>Window's visual (Xlib Visual), requires
-                    Lua extras enabled at compile time.</option>
+                    <option>Window's visual (Xlib Visual), requires Lua extras
+                    enabled at compile time.</option>
                 </member>
                 <member>
                     <command>display</command>
-                    <option>Window's display (Xlib Display),
-                    requires Lua extras enabled at compile
-                    time.</option>
+                    <option>Window's display (Xlib Display), requires Lua
+                    extras enabled at compile time.</option>
                 </member>
                 <member>
                     <command>width</command>
@@ -63,42 +60,37 @@
                 </member>
                 <member>
                     <command>border_inner_margin</command>
-                    <option>Window's inner border margin (in
-                    pixels).</option>
+                    <option>Window's inner border margin (in pixels).</option>
                 </member>
                 <member>
                     <command>border_outer_margin</command>
-                    <option>Window's outer border margin (in
-                    pixels).</option>
+                    <option>Window's outer border margin (in pixels).</option>
                 </member>
                 <member>
                     <command>border_width</command>
-                    <option>Window's border width (in
-                    pixels).</option>
+                    <option>Window's border width (in pixels).</option>
                 </member>
                 <member>
                     <command>text_start_x</command>
-                    <option>The x component of the starting
-                    coordinate of text drawing.</option>
+                    <option>The x component of the starting coordinate of text
+                    drawing.</option>
                 </member>
                 <member>
                     <command>text_start_y</command>
-                    <option>The y component of the starting
-                    coordinate of text drawing.</option>
+                    <option>The y component of the starting coordinate of text
+                    drawing.</option>
                 </member>
                 <member>
                     <command>text_width</command>
-                    <option>The width of the text drawing
-                    region.</option>
+                    <option>The width of the text drawing region.</option>
                 </member>
                 <member>
                     <command>text_height</command>
-                    <option>The height of the text drawing
-                    region.</option>
+                    <option>The height of the text drawing region.</option>
                 </member>
             </simplelist>
-            <para>NOTE: This table is only defined when X support
-            is enabled.</para>
+            <para>NOTE: This table is only defined when X support is
+            enabled.</para>
         </listitem>
     </varlistentry>
     <varlistentry>
@@ -109,14 +101,12 @@
             <option>table</option>
         </term>
         <listitem>
-            <para>This table contains some information about
-            Conky's internal data. The following table describes
-            the values contained:</para>
+            <para>This table contains some information about Conky's internal
+            data. The following table describes the values contained:</para>
             <simplelist>
                 <member>
                     <command>update_interval</command>
-                    <option>Conky's update interval (in
-                    seconds).</option>
+                    <option>Conky's update interval (in seconds).</option>
                 </member>
             </simplelist>
         </listitem>
@@ -129,9 +119,9 @@
             <option>string</option>
         </term>
         <listitem>
-            <para>A string containing the build info for this
-            particular instance of Conky, including the version,
-            build date, and architecture.</para>
+            <para>A string containing the build info for this particular
+            instance of Conky, including the version, build date, and
+            architecture.</para>
         </listitem>
     </varlistentry>
     <varlistentry>
@@ -142,8 +132,8 @@
             <option>string</option>
         </term>
         <listitem>
-            <para>A string containing the build date for this
-            particular instance of Conky.</para>
+            <para>A string containing the build date for this particular
+            instance of Conky.</para>
         </listitem>
     </varlistentry>
     <varlistentry>
@@ -154,8 +144,8 @@
             <option>string</option>
         </term>
         <listitem>
-            <para>A string containing the build architecture for
-            this particular instance of Conky.</para>
+            <para>A string containing the build architecture for this
+            particular instance of Conky.</para>
         </listitem>
     </varlistentry>
     <varlistentry>
@@ -166,8 +156,8 @@
             <option>string</option>
         </term>
         <listitem>
-            <para>A string containing the version of the current
-            instance of Conky.</para>
+            <para>A string containing the version of the current instance of
+            Conky.</para>
         </listitem>
     </varlistentry>
     <varlistentry>
@@ -190,12 +180,11 @@
             <option>function</option>
         </term>
         <listitem>
-            <para>Call this function to return a new
-            cairo_text_extents_t structure. A creation function for
-            this structure is not provided by the cairo API. After
-            calling this, you should use tolua.takeownership() on
-            the return value to ensure ownership is passed
-            properly.</para>
+            <para>Call this function to return a new cairo_text_extents_t
+            structure. A creation function for this structure is not provided
+            by the cairo API. After calling this, you should use
+            tolua.takeownership() on the return value to ensure ownership is
+            passed properly.</para>
         </listitem>
     </varlistentry>
     <varlistentry>
@@ -206,12 +195,11 @@
             <option>function</option>
         </term>
         <listitem>
-            <para>Call this function to return a new
-            cairo_font_extents_t structure. A creation function for
-            this structure is not provided by the cairo API. After
-            calling this, you should use tolua.takeownership() on
-            the return value to ensure ownership is passed
-            properly.</para>
+            <para>Call this function to return a new cairo_font_extents_t
+            structure. A creation function for this structure is not provided
+            by the cairo API. After calling this, you should use
+            tolua.takeownership() on the return value to ensure ownership is
+            passed properly.</para>
         </listitem>
     </varlistentry>
     <varlistentry>
@@ -222,18 +210,17 @@
             <option>function</option>
         </term>
         <listitem>
-            <para>Call this function to return a new cairo_matrix_t
-            structure. A creation function for this structure is
-            not provided by the cairo API. After calling this, you
-            should use tolua.takeownership() on the return value to
-            ensure ownership is passed properly.</para>
+            <para>Call this function to return a new cairo_matrix_t structure.
+            A creation function for this structure is not provided by the
+            cairo API. After calling this, you should use
+            tolua.takeownership() on the return value to ensure ownership is
+            passed properly.</para>
         </listitem>
     </varlistentry>
     <varlistentry>
         <term>
             <command>
-                <option>
-                cairo_text_extents_t:destroy(structure)</option>
+                <option>cairo_text_extents_t:destroy(structure)</option>
             </command>
             <option>function</option>
         </term>
@@ -245,8 +232,7 @@
     <varlistentry>
         <term>
             <command>
-                <option>
-                cairo_font_extents_t:destroy(structure)</option>
+                <option>cairo_font_extents_t:destroy(structure)</option>
             </command>
             <option>function</option>
         </term>

--- a/doc/variables.xml
+++ b/doc/variables.xml
@@ -18,7 +18,7 @@
                 <option>acpifan</option>
             </command>
         </term>
-        <listitem>ACPI fan state
+        <listitem>ACPI fan state.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -58,7 +58,7 @@
                 <option>adt746xcpu</option>
             </command>
         </term>
-        <listitem>CPU temperature from therm_adt746x
+        <listitem>CPU temperature from therm_adt746x.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -67,7 +67,7 @@
                 <option>adt746xfan</option>
             </command>
         </term>
-        <listitem>Fan speed from therm_adt746x
+        <listitem>Fan speed from therm_adt746x.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -77,7 +77,7 @@
             </command>
             <option>(num)</option>
         </term>
-        <listitem>Align text to centre
+        <listitem>Align text to centre.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -87,7 +87,7 @@
             </command>
             <option>(num)</option>
         </term>
-        <listitem>Right-justify text, with space of N
+        <listitem>Right-justify text, with space of N.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -99,7 +99,7 @@
             <option>port</option>
         </term>
         <listitem>Sets up the connection to apcupsd daemon. Prints nothing,
-        defaults to localhost:3551
+        defaults to localhost:3551.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -237,7 +237,7 @@
                 <option>apm_adapter</option>
             </command>
         </term>
-        <listitem>Display APM AC adapter status (FreeBSD, OpenBSD only)
+        <listitem>Display APM AC adapter status. FreeBSD, OpenBSD only.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -246,7 +246,7 @@
                 <option>apm_battery_life</option>
             </command>
         </term>
-        <listitem>Display APM battery life in percent (FreeBSD, OpenBSD only)
+        <listitem>Display APM battery life in percent. FreeBSD, OpenBSD only.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -256,7 +256,7 @@
             </command>
         </term>
         <listitem>Display remaining APM battery life in hh:mm:ss or "unknown"
-        if AC adapterstatus is on-line or charging (FreeBSD, OpenBSD only)
+        if AC adapterstatus is on-line or charging. FreeBSD, OpenBSD only.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -266,7 +266,7 @@
             </command>
             <option>(height),(width)</option>
         </term>
-        <listitem>Progress bar
+        <listitem>Progress bar.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -275,7 +275,7 @@
                 <option>audacious_bitrate</option>
             </command>
         </term>
-        <listitem>Bitrate of current tune
+        <listitem>Bitrate of current tune.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -284,7 +284,7 @@
                 <option>audacious_channels</option>
             </command>
         </term>
-        <listitem>Number of audio channels of current tune
+        <listitem>Number of audio channels of current tune.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -293,7 +293,7 @@
                 <option>audacious_filename</option>
             </command>
         </term>
-        <listitem>Full path and filename of current tune
+        <listitem>Full path and filename of current tune.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -302,7 +302,7 @@
                 <option>audacious_frequency</option>
             </command>
         </term>
-        <listitem>Sampling frequency of current tune
+        <listitem>Sampling frequency of current tune.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -311,7 +311,7 @@
                 <option>audacious_length</option>
             </command>
         </term>
-        <listitem>Total length of current tune as MM:SS
+        <listitem>Total length of current tune as MM:SS.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -320,7 +320,7 @@
                 <option>audacious_length_seconds</option>
             </command>
         </term>
-        <listitem>Total length of current tune in seconds
+        <listitem>Total length of current tune in seconds.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -329,7 +329,7 @@
                 <option>audacious_main_volume</option>
             </command>
         </term>
-        <listitem>The current volume fetched from Audacious
+        <listitem>The current volume fetched from Audacious.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -338,7 +338,7 @@
                 <option>audacious_playlist_length</option>
             </command>
         </term>
-        <listitem>Number of tunes in playlist
+        <listitem>Number of tunes in playlist.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -347,7 +347,7 @@
                 <option>audacious_playlist_position</option>
             </command>
         </term>
-        <listitem>Playlist position of current tune
+        <listitem>Playlist position of current tune.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -356,7 +356,7 @@
                 <option>audacious_position</option>
             </command>
         </term>
-        <listitem>Position of current tune (MM:SS)
+        <listitem>Position of current tune (MM:SS).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -365,7 +365,7 @@
                 <option>audacious_position_seconds</option>
             </command>
         </term>
-        <listitem>Position of current tune in seconds
+        <listitem>Position of current tune in seconds.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -374,7 +374,7 @@
                 <option>audacious_status</option>
             </command>
         </term>
-        <listitem>Player status (Playing/Paused/Stopped/Not running)
+        <listitem>Player status (Playing/Paused/Stopped/Not running).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -384,7 +384,7 @@
             </command>
             <option>(max length)</option>
         </term>
-        <listitem>Title of current tune with optional maximum length specifier
+        <listitem>Title of current tune with optional maximum length specifier.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -475,7 +475,7 @@
                 <option>bmpx_album</option>
             </command>
         </term>
-        <listitem>Album in current BMPx track
+        <listitem>Album in current BMPx track.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -484,7 +484,7 @@
                 <option>bmpx_artist</option>
             </command>
         </term>
-        <listitem>Artist in current BMPx track
+        <listitem>Artist in current BMPx track.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -493,7 +493,7 @@
                 <option>bmpx_bitrate</option>
             </command>
         </term>
-        <listitem>Bitrate of the current BMPx track
+        <listitem>Bitrate of the current BMPx track.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -502,7 +502,7 @@
                 <option>bmpx_title</option>
             </command>
         </term>
-        <listitem>Title of the current BMPx track
+        <listitem>Title of the current BMPx track.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -511,7 +511,7 @@
                 <option>bmpx_track</option>
             </command>
         </term>
-        <listitem>Track number of the current BMPx track
+        <listitem>Track number of the current BMPx track.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -520,7 +520,7 @@
                 <option>bmpx_uri</option>
             </command>
         </term>
-        <listitem>URI of the current BMPx track
+        <listitem>URI of the current BMPx track.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -529,7 +529,7 @@
                 <option>buffers</option>
             </command>
         </term>
-        <listitem>Amount of memory buffered
+        <listitem>Amount of memory buffered.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -538,7 +538,7 @@
                 <option>cached</option>
             </command>
         </term>
-        <listitem>Amount of memory cached
+        <listitem>Amount of memory cached.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -574,7 +574,7 @@
             </command>
             <option>string</option>
         </term>
-        <listitem>PID of the first process that has string in it's commandline
+        <listitem>PID of the first process that has string in its commandline.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -619,7 +619,7 @@
                 <option>cmus_file</option>
             </command>
         </term>
-        <listitem>Print the file name of the current cmus song
+        <listitem>Print the file name of the current cmus song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -628,7 +628,7 @@
                 <option>cmus_date</option>
             </command>
         </term>
-        <listitem>Print the date of the current cmus song
+        <listitem>Print the date of the current cmus song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -637,7 +637,7 @@
                 <option>cmus_genre</option>
             </command>
         </term>
-        <listitem>Print the genre name of the current cmus song
+        <listitem>Print the genre name of the current cmus song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -730,9 +730,9 @@
             <option>(color)</option>
         </term>
         <listitem>Change drawing color to 'color' which is a name of a color
-        or a hexcode preceded with # (for example #0A1B2C ). If you use
-        ncurses only the following colors are supported:
-        red,green,yellow,blue,magenta,cyan,black,white.
+        or a hexcode preceded with #, e.g. #0A1B2C. If you use ncurses only the
+        following colors are supported: red, green, yellow, blue, magenta,
+        cyan, black, and white.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -766,7 +766,7 @@
                 <option>conky_build_arch</option>
             </command>
         </term>
-        <listitem>CPU architecture Conky was built for
+        <listitem>CPU architecture Conky was built for.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -775,7 +775,7 @@
                 <option>conky_build_date</option>
             </command>
         </term>
-        <listitem>Date Conky was built
+        <listitem>Date Conky was built.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -784,7 +784,7 @@
                 <option>conky_version</option>
             </command>
         </term>
-        <listitem>Conky version
+        <listitem>Conky version.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -996,7 +996,7 @@
             </command>
             <option>(net)</option>
         </term>
-        <listitem>Download speed in suitable IEC units
+        <listitem>Download speed in suitable IEC units.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1006,7 +1006,7 @@
             </command>
             <option>(net)</option>
         </term>
-        <listitem>Download speed in KiB with one decimal
+        <listitem>Download speed in KiB with one decimal.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1044,7 +1044,7 @@
                 <option>else</option>
             </command>
         </term>
-        <listitem>Text to show if any of the above are not true
+        <listitem>Text to show if any of the above are not true.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1063,7 +1063,7 @@
                 <option>entropy_avail</option>
             </command>
         </term>
-        <listitem>Current entropy available for crypto freaks
+        <listitem>Current entropy available for crypto freaks.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1073,7 +1073,7 @@
             </command>
             <option>(height),(width)</option>
         </term>
-        <listitem>Normalized bar of available entropy for crypto freaks
+        <listitem>Normalized bar of available entropy for crypto freaks.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1083,7 +1083,7 @@
             </command>
         </term>
         <listitem>Percentage of entropy available in comparison to the
-        poolsize
+        poolsize.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1092,7 +1092,7 @@
                 <option>entropy_poolsize</option>
             </command>
         </term>
-        <listitem>Total size of system entropy pool for crypto freaks
+        <listitem>Total size of system entropy pool for crypto freaks.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1315,7 +1315,7 @@
         </term>
         <listitem>Specify a different font. This new font will apply to the
         current line and everything following. You can use a $font with no
-        arguments to change back to the default font (much like with $color)
+        arguments to change back to the default font (much like with $color).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1346,7 +1346,7 @@
         numbers behind the point by using \S followed by a number that
         specifies the amount of digits behind the point that you want to see
         (maximum 9). You can also place a 'x' behind \S so you have all digits
-        behind the point and no trailing zero's. (also maximum 9)
+        behind the point and no trailing zero's. (also maximum 9).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1550,7 +1550,7 @@
             </command>
             <option>(height)</option>
         </term>
-        <listitem>Horizontal line, height is the height in pixels
+        <listitem>Horizontal line, height is the height in pixels.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1781,7 +1781,7 @@
         file 'file'. The events are first ordered by starting time, events
         that started in the past are ignored. The events that are shown are
         the VEVENTS, the title that is shown is the SUMMARY and the starting
-        time used for sorting is DTSTART .
+        time used for sorting is DTSTART.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1826,7 +1826,7 @@
             <option>(var)</option>
         </term>
         <listitem>if conky variable VAR is empty, display everything between
-        $if_empty and the matching $endif
+        $if_empty and the matching $endif.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1849,7 +1849,7 @@
             </command>
         </term>
         <listitem>if there is at least one default gateway, display everything
-        between $if_gw and the matching $endif
+        between $if_gw and the matching $endif.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1897,7 +1897,7 @@
             <option>(mountpoint)</option>
         </term>
         <listitem>if MOUNTPOINT is mounted, display everything between
-        $if_mounted and the matching $endif
+        $if_mounted and the matching $endif.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1907,7 +1907,7 @@
             </command>
         </term>
         <listitem>if mpd is playing or paused, display everything between
-        $if_mpd_playing and the matching $endif
+        $if_mpd_playing and the matching $endif.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1952,7 +1952,7 @@
         </term>
         <listitem>when using smapi, if the battery with index INDEX is
         installed, display everything between $if_smapi_bat_installed and the
-        matching $endif
+        matching $endif.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1963,7 +1963,7 @@
             <option>(interface)</option>
         </term>
         <listitem>if INTERFACE exists and is up, display everything between
-        $if_up and the matching $endif
+        $if_up and the matching $endif.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2057,7 +2057,7 @@
             <option>disk</option>
         </term>
         <listitem>Prints the current ioscheduler used for the given disk name
-        (i.e. e.g. "hda" or "sdb")
+        (i.e. e.g. "hda" or "sdb").
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2080,7 +2080,7 @@
                 <option>kernel</option>
             </command>
         </term>
-        <listitem>Kernel version
+        <listitem>Kernel version.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2125,7 +2125,7 @@
                 <option>version</option>
             </command>
         </term>
-        <listitem>Git version numer (DragonFly only)
+        <listitem>Git version number. DragonFly only.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2134,7 +2134,7 @@
                 <option>laptop_mode</option>
             </command>
         </term>
-        <listitem>The value of /proc/sys/vm/laptop_mode
+        <listitem>The value of /proc/sys/vm/laptop_mode.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2144,7 +2144,7 @@
             </command>
             <option>textfile</option>
         </term>
-        <listitem>Displays the number of lines in the given file
+        <listitem>Displays the number of lines in the given file.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2257,7 +2257,7 @@
                 <option>machine</option>
             </command>
         </term>
-        <listitem>Machine, i686 for example
+        <listitem>Machine, e.g. i686, x86_64.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2293,7 +2293,7 @@
                 <option>mem</option>
             </command>
         </term>
-        <listitem>Amount of memory in use
+        <listitem>Amount of memory in use.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2303,7 +2303,7 @@
             </command>
         </term>
         <listitem>Amount of memory in use, including that used by system
-        buffers and caches
+        buffers and caches.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2313,7 +2313,7 @@
             </command>
             <option>(height),(width)</option>
         </term>
-        <listitem>Bar that shows amount of memory in use
+        <listitem>Bar that shows amount of memory in use.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2324,7 +2324,7 @@
             <option>(height),(width)</option>
         </term>
         <listitem>Bar that shows amount of memory in use (including memory
-        used by system buffers and caches)
+        used by system buffers and caches).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2348,7 +2348,7 @@
                 <option>memdirty</option>
             </command>
         </term>
-        <listitem>Amount of "dirty" memory (linux only)
+        <listitem>Amount of "dirty" memory. Linux only.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2358,7 +2358,7 @@
             </command>
         </term>
         <listitem>Amount of free memory including the memory that is very
-        easily freed (buffers/cache)
+        easily freed (buffers/cache).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2367,7 +2367,7 @@
                 <option>memfree</option>
             </command>
         </term>
-        <listitem>Amount of free memory
+        <listitem>Amount of free memory.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2377,7 +2377,7 @@
             </command>
             <option>(height),(width)</option>
         </term>
-        <listitem>Gauge that shows amount of memory in use (see cpugauge)
+        <listitem>Gauge that shows amount of memory in use (see cpugauge).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2400,7 +2400,7 @@
                 <option>memmax</option>
             </command>
         </term>
-        <listitem>Total amount of memory
+        <listitem>Total amount of memory.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2409,7 +2409,7 @@
                 <option>memperc</option>
             </command>
         </term>
-        <listitem>Percentage of memory in use
+        <listitem>Percentage of memory in use.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2489,7 +2489,7 @@
                 <option>moc_album</option>
             </command>
         </term>
-        <listitem>Album of the current MOC song
+        <listitem>Album of the current MOC song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2498,7 +2498,7 @@
                 <option>moc_artist</option>
             </command>
         </term>
-        <listitem>Artist of the current MOC song
+        <listitem>Artist of the current MOC song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2507,7 +2507,7 @@
                 <option>moc_bitrate</option>
             </command>
         </term>
-        <listitem>Bitrate in the current MOC song
+        <listitem>Bitrate in the current MOC song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2516,7 +2516,7 @@
                 <option>moc_curtime</option>
             </command>
         </term>
-        <listitem>Current time of the current MOC song
+        <listitem>Current time of the current MOC song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2525,7 +2525,7 @@
                 <option>moc_file</option>
             </command>
         </term>
-        <listitem>File name of the current MOC song
+        <listitem>File name of the current MOC song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2534,7 +2534,7 @@
                 <option>moc_rate</option>
             </command>
         </term>
-        <listitem>Rate of the current MOC song
+        <listitem>Rate of the current MOC song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2561,7 +2561,7 @@
                 <option>moc_timeleft</option>
             </command>
         </term>
-        <listitem>Time left in the current MOC song
+        <listitem>Time left in the current MOC song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2570,7 +2570,7 @@
                 <option>moc_title</option>
             </command>
         </term>
-        <listitem>Title of the current MOC song
+        <listitem>Title of the current MOC song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2579,7 +2579,7 @@
                 <option>moc_totaltime</option>
             </command>
         </term>
-        <listitem>Total length of the current MOC song
+        <listitem>Total length of the current MOC song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2617,7 +2617,7 @@
                 <option>mpd_album</option>
             </command>
         </term>
-        <listitem>Album in current MPD song
+        <listitem>Album in current MPD song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2626,7 +2626,7 @@
                 <option>mpd_artist</option>
             </command>
         </term>
-        <listitem>Artist in current MPD song must be enabled at compile
+        <listitem>Artist in current MPD song must be enabled at compile.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2645,7 +2645,7 @@
             </command>
             <option>(height),(width)</option>
         </term>
-        <listitem>Bar of mpd's progress
+        <listitem>Bar of mpd's progress.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2654,7 +2654,7 @@
                 <option>mpd_bitrate</option>
             </command>
         </term>
-        <listitem>Bitrate of current song
+        <listitem>Bitrate of current song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2663,7 +2663,7 @@
                 <option>mpd_date</option>
             </command>
         </term>
-        <listitem>Date of current song
+        <listitem>Date of current song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2672,7 +2672,7 @@
                 <option>mpd_elapsed</option>
             </command>
         </term>
-        <listitem>Song's elapsed time
+        <listitem>Song's elapsed time.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2681,7 +2681,7 @@
                 <option>mpd_file</option>
             </command>
         </term>
-        <listitem>Prints the file name of the current MPD song
+        <listitem>Prints the file name of the current MPD song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2690,7 +2690,7 @@
                 <option>mpd_length</option>
             </command>
         </term>
-        <listitem>Song's length
+        <listitem>Song's length.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2699,7 +2699,7 @@
                 <option>mpd_name</option>
             </command>
         </term>
-        <listitem>Prints the MPD name field
+        <listitem>Prints the MPD name field.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2708,7 +2708,7 @@
                 <option>mpd_percent</option>
             </command>
         </term>
-        <listitem>Percent of song's progress
+        <listitem>Percent of song's progress.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2717,7 +2717,7 @@
                 <option>mpd_random</option>
             </command>
         </term>
-        <listitem>Random status (On/Off)
+        <listitem>Random status (On/Off).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2726,7 +2726,7 @@
                 <option>mpd_repeat</option>
             </command>
         </term>
-        <listitem>Repeat status (On/Off)
+        <listitem>Repeat status (On/Off).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2737,7 +2737,7 @@
             <option>(max length)</option>
         </term>
         <listitem>Prints the song name in either the form "artist - title" or
-        file name, depending on whats available
+        file name, depending on whats available.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2756,7 +2756,7 @@
             </command>
             <option>(max length)</option>
         </term>
-        <listitem>Title of current MPD song
+        <listitem>Title of current MPD song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2765,7 +2765,7 @@
                 <option>mpd_track</option>
             </command>
         </term>
-        <listitem>Prints the MPD track field
+        <listitem>Prints the MPD track field.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2774,7 +2774,7 @@
                 <option>mpd_vol</option>
             </command>
         </term>
-        <listitem>MPD's volume
+        <listitem>MPD's volume.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2817,7 +2817,7 @@
                 <option>nodename</option>
             </command>
         </term>
-        <listitem>Hostname
+        <listitem>Hostname.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3104,7 +3104,7 @@
             </command>
             <option>(color)</option>
         </term>
-        <listitem>Change outline color
+        <listitem>Change outline color.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3220,7 +3220,7 @@
             <option>pid</option>
         </term>
         <listitem>Directory used as rootdirectory by the process (this will be
-        "/" unless the process did a chroot syscall)
+        "/" unless the process did a chroot syscall).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3230,7 +3230,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>Command line this process was invoked with
+        <listitem>Command line this process was invoked with.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3240,7 +3240,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>Current working directory of the process
+        <listitem>Current working directory of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3250,7 +3250,7 @@
             </command>
             <option>pid varname</option>
         </term>
-        <listitem>Contents of a environment-var of the process
+        <listitem>Contents of a environment-var of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3260,7 +3260,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>List of environment-vars that the process can see
+        <listitem>List of environment-vars that the process can see.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3270,7 +3270,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>Path to executed command that started the process
+        <listitem>Path to executed command that started the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3280,7 +3280,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>The nice value of the process
+        <listitem>The nice value of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3290,7 +3290,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>List of files that the process has open
+        <listitem>List of files that the process has open.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3300,7 +3300,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>The pid of the parent of the process
+        <listitem>The pid of the parent of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3310,7 +3310,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>The priority of the process (see 'priority' in "man 5 proc")
+        <listitem>The priority of the process (see 'priority' in "man 5 proc").
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3320,7 +3320,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>Total number of bytes read by the process
+        <listitem>Total number of bytes read by the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3330,7 +3330,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>State of the process
+        <listitem>State of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3343,7 +3343,7 @@
         <listitem>One of the chars in "RSDZTW" representing the state of the
         process where R is running, S is sleeping in an interruptible wait, D
         is waiting in uninterruptible disk sleep, Z is zombie, T is traced or
-        stopped (on a signal), and W is paging
+        stopped (on a signal), and W is paging.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3353,7 +3353,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>Filedescriptor binded to the STDERR of the process
+        <listitem>Filedescriptor binded to the STDERR of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3363,7 +3363,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>Filedescriptor binded to the STDIN of the process
+        <listitem>Filedescriptor binded to the STDIN of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3373,7 +3373,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>Filedescriptor binded to the STDOUT of the process
+        <listitem>Filedescriptor binded to the STDOUT of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3383,7 +3383,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>Number of threads in process containing this thread
+        <listitem>Number of threads in process containing this thread.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3393,7 +3393,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>List with pid's from threads from this process
+        <listitem>List with pid's from threads from this process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3404,7 +3404,7 @@
             <option>pid</option>
         </term>
         <listitem>Amount of time that the process has been scheduled in kernel
-        mode in seconds
+        mode in seconds.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3415,7 +3415,7 @@
             <option>pid</option>
         </term>
         <listitem>Amount of time that the process has been scheduled in user
-        mode in seconds
+        mode in seconds.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3425,7 +3425,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>Sum of $pid_time_kernelmode and $pid_time_usermode
+        <listitem>Sum of $pid_time_kernelmode and $pid_time_usermode.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3435,7 +3435,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>The real uid of the process
+        <listitem>The real uid of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3445,7 +3445,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>The effective uid of the process
+        <listitem>The effective uid of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3455,7 +3455,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>The saved set uid of the process
+        <listitem>The saved set uid of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3465,7 +3465,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>The file system uid of the process
+        <listitem>The file system uid of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3475,7 +3475,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>The real gid of the process
+        <listitem>The real gid of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3485,7 +3485,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>The effective gid of the process
+        <listitem>The effective gid of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3495,7 +3495,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>The saved set gid of the process
+        <listitem>The saved set gid of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3505,7 +3505,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>The file system gid of the process
+        <listitem>The file system gid of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3515,7 +3515,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>Peak virtual memory size of the process
+        <listitem>Peak virtual memory size of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3525,7 +3525,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>Virtual memory size of the process
+        <listitem>Virtual memory size of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3535,7 +3535,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>Locked memory size of the process
+        <listitem>Locked memory size of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3545,7 +3545,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>Peak resident set size ("high water mark") of the process
+        <listitem>Peak resident set size ("high water mark") of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3555,7 +3555,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>Resident set size of the process
+        <listitem>Resident set size of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3565,7 +3565,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>Data segment size of the process
+        <listitem>Data segment size of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3575,7 +3575,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>Stack segment size of the process
+        <listitem>Stack segment size of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3585,7 +3585,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>Text segment size of the process
+        <listitem>Text segment size of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3595,7 +3595,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>Shared library code size of the process
+        <listitem>Shared library code size of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3605,7 +3605,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>Page table entries size of the process
+        <listitem>Page table entries size of the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3615,7 +3615,7 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>Total number of bytes written by the process
+        <listitem>Total number of bytes written by the process.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3675,7 +3675,7 @@
                 <option>processes</option>
             </command>
         </term>
-        <listitem>Total processes (sleeping and running)
+        <listitem>Total processes (sleeping and running).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3737,7 +3737,7 @@
                 <option>running_processes</option>
             </command>
         </term>
-        <listitem>Running processes (not sleeping), requires Linux 2.6
+        <listitem>Running processes (not sleeping). Requires Linux 2.6.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3807,7 +3807,7 @@
         '${sip_status 0}' # print allows apple-internal? Yes or No? NOTES: *
         Available for all macOS versions (even the ones prior El Capitan where
         SIP was first introduced) * If run on versions prior El Capitan SIP is
-        unavailable, so all you will get is "unsupported"
+        unavailable, so all you will get is "unsupported".
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3817,7 +3817,7 @@
             </command>
             <option>(color)</option>
         </term>
-        <listitem>Change shading color
+        <listitem>Change shading color.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3910,7 +3910,7 @@
             </command>
             <option>(space)</option>
         </term>
-        <listitem>Stippled (dashed) horizontal line
+        <listitem>Stippled (dashed) horizontal line.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3948,7 +3948,7 @@
         Time), tradelinks, tt(Ticker Trend), 1ytp(1 yr Target Price), volume,
         hv(Holdings Value), hvrt(Holdings Value realtime), 52weekrange,
         dvc(Day's Value Change), dvcrt(Day's Value Change realtime), se(Stock
-        Exchange), dy(Dividend Yield)
+        Exchange), dy(Dividend Yield).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3957,7 +3957,7 @@
                 <option>swap</option>
             </command>
         </term>
-        <listitem>Amount of swap in use
+        <listitem>Amount of swap in use.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3967,7 +3967,7 @@
             </command>
             <option>(height),(width)</option>
         </term>
-        <listitem>Bar that shows amount of swap in use
+        <listitem>Bar that shows amount of swap in use.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3976,7 +3976,7 @@
                 <option>swapfree</option>
             </command>
         </term>
-        <listitem>Amount of free swap
+        <listitem>Amount of free swap.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3985,7 +3985,7 @@
                 <option>swapmax</option>
             </command>
         </term>
-        <listitem>Total amount of swap
+        <listitem>Total amount of swap.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3994,7 +3994,7 @@
                 <option>swapperc</option>
             </command>
         </term>
-        <listitem>Percentage of swap in use
+        <listitem>Percentage of swap in use.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4003,7 +4003,7 @@
                 <option>sysname</option>
             </command>
         </term>
-        <listitem>System name, Linux for example
+        <listitem>System name, e.g. Linux.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4013,7 +4013,7 @@
             </command>
             <option>(name)</option>
         </term>
-        <listitem>Print sysctl value by name. For FreeBSD only.
+        <listitem>Print sysctl value by name. FreeBSD only.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4244,7 +4244,7 @@
                 <option>threads</option>
             </command>
         </term>
-        <listitem>Total threads
+        <listitem>Total threads.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4254,8 +4254,8 @@
             </command>
             <option>(format)</option>
         </term>
-        <listitem>Local time, see man strftime to get more information about
-        format
+        <listitem>Local time, see "man strftime" to get more information about
+        format.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4293,7 +4293,7 @@
             <option>type num</option>
         </term>
         <listitem>Same as top, except sorted by the amount of I/O the process
-        has done during the update interval
+        has done during the update interval.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4303,7 +4303,7 @@
             </command>
             <option>type num</option>
         </term>
-        <listitem>Same as top, except sorted by mem usage instead of cpu
+        <listitem>Same as top, except sorted by mem usage instead of cpu.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4314,7 +4314,7 @@
             <option>type num</option>
         </term>
         <listitem>Same as top, except sorted by total CPU time instead of
-        current CPU usage
+        current CPU usage.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4336,7 +4336,7 @@
             </command>
             <option>(net)</option>
         </term>
-        <listitem>Total upload, this one too, may overflow
+        <listitem>Total upload, this one too, may overflow.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4372,7 +4372,7 @@
             </command>
             <option>gid</option>
         </term>
-        <listitem>Name of group with this gid
+        <listitem>Name of group with this gid.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4382,7 +4382,7 @@
             </command>
             <option>uid</option>
         </term>
-        <listitem>Username of user with this uid
+        <listitem>Username of user with this uid.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4444,7 +4444,7 @@
             </command>
             <option>Number of updates</option>
         </term>
-        <listitem>for debugging
+        <listitem>for debugging.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4454,7 +4454,7 @@
             </command>
             <option>(net)</option>
         </term>
-        <listitem>Upload speed in suitable IEC units
+        <listitem>Upload speed in suitable IEC units.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4464,7 +4464,7 @@
             </command>
             <option>(net)</option>
         </term>
-        <listitem>Upload speed in KiB with one decimal
+        <listitem>Upload speed in KiB with one decimal.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4489,7 +4489,7 @@
                 <option>uptime</option>
             </command>
         </term>
-        <listitem>Uptime
+        <listitem>Uptime.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4498,7 +4498,7 @@
                 <option>uptime_short</option>
             </command>
         </term>
-        <listitem>Uptime in a shorter format
+        <listitem>Uptime in a shorter format.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4507,7 +4507,7 @@
                 <option>user_names</option>
             </command>
         </term>
-        <listitem>Lists the names of the users logged in
+        <listitem>Lists the names of the users logged in.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4516,7 +4516,7 @@
                 <option>user_number</option>
             </command>
         </term>
-        <listitem>Number of users logged in
+        <listitem>Number of users logged in.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4525,7 +4525,7 @@
                 <option>user_terms</option>
             </command>
         </term>
-        <listitem>Lists the consoles in use
+        <listitem>Lists the consoles in use.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4534,7 +4534,7 @@
                 <option>user_times</option>
             </command>
         </term>
-        <listitem>Lists how long users have been logged in for
+        <listitem>Lists how long users have been logged in for.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4545,7 +4545,7 @@
             <option>console</option>
         </term>
         <listitem>Lists how long the user for the given console has been
-        logged in for
+        logged in for.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4766,7 +4766,7 @@
             </command>
             <option>(net)</option>
         </term>
-        <listitem>Wireless access point MAC address (Linux only)
+        <listitem>Wireless access point MAC address. Linux only.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4776,7 +4776,7 @@
             </command>
             <option>(net)</option>
         </term>
-        <listitem>Wireless bitrate (ie 11 Mb/s) (Linux only)
+        <listitem>Wireless bitrate (ie 11 Mb/s). Linux only.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4786,7 +4786,7 @@
             </command>
             <option>(net)</option>
         </term>
-        <listitem>WLAN channel on which device 'net' is listening
+        <listitem>WLAN channel on which device 'net' is listening.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4796,7 +4796,7 @@
             </command>
             <option>(net)</option>
         </term>
-        <listitem>Wireless access point ESSID (Linux only)
+        <listitem>Wireless access point ESSID. Linux only.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4806,7 +4806,7 @@
             </command>
             <option>(net)</option>
         </term>
-        <listitem>Frequency on which device 'net' is listening
+        <listitem>Frequency on which device 'net' is listening.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4816,7 +4816,7 @@
             </command>
             <option>(height),(width) (net)</option>
         </term>
-        <listitem>Wireless link quality bar (Linux only)
+        <listitem>Wireless link quality bar. Linux only.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4826,7 +4826,7 @@
             </command>
             <option>(net)</option>
         </term>
-        <listitem>Wireless link quality (Linux only)
+        <listitem>Wireless link quality. Linux only.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4836,7 +4836,7 @@
             </command>
             <option>(net)</option>
         </term>
-        <listitem>Wireless link quality maximum value (Linux only)
+        <listitem>Wireless link quality maximum value. Linux only.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4846,7 +4846,7 @@
             </command>
             <option>(net)</option>
         </term>
-        <listitem>Wireless link quality in percents (Linux only)
+        <listitem>Wireless link quality in percents. Linux only.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4856,7 +4856,7 @@
             </command>
             <option>(net)</option>
         </term>
-        <listitem>Wireless mode (Managed/Ad-Hoc/Master) (Linux only)
+        <listitem>Wireless mode (Managed/Ad-Hoc/Master). Linux only.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4866,7 +4866,7 @@
             </command>
             <option>textfile</option>
         </term>
-        <listitem>Displays the number of words in the given file
+        <listitem>Displays the number of words in the given file.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4875,7 +4875,7 @@
                 <option>xmms2_album</option>
             </command>
         </term>
-        <listitem>Album in current XMMS2 song
+        <listitem>Album in current XMMS2 song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4884,7 +4884,7 @@
                 <option>xmms2_artist</option>
             </command>
         </term>
-        <listitem>Artist in current XMMS2 song
+        <listitem>Artist in current XMMS2 song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4894,7 +4894,7 @@
             </command>
             <option>(height),(width)</option>
         </term>
-        <listitem>Bar of XMMS2's progress
+        <listitem>Bar of XMMS2's progress.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4903,7 +4903,7 @@
                 <option>xmms2_bitrate</option>
             </command>
         </term>
-        <listitem>Bitrate of current song
+        <listitem>Bitrate of current song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4912,7 +4912,7 @@
                 <option>xmms2_comment</option>
             </command>
         </term>
-        <listitem>Comment in current XMMS2 song
+        <listitem>Comment in current XMMS2 song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4930,7 +4930,7 @@
                 <option>xmms2_duration</option>
             </command>
         </term>
-        <listitem>Duration of current song
+        <listitem>Duration of current song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4939,7 +4939,7 @@
                 <option>xmms2_elapsed</option>
             </command>
         </term>
-        <listitem>Song's elapsed time
+        <listitem>Song's elapsed time.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4948,7 +4948,7 @@
                 <option>xmms2_genre</option>
             </command>
         </term>
-        <listitem>Genre in current XMMS2 song
+        <listitem>Genre in current XMMS2 song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4957,7 +4957,7 @@
                 <option>xmms2_id</option>
             </command>
         </term>
-        <listitem>XMMS2 id of current song
+        <listitem>XMMS2 id of current song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4966,7 +4966,7 @@
                 <option>xmms2_percent</option>
             </command>
         </term>
-        <listitem>Percent of song's progress
+        <listitem>Percent of song's progress.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4984,7 +4984,7 @@
                 <option>xmms2_size</option>
             </command>
         </term>
-        <listitem>Size of current song
+        <listitem>Size of current song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4994,7 +4994,7 @@
             </command>
         </term>
         <listitem>Prints the song name in either the form "artist - title" or
-        file name, depending on whats available
+        file name, depending on whats available.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -5003,7 +5003,7 @@
                 <option>xmms2_status</option>
             </command>
         </term>
-        <listitem>XMMS2 status (Playing, Paused, Stopped, or Disconnected)
+        <listitem>XMMS2 status (Playing, Paused, Stopped, or Disconnected).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -5021,7 +5021,7 @@
                 <option>xmms2_title</option>
             </command>
         </term>
-        <listitem>Title in current XMMS2 song
+        <listitem>Title in current XMMS2 song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -5030,7 +5030,7 @@
                 <option>xmms2_tracknr</option>
             </command>
         </term>
-        <listitem>Track number in current XMMS2 song
+        <listitem>Track number in current XMMS2 song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -5039,7 +5039,7 @@
                 <option>xmms2_url</option>
             </command>
         </term>
-        <listitem>Full path to current song
+        <listitem>Full path to current song.
         <para /></listitem>
     </varlistentry>
 </variablelist>

--- a/doc/variables.xml
+++ b/doc/variables.xml
@@ -7,9 +7,10 @@
             <option>(adapter)</option>
         </term>
         <listitem>ACPI ac adapter state. On linux, the adapter option
-        specifies the subfolder of /sys/class/power_supply containing the
-        state information (tries "AC" and "ADP1" if there is no argument
-        given). Non-linux systems ignore it.
+        specifies the subfolder of
+        <filename>/sys/class/power_supply</filename>&#160;containing the state
+        information (tries "AC" and "ADP1" if there is no argument given).
+        Non-linux systems ignore it.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -384,7 +385,8 @@
             </command>
             <option>(max length)</option>
         </term>
-        <listitem>Title of current tune with optional maximum length specifier.
+        <listitem>Title of current tune with optional maximum length
+        specifier.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -575,6 +577,7 @@
             <option>string</option>
         </term>
         <listitem>PID of the first process that has string in its commandline.
+
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -730,8 +733,8 @@
             <option>(color)</option>
         </term>
         <listitem>Change drawing color to 'color' which is a name of a color
-        or a hexcode preceded with #, e.g. #0A1B2C. If you use ncurses only the
-        following colors are supported: red, green, yellow, blue, magenta,
+        or a hexcode preceded with #, e.g. #0A1B2C. If you use ncurses only
+        the following colors are supported: red, green, yellow, blue, magenta,
         cyan, black, and white.
         <para /></listitem>
     </varlistentry>
@@ -983,10 +986,11 @@
         <listitem>The name of the distribution. It could be that some of the
         untested distributions will show up wrong or as "unknown", if that's
         the case post a bug on sourceforge, make sure it contains the name of
-        your distribution, the contents of /proc/version and if there is a
-        file that only exists on your distribution, also add the path of that
-        file in the bug. If there is no such file, please add another way
-        which we can use to identify your distribution.
+        your distribution, the contents of
+        <filename>/proc/version</filename>&#160;and if there is a file that
+        only exists on your distribution, also add the path of that file in
+        the bug. If there is no such file, please add another way which we can
+        use to identify your distribution.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1564,11 +1568,11 @@
         omitted if you have only one hwmon device. Parameter type is either
         'in' or 'vol' meaning voltage; 'fan' meaning fan; 'temp' meaning
         temperature. Parameter n is number of the sensor. See
-        /sys/class/hwmon/ on your local computer. The optional arguments
-        'factor' and 'offset' allow precalculation of the raw input, which is
-        being modified as follows: 'input = input * factor + offset'. Note
-        that they have to be given as decimal values (i.e. contain at least
-        one decimal place).
+        <filename>/sys/class/hwmon/</filename>&#160;on your local computer.
+        The optional arguments 'factor' and 'offset' allow precalculation of
+        the raw input, which is being modified as follows: 'input = input *
+        factor + offset'. Note that they have to be given as decimal values
+        (i.e. contain at least one decimal place).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1592,11 +1596,11 @@
         omitted if you have only one I2C device. Parameter type is either 'in'
         or 'vol' meaning voltage; 'fan' meaning fan; 'temp' meaning
         temperature. Parameter n is number of the sensor. See
-        /sys/bus/i2c/devices/ on your local computer. The optional arguments
-        'factor' and 'offset' allow precalculation of the raw input, which is
-        being modified as follows: 'input = input * factor + offset'. Note
-        that they have to be given as decimal values (i.e. contain at least
-        one decimal place).
+        <filename>/sys/bus/i2c/devices/</filename>&#160;on your local
+        computer. The optional arguments 'factor' and 'offset' allow
+        precalculation of the raw input, which is being modified as follows:
+        'input = input * factor + offset'. Note that they have to be given as
+        decimal values (i.e. contain at least one decimal place).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1872,7 +1876,7 @@
             <member>
             <command>long</command>Argument consists of only digits.</member>
             <member>
-            <command>string</command>Argument is enclosed in quotation marks
+            <command>string</command>Argument is enclosed in quotation marks.
             (")</member>
         </simplelist>Valid operands are: '&gt;', '&lt;', '&gt;=', '&lt;=',
         '==', '!='.
@@ -2134,7 +2138,8 @@
                 <option>laptop_mode</option>
             </command>
         </term>
-        <listitem>The value of /proc/sys/vm/laptop_mode.
+        <listitem>The value of
+        <filename>/proc/sys/vm/laptop_mode</filename>.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2285,6 +2290,7 @@
         <listitem>Print a summary of recent messages in an mbox format
         mailbox. mbox parameter is the filename of the mailbox (can be
         encapsulated using '"', ie. ${mboxscan -n 10 "/home/brenden/some box"}
+
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3310,7 +3316,8 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>The priority of the process (see 'priority' in "man 5 proc").
+        <listitem>The priority of the process (see 'priority' in "man 5
+        proc").
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3629,11 +3636,11 @@
         omitted if you have only one platform device. Platform type is either
         'in' or 'vol' meaning voltage; 'fan' meaning fan; 'temp' meaning
         temperature. Parameter n is number of the sensor. See
-        /sys/bus/platform/devices/ on your local computer. The optional
-        arguments 'factor' and 'offset' allow precalculation of the raw input,
-        which is being modified as follows: 'input = input * factor + offset'.
-        Note that they have to be given as decimal values (i.e. contain at
-        least one decimal place).
+        <filename>/sys/bus/platform/devices/</filename>&#160;on your local
+        computer. The optional arguments 'factor' and 'offset' allow
+        precalculation of the raw input, which is being modified as follows:
+        'input = input * factor + offset'. Note that they have to be given as
+        decimal values (i.e. contain at least one decimal place).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3828,10 +3835,11 @@
             <option>(ARGS)</option>
         </term>
         <listitem>when using smapi, display contents of the
-        /sys/devices/platform/smapi directory. ARGS are either '(FILENAME)' or
-        'bat (INDEX) (FILENAME)' to display the corresponding files' content.
-        This is a very raw method of accessing the smapi values. When
-        available, better use one of the smapi_* variables instead.
+        <filename>/sys/devices/platform/smapi</filename>&#160;directory. ARGS
+        are either '(FILENAME)' or 'bat (INDEX) (FILENAME)' to display the
+        corresponding files' content. This is a very raw method of accessing
+        the smapi values. When available, better use one of the smapi_*
+        variables instead.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4620,9 +4628,12 @@
             </simplelist>
             <para>'locID' must be a valid location identifier for the required
             uri. For the NOAA site this must be a valid ICAO (see for instance
-            https://pilotweb.nas.faa.gov/qryhtml/icao/). For the weather.com
-            site this must be a valid location ID (see for instance
-            http://aspnetresources.com/tools/locid.aspx).</para>
+
+            <filename>https://pilotweb.nas.faa.gov/qryhtml/icao/</filename>).
+            For the weather.com site this must be a valid location ID (see for
+            instance
+            <filename>
+            http://aspnetresources.com/tools/locid.aspx</filename>).</para>
             <para>'data_type' must be one of the following:</para>
             <simplelist>
                 <member>

--- a/doc/variables.xml
+++ b/doc/variables.xml
@@ -6,9 +6,10 @@
             </command>
             <option>(adapter)</option>
         </term>
-        <listitem>ACPI ac adapter state. On linux, the adapter option specifies the
-        subfolder of /sys/class/power_supply containing the state information (tries "AC"
-        and "ADP1" if there is no argument given). Non-linux systems ignore it.
+        <listitem>ACPI ac adapter state. On linux, the adapter option
+        specifies the subfolder of /sys/class/power_supply containing the
+        state information (tries "AC" and "ADP1" if there is no argument
+        given). Non-linux systems ignore it.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -36,8 +37,8 @@
             </command>
             <option>(interface)</option>
         </term>
-        <listitem>IP address for an interface, or "No Address" if
-        no address is assigned.
+        <listitem>IP address for an interface, or "No Address" if no address
+        is assigned.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -47,8 +48,8 @@
             </command>
             <option>(interface)</option>
         </term>
-        <listitem>IP addresses for an interface (if one - works
-        like addr). Linux only.
+        <listitem>IP addresses for an interface (if one - works like addr).
+        Linux only.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -97,8 +98,8 @@
             <option>host</option>
             <option>port</option>
         </term>
-        <listitem>Sets up the connection to apcupsd daemon. Prints
-        nothing, defaults to localhost:3551
+        <listitem>Sets up the connection to apcupsd daemon. Prints nothing,
+        defaults to localhost:3551
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -170,8 +171,8 @@
             <command>
                 <option>apcupsd_loadgraph</option>
             </command>
-            <option>(height),(width) (gradient colour 1) (gradient
-            colour 2) (scale) (-t) (-l)</option>
+            <option>(height),(width) (gradient colour 1) (gradient colour 2)
+            (scale) (-t) (-l)</option>
         </term>
         <listitem>History graph of current load.
         <para /></listitem>
@@ -245,8 +246,7 @@
                 <option>apm_battery_life</option>
             </command>
         </term>
-        <listitem>Display APM battery life in percent (FreeBSD, OpenBSD
-        only)
+        <listitem>Display APM battery life in percent (FreeBSD, OpenBSD only)
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -255,9 +255,8 @@
                 <option>apm_battery_time</option>
             </command>
         </term>
-        <listitem>Display remaining APM battery life in hh:mm:ss or
-        "unknown" if AC adapterstatus is on-line or charging
-        (FreeBSD, OpenBSD only)
+        <listitem>Display remaining APM battery life in hh:mm:ss or "unknown"
+        if AC adapterstatus is on-line or charging (FreeBSD, OpenBSD only)
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -375,8 +374,7 @@
                 <option>audacious_status</option>
             </command>
         </term>
-        <listitem>Player status (Playing/Paused/Stopped/Not
-        running)
+        <listitem>Player status (Playing/Paused/Stopped/Not running)
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -386,8 +384,7 @@
             </command>
             <option>(max length)</option>
         </term>
-        <listitem>Title of current tune with optional maximum
-        length specifier
+        <listitem>Title of current tune with optional maximum length specifier
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -397,9 +394,9 @@
             </command>
             <option>(num)</option>
         </term>
-        <listitem>Battery status and remaining percentage capacity
-        of ACPI or APM battery. ACPI battery number can be given as
-        argument (default is BAT0).
+        <listitem>Battery status and remaining percentage capacity of ACPI or
+        APM battery. ACPI battery number can be given as argument (default is
+        BAT0).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -409,10 +406,9 @@
             </command>
             <option>(height),(width) (num)</option>
         </term>
-        <listitem>Battery percentage remaining of ACPI battery in a
-        bar. ACPI battery number can be given as argument (default
-        is BAT0, use all to get the mean percentage remaining for
-        all batteries).
+        <listitem>Battery percentage remaining of ACPI battery in a bar. ACPI
+        battery number can be given as argument (default is BAT0, use all to
+        get the mean percentage remaining for all batteries).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -422,10 +418,9 @@
             </command>
             <option>(num)</option>
         </term>
-        <listitem>Battery percentage remaining for ACPI battery.
-        ACPI battery number can be given as argument (default is
-        BAT0, use all to get the mean percentage remaining for
-        all batteries).
+        <listitem>Battery percentage remaining for ACPI battery. ACPI battery
+        number can be given as argument (default is BAT0, use all to get the
+        mean percentage remaining for all batteries).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -435,12 +430,11 @@
             </command>
             <option>(num)</option>
         </term>
-        <listitem>Battery status and remaining percentage capacity
-        of ACPI or APM battery. ACPI battery number can be given as
-        argument (default is BAT0). This mode display a short
-        status, which means that C is displayed instead of
-        charging, D for discharging, F for full, N for not present,
-        E for empty and U for unknown.
+        <listitem>Battery status and remaining percentage capacity of ACPI or
+        APM battery. ACPI battery number can be given as argument (default is
+        BAT0). This mode display a short status, which means that C is
+        displayed instead of charging, D for discharging, F for full, N for
+        not present, E for empty and U for unknown.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -450,12 +444,10 @@
             </command>
             <option>(num)</option>
         </term>
-        <listitem>Battery status for ACPI battery.
-            ACPI battery number can be given as argument
-            (default is BAT0).
+        <listitem>Battery status for ACPI battery. ACPI battery number can be
+        given as argument (default is BAT0).
         <para /></listitem>
     </varlistentry>
-
     <varlistentry>
         <term>
             <command>
@@ -463,9 +455,8 @@
             </command>
             <option>(num)</option>
         </term>
-        <listitem>Battery charge/discharge time remaining of ACPI
-        battery. ACPI battery number can be given as argument
-        (default is BAT0).
+        <listitem>Battery charge/discharge time remaining of ACPI battery.
+        ACPI battery number can be given as argument (default is BAT0).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -476,7 +467,6 @@
             <option>text_and_other_conky_vars</option>
         </term>
         <listitem>Let 'text_and_other_conky_vars' blink on and off.
-
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -558,9 +548,9 @@
             </command>
             <option>file</option>
         </term>
-        <listitem>Reads a file and displays the contents in conky.
-        This is useful if you have an independent process
-        generating output that you want to include in conky.
+        <listitem>Reads a file and displays the contents in conky. This is
+        useful if you have an independent process generating output that you
+        want to include in conky.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -570,12 +560,11 @@
             </command>
             <option>file</option>
         </term>
-        <listitem>Reads a file and displays the contents in conky.
-        This is useful if you have an independent process
-        generating output that you want to include in conky.  This
-        differs from $cat in that it parses the contents of the
-        file, so you can insert things like ${color red}hi!${color}
-        in your file and have it correctly parsed by Conky.
+        <listitem>Reads a file and displays the contents in conky. This is
+        useful if you have an independent process generating output that you
+        want to include in conky. This differs from $cat in that it parses the
+        contents of the file, so you can insert things like ${color
+        red}hi!${color} in your file and have it correctly parsed by Conky.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -585,8 +574,7 @@
             </command>
             <option>string</option>
         </term>
-        <listitem>PID of the first process that has string in it's
-	commandline
+        <listitem>PID of the first process that has string in it's commandline
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -595,7 +583,7 @@
                 <option>cmus_aaa</option>
             </command>
         </term>
-       <listitem>Print aaa status of cmus (all/artist/album).
+        <listitem>Print aaa status of cmus (all/artist/album).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -677,7 +665,7 @@
                 <option>cmus_random</option>
             </command>
         </term>
-       <listitem>Random status of cmus (on/off).
+        <listitem>Random status of cmus (on/off).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -686,7 +674,7 @@
                 <option>cmus_repeat</option>
             </command>
         </term>
-       <listitem>Repeat status of cmus (song/all/off).
+        <listitem>Repeat status of cmus (song/all/off).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -731,7 +719,7 @@
                 <option>cmus_track</option>
             </command>
         </term>
-       <listitem>Print track number of current cmus song.
+        <listitem>Print track number of current cmus song.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -741,10 +729,10 @@
             </command>
             <option>(color)</option>
         </term>
-        <listitem>Change drawing color to 'color' which is a name of
-        a color or a hexcode preceded with # (for example #0A1B2C ).
-        If you use ncurses only the following colors are supported:
-	red,green,yellow,blue,magenta,cyan,black,white.
+        <listitem>Change drawing color to 'color' which is a name of a color
+        or a hexcode preceded with # (for example #0A1B2C ). If you use
+        ncurses only the following colors are supported:
+        red,green,yellow,blue,magenta,cyan,black,white.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -753,8 +741,8 @@
                 <option>colorN</option>
             </command>
         </term>
-        <listitem>Change drawing color to colorN configuration
-        option, where N is a digit between 0 and 9, inclusively.
+        <listitem>Change drawing color to colorN configuration option, where N
+        is a digit between 0 and 9, inclusively.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -764,13 +752,12 @@
             </command>
             <option>var1 var2</option>
         </term>
-        <listitem>Places the lines of var2 to the right of the
-        lines of var1 separated by the chars that are put between
-        var1 and var2. For example: ${combine ${head /proc/cpuinfo
-        2} - ${head /proc/meminfo 1}} gives as output
-        "cpuinfo_line1 - meminfo_line1" on line 1 and
-        "cpuinfo_line2 -" on line 2. $combine vars can also be
-        nested to place more vars next to each other.
+        <listitem>Places the lines of var2 to the right of the lines of var1
+        separated by the chars that are put between var1 and var2. For
+        example: ${combine ${head /proc/cpuinfo 2} - ${head /proc/meminfo 1}}
+        gives as output "cpuinfo_line1 - meminfo_line1" on line 1 and
+        "cpuinfo_line2 -" on line 2. $combine vars can also be nested to place
+        more vars next to each other.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -807,10 +794,9 @@
             </command>
             <option>(cpuN)</option>
         </term>
-        <listitem>CPU usage in percents. For SMP machines, the CPU
-        number can be provided as an argument. ${cpu cpu0} is the
-        total usage, and ${cpu cpuX} (X &gt;= 1) are individual
-        CPUs.
+        <listitem>CPU usage in percents. For SMP machines, the CPU number can
+        be provided as an argument. ${cpu cpu0} is the total usage, and ${cpu
+        cpuX} (X &gt;= 1) are individual CPUs.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -820,8 +806,8 @@
             </command>
             <option>(cpuN) (height),(width)</option>
         </term>
-        <listitem>Bar that shows CPU usage, height is bar's height
-        in pixels. See $cpu for more info on SMP.
+        <listitem>Bar that shows CPU usage, height is bar's height in pixels.
+        See $cpu for more info on SMP.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -831,9 +817,9 @@
             </command>
             <option>(cpuN) (height),(width)</option>
         </term>
-        <listitem>Elliptical gauge that shows CPU usage, height and
-        width are gauge's vertical and horizontal axis
-        respectively. See $cpu for more info on SMP.
+        <listitem>Elliptical gauge that shows CPU usage, height and width are
+        gauge's vertical and horizontal axis respectively. See $cpu for more
+        info on SMP.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -841,16 +827,14 @@
             <command>
                 <option>cpugraph</option>
             </command>
-            <option>(cpuN) (height),(width) (gradient colour 1)
-            (gradient colour 2) (scale) (-t) (-l)</option>
+            <option>(cpuN) (height),(width) (gradient colour 1) (gradient
+            colour 2) (scale) (-t) (-l)</option>
         </term>
-        <listitem>CPU usage graph, with optional colours in hex,
-        minus the #. See $cpu for more info on SMP. Uses a
-        logarithmic scale (to see small numbers) when you use the
-        -l switch. Takes the switch '-t' to use a temperature
-        gradient, which makes the gradient values change depending
-        on the amplitude of a particular graph value (try it and
-        see).
+        <listitem>CPU usage graph, with optional colours in hex, minus the #.
+        See $cpu for more info on SMP. Uses a logarithmic scale (to see small
+        numbers) when you use the -l switch. Takes the switch '-t' to use a
+        temperature gradient, which makes the gradient values change depending
+        on the amplitude of a particular graph value (try it and see).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -860,16 +844,13 @@
             </command>
             <option>url (interval_in_minutes)</option>
         </term>
-        <listitem>
-            Download data from URI using Curl at the
-            specified interval. The interval may be a positive floating
-            point value (0 is allowed), otherwise defaults to 15
-            minutes. Most useful when used in conjunction with Lua
-            and the Lua API. This object is threaded, and once a
-            thread is created it can't be explicitly destroyed.
-            One thread will run for each URI specified. You can use
-            any protocol that Curl supports.
-	<para /></listitem>
+        <listitem>Download data from URI using Curl at the specified interval.
+        The interval may be a positive floating point value (0 is allowed),
+        otherwise defaults to 15 minutes. Most useful when used in conjunction
+        with Lua and the Lua API. This object is threaded, and once a thread
+        is created it can't be explicitly destroyed. One thread will run for
+        each URI specified. You can use any protocol that Curl supports.
+        <para /></listitem>
     </varlistentry>
     <varlistentry>
         <term>
@@ -877,8 +858,8 @@
                 <option>desktop</option>
             </command>
         </term>
-        <listitem>Number of the desktop on which conky is running
-        or the message "Not running in X" if this is the case.
+        <listitem>Number of the desktop on which conky is running or the
+        message "Not running in X" if this is the case.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -887,8 +868,8 @@
                 <option>desktop_name</option>
             </command>
         </term>
-        <listitem>Name of the desktop on which conky is running or
-        the message "Not running in X" if this is the case.
+        <listitem>Name of the desktop on which conky is running or the message
+        "Not running in X" if this is the case.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -897,8 +878,8 @@
                 <option>desktop_number</option>
             </command>
         </term>
-        <listitem>Number of desktops or the message "Not running in
-        X" if this is the case.
+        <listitem>Number of desktops or the message "Not running in X" if this
+        is the case.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -908,9 +889,8 @@
             </command>
             <option>device</option>
         </term>
-        <listitem>Disk protection status, if supported (needs
-        kernel-patch). Prints either "frozen" or "free " (note the
-        padding).
+        <listitem>Disk protection status, if supported (needs kernel-patch).
+        Prints either "frozen" or "free " (note the padding).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -920,10 +900,10 @@
             </command>
             <option>(device)</option>
         </term>
-        <listitem>Displays current disk IO. Device is optional, and
-            takes the form of sda for /dev/sda. A block device label can
-            be specified with label:foo and a block device partuuid can
-            be specified with partuuid:40000000-01.
+        <listitem>Displays current disk IO. Device is optional, and takes the
+        form of sda for /dev/sda. A block device label can be specified with
+        label:foo and a block device partuuid can be specified with
+        partuuid:40000000-01.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -933,8 +913,7 @@
             </command>
             <option>(device)</option>
         </term>
-        <listitem>Displays current disk IO for reads. Device as in
-        diskio.
+        <listitem>Displays current disk IO for reads. Device as in diskio.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -944,8 +923,7 @@
             </command>
             <option>(device)</option>
         </term>
-        <listitem>Displays current disk IO for writes. Device as in
-        diskio.
+        <listitem>Displays current disk IO for writes. Device as in diskio.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -953,16 +931,15 @@
             <command>
                 <option>diskiograph</option>
             </command>
-            <option>(device) (height),(width) (gradient colour 1)
-            (gradient colour 2) (scale) (-t) (-l)</option>
+            <option>(device) (height),(width) (gradient colour 1) (gradient
+            colour 2) (scale) (-t) (-l)</option>
         </term>
-        <listitem>Disk IO graph, colours defined in hex, minus the
-        #. If scale is non-zero, it becomes the scale for the
-        graph. Uses a logarithmic scale (to see small numbers) when
-        you use -l switch. Takes the switch '-t' to use a
-        temperature gradient, which makes the gradient values
-        change depending on the amplitude of a particular graph
-        value (try it and see).
+        <listitem>Disk IO graph, colours defined in hex, minus the #. If scale
+        is non-zero, it becomes the scale for the graph. Uses a logarithmic
+        scale (to see small numbers) when you use -l switch. Takes the switch
+        '-t' to use a temperature gradient, which makes the gradient values
+        change depending on the amplitude of a particular graph value (try it
+        and see).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -970,15 +947,14 @@
             <command>
                 <option>diskiograph_read</option>
             </command>
-            <option>(device) (height),(width) (gradient colour 1)
-            (gradient colour 2) (scale) (-t) (-l)</option>
+            <option>(device) (height),(width) (gradient colour 1) (gradient
+            colour 2) (scale) (-t) (-l)</option>
         </term>
-        <listitem>Disk IO graph for reads, colours defined in hex,
-        minus the #. If scale is non-zero, it becomes the scale for
-        the graph. Device as in diskio. Uses a logarithmic scale
-        (to see small numbers) when you use -l switch. Takes the
-        switch '-t' to use a temperature gradient, which makes the
-        gradient values change depending on the amplitude of a
+        <listitem>Disk IO graph for reads, colours defined in hex, minus the
+        #. If scale is non-zero, it becomes the scale for the graph. Device as
+        in diskio. Uses a logarithmic scale (to see small numbers) when you
+        use -l switch. Takes the switch '-t' to use a temperature gradient,
+        which makes the gradient values change depending on the amplitude of a
         particular graph value (try it and see).
         <para /></listitem>
     </varlistentry>
@@ -987,15 +963,14 @@
             <command>
                 <option>diskiograph_write</option>
             </command>
-            <option>(device) (height),(width) (gradient colour 1)
-            (gradient colour 2) (scale) (-t) (-l)</option>
+            <option>(device) (height),(width) (gradient colour 1) (gradient
+            colour 2) (scale) (-t) (-l)</option>
         </term>
-        <listitem>Disk IO graph for writes, colours defined in hex,
-        minus the #. If scale is non-zero, it becomes the scale for
-        the graph. Device as in diskio. Uses a logarithmic scale
-        (to see small numbers) when you use -l switch. Takes the
-        switch '-t' to use a temperature gradient, which makes the
-        gradient values change depending on the amplitude of a
+        <listitem>Disk IO graph for writes, colours defined in hex, minus the
+        #. If scale is non-zero, it becomes the scale for the graph. Device as
+        in diskio. Uses a logarithmic scale (to see small numbers) when you
+        use -l switch. Takes the switch '-t' to use a temperature gradient,
+        which makes the gradient values change depending on the amplitude of a
         particular graph value (try it and see).
         <para /></listitem>
     </varlistentry>
@@ -1005,14 +980,13 @@
                 <option>distribution</option>
             </command>
         </term>
-        <listitem>The name of the distribution. It could be that some
-        of the untested distributions will show up wrong or as "unknown",
-        if that's the case post a bug on sourceforge, make sure it
-        contains the name of your distribution, the contents of
-        /proc/version and if there is a file that only exists on your
-        distribution, also add the path of that file in the bug. If there
-        is no such file, please add another way which we can use to identify
-        your distribution.
+        <listitem>The name of the distribution. It could be that some of the
+        untested distributions will show up wrong or as "unknown", if that's
+        the case post a bug on sourceforge, make sure it contains the name of
+        your distribution, the contents of /proc/version and if there is a
+        file that only exists on your distribution, also add the path of that
+        file in the bug. If there is no such file, please add another way
+        which we can use to identify your distribution.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1040,16 +1014,15 @@
             <command>
                 <option>downspeedgraph</option>
             </command>
-            <option>(netdev) (height),(width) (gradient colour 1)
-            (gradient colour 2) (scale) (-t) (-l)</option>
+            <option>(netdev) (height),(width) (gradient colour 1) (gradient
+            colour 2) (scale) (-t) (-l)</option>
         </term>
-        <listitem>Download speed graph, colours defined in hex,
-        minus the #. If scale is non-zero, it becomes the scale for
-        the graph. Uses a logarithmic scale (to see small numbers)
-        when you use -l switch. Takes the switch '-t' to use a
-        temperature gradient, which makes the gradient values
-        change depending on the amplitude of a particular graph
-        value (try it and see).
+        <listitem>Download speed graph, colours defined in hex, minus the #.
+        If scale is non-zero, it becomes the scale for the graph. Uses a
+        logarithmic scale (to see small numbers) when you use -l switch. Takes
+        the switch '-t' to use a temperature gradient, which makes the
+        gradient values change depending on the amplitude of a particular
+        graph value (try it and see).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1060,9 +1033,9 @@
             <option>(maildir)</option>
             <option>(interval)</option>
         </term>
-        <listitem>Number of mails marked as draft in the specified
-        mailbox or mail spool if not. Only maildir type mailboxes
-        are supported, mbox type will return -1.
+        <listitem>Number of mails marked as draft in the specified mailbox or
+        mail spool if not. Only maildir type mailboxes are supported, mbox
+        type will return -1.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1100,8 +1073,7 @@
             </command>
             <option>(height),(width)</option>
         </term>
-        <listitem>Normalized bar of available entropy for crypto
-        freaks
+        <listitem>Normalized bar of available entropy for crypto freaks
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1110,8 +1082,8 @@
                 <option>entropy_perc</option>
             </command>
         </term>
-        <listitem>Percentage of entropy available in comparison to
-        the poolsize
+        <listitem>Percentage of entropy available in comparison to the
+        poolsize
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1120,8 +1092,7 @@
                 <option>entropy_poolsize</option>
             </command>
         </term>
-        <listitem>Total size of system entropy pool for crypto
-        freaks
+        <listitem>Total size of system entropy pool for crypto freaks
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1131,11 +1102,10 @@
             </command>
             <option>string</option>
         </term>
-        <listitem>Evaluates given string according to the rules of
-        conky.text interpretation, i.e. parsing any contained text object
-        specifications into their output, any occuring '$$' into a
-        single '$' and so on. The output is then being parsed
-        again.
+        <listitem>Evaluates given string according to the rules of conky.text
+        interpretation, i.e. parsing any contained text object specifications
+        into their output, any occuring '$$' into a single '$' and so on. The
+        output is then being parsed again.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1145,11 +1115,11 @@
             </command>
             <option>api_keyID api_vCode character_id</option>
         </term>
-        <listitem>Fetches a character's currently training skill from
-        the Eve Online API servers (http://www.eveonline.com/) and
-        displays the skill along with the remaining training time.
-        If the character is not actively training a skill then returns
-        the empty string (for use with $if_empty).
+        <listitem>Fetches a character's currently training skill from the Eve
+        Online API servers (http://www.eveonline.com/) and displays the skill
+        along with the remaining training time. If the character is not
+        actively training a skill then returns the empty string (for use with
+        $if_empty).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1159,10 +1129,9 @@
             </command>
             <option>command</option>
         </term>
-        <listitem>Executes a shell command and displays the output
-        in conky. Warning: this takes a lot more resources than
-        other variables. I'd recommend coding wanted behaviour in C/C++
-        and posting a patch.
+        <listitem>Executes a shell command and displays the output in conky.
+        Warning: this takes a lot more resources than other variables. I'd
+        recommend coding wanted behaviour in C/C++ and posting a patch.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1173,11 +1142,11 @@
             <option>(height),(width)</option>
             <option>command</option>
         </term>
-        <listitem>Same as exec, except if the first value returned is
-        a value between 0-100, it will use that number to draw a
-        horizontal bar. The height and width parameters are optional,
-        and default to the default_bar_height and default_bar_width
-        config settings, respectively.
+        <listitem>Same as exec, except if the first value returned is a value
+        between 0-100, it will use that number to draw a horizontal bar. The
+        height and width parameters are optional, and default to the
+        default_bar_height and default_bar_width config settings,
+        respectively.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1188,12 +1157,11 @@
             <option>(height),(width)</option>
             <option>command</option>
         </term>
-        <listitem>Same as exec, except if the first value returned is
-        a value between 0-100, it will use that number to draw a
-        round gauge (much like a vehicle speedometer). The height and
-        width parameters are optional, and default to the
-        default_gauge_height and default_gauge_width config settings,
-        respectively.
+        <listitem>Same as exec, except if the first value returned is a value
+        between 0-100, it will use that number to draw a round gauge (much
+        like a vehicle speedometer). The height and width parameters are
+        optional, and default to the default_gauge_height and
+        default_gauge_width config settings, respectively.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1210,36 +1178,32 @@
             <option>(-l)</option>
         </term>
         <listitem>
-        <para>Draws a horizontally scrolling graph with values
-        from 0-100 plotted on the vertical axis. All parameters
-        following the command are optional. Gradient colors can
-        be specified as hexadecimal values with no 0x or #
-        prefix. Use the -t switch to enable a temperature
-        gradient, so that small values are "cold" with color 1
-        and large values are "hot" with color 2. Without the -t
-        switch, the colors produce a horizontal gradient
-        spanning the width of the graph. The scale parameter
-        defines the maximum value of the graph. Use the -l
-        switch to enable a logarithmic scale, which helps to see
-        small values. The default size for graphs can be
-        controlled via the default_graph_height and
-        default_graph_width config settings.</para>
-
-        <para>If you need to execute a command with spaces, you
-        have a couple options: 1) wrap your command in
-        double-quotes, or 2) put your command into a separate
-        file, such as ~/bin/myscript.sh, and use that as your
-        execgraph command. Remember to make your script
-        executable!</para>
-
-        <para>In the following example, we set up execgraph to
-        display seconds (0-59) on a graph that is 50px high and 200px
-        wide, using a temperature gradient with colors ranging from red
-        for small values (FF0000) to yellow for large values (FFFF00).
-        We set the scale to 60.</para>
-
-        <para><command>${execgraph ~/seconds.sh 50,200 FF0000
-        FFFF00 60 -t}</command></para>
+            <para>Draws a horizontally scrolling graph with values from 0-100
+            plotted on the vertical axis. All parameters following the command
+            are optional. Gradient colors can be specified as hexadecimal
+            values with no 0x or # prefix. Use the -t switch to enable a
+            temperature gradient, so that small values are "cold" with color 1
+            and large values are "hot" with color 2. Without the -t switch,
+            the colors produce a horizontal gradient spanning the width of the
+            graph. The scale parameter defines the maximum value of the graph.
+            Use the -l switch to enable a logarithmic scale, which helps to
+            see small values. The default size for graphs can be controlled
+            via the default_graph_height and default_graph_width config
+            settings.</para>
+            <para>If you need to execute a command with spaces, you have a
+            couple options: 1) wrap your command in double-quotes, or 2) put
+            your command into a separate file, such as ~/bin/myscript.sh, and
+            use that as your execgraph command. Remember to make your script
+            executable!</para>
+            <para>In the following example, we set up execgraph to display
+            seconds (0-59) on a graph that is 50px high and 200px wide, using
+            a temperature gradient with colors ranging from red for small
+            values (FF0000) to yellow for large values (FFFF00). We set the
+            scale to 60.</para>
+            <para>
+                <command>${execgraph ~/seconds.sh 50,200 FF0000 FFFF00 60
+                -t}</command>
+            </para>
         </listitem>
     </varlistentry>
     <varlistentry>
@@ -1250,9 +1214,9 @@
             <option>interval</option>
             <option>command</option>
         </term>
-        <listitem>Same as exec, but with a specific interval in
-        seconds. The interval can't be less than the update_interval
-        in your configuration. See also $texeci.
+        <listitem>Same as exec, but with a specific interval in seconds. The
+        interval can't be less than the update_interval in your configuration.
+        See also $texeci.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1303,18 +1267,16 @@
             </command>
             <option>command</option>
         </term>
-        <listitem>Executes a shell command and displays the output
-        in conky. Warning: this takes a lot more resources than
-        other variables. I'd recommend coding wanted behaviour in C/C++
-        and posting a patch. This differs from $exec in that it
-        parses the output of the command, so you can insert things
-        like ${color red}hi!${color} in your script and have it
-        correctly parsed by Conky. Caveats: Conky parses and
-        evaluates the output of $execp every time Conky loops, and
-        then destroys all the objects. If you try to use anything
-        like $execi within an $execp statement, it will
-        functionally run at the same interval that the $execp
-        statement runs, as it is created and destroyed at every
+        <listitem>Executes a shell command and displays the output in conky.
+        Warning: this takes a lot more resources than other variables. I'd
+        recommend coding wanted behaviour in C/C++ and posting a patch. This
+        differs from $exec in that it parses the output of the command, so you
+        can insert things like ${color red}hi!${color} in your script and have
+        it correctly parsed by Conky. Caveats: Conky parses and evaluates the
+        output of $execp every time Conky loops, and then destroys all the
+        objects. If you try to use anything like $execi within an $execp
+        statement, it will functionally run at the same interval that the
+        $execp statement runs, as it is created and destroyed at every
         interval.
         <para /></listitem>
     </varlistentry>
@@ -1326,9 +1288,9 @@
             <option>interval</option>
             <option>command</option>
         </term>
-        <listitem>Same as execp, but with an interval. Note that
-        the output from the $execpi command is still parsed
-        and evaluated at every interval.
+        <listitem>Same as execp, but with an interval. Note that the output
+        from the $execpi command is still parsed and evaluated at every
+        interval.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1339,9 +1301,9 @@
             <option>(maildir)</option>
             <option>(interval)</option>
         </term>
-        <listitem>Number of mails marked as flagged in the
-        specified mailbox or mail spool if not. Only maildir type
-        mailboxes are supported, mbox type will return -1.
+        <listitem>Number of mails marked as flagged in the specified mailbox
+        or mail spool if not. Only maildir type mailboxes are supported, mbox
+        type will return -1.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1351,10 +1313,9 @@
             </command>
             <option>(font)</option>
         </term>
-        <listitem>Specify a different font. This new font will
-        apply to the current line and everything following. You can
-        use a $font with no arguments to change back to the default
-        font (much like with $color)
+        <listitem>Specify a different font. This new font will apply to the
+        current line and everything following. You can use a $font with no
+        arguments to change back to the default font (much like with $color)
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1363,8 +1324,8 @@
                 <option>fontN</option>
             </command>
         </term>
-        <listitem>Change font to fontN configuration
-        option, where N is a digit between 0 and 9, inclusively. 
+        <listitem>Change font to fontN configuration option, where N is a
+        digit between 0 and 9, inclusively.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1374,19 +1335,18 @@
             </command>
             <option>seconds format</option>
         </term>
-        <listitem>Format time given in seconds. This var only works when
-	the times_in_seconds configuration setting is on. Format is a string
-	that should start and end with a "-char. The "-chars are not
-	part of the output, \w,\d,\h,\m,\s,\(,\) and \\ are replaced by
-	weeks,days,hours,minutes,seconds,(,) and \. If you leave out a unit,
-	it's value will be expressed in the highest unite lower then the
-	one left out. Text between ()-chars will not be visible if a
-	replaced unit in this text is 0. If seconds is a decimal number
-	then you can see the numbers behind the point by using \S
-	followed by a number that specifies the amount of
-	digits behind the point that you want to see (maximum 9).
-	You can also place a 'x' behind \S so you have all digits behind
-	the point and no trailing zero's. (also maximum 9)
+        <listitem>Format time given in seconds. This var only works when the
+        times_in_seconds configuration setting is on. Format is a string that
+        should start and end with a "-char. The "-chars are not part of the
+        output, \w,\d,\h,\m,\s,\(,\) and \\ are replaced by
+        weeks,days,hours,minutes,seconds,(,) and \. If you leave out a unit,
+        it's value will be expressed in the highest unite lower then the one
+        left out. Text between ()-chars will not be visible if a replaced unit
+        in this text is 0. If seconds is a decimal number then you can see the
+        numbers behind the point by using \S followed by a number that
+        specifies the amount of digits behind the point that you want to see
+        (maximum 9). You can also place a 'x' behind \S so you have all digits
+        behind the point and no trailing zero's. (also maximum 9)
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1397,9 +1357,9 @@
             <option>(maildir)</option>
             <option>(interval)</option>
         </term>
-        <listitem>Number of mails marked as forwarded in the
-        specified mailbox or mail spool if not. Only maildir type
-        mailboxes are supported, mbox type will return -1.
+        <listitem>Number of mails marked as forwarded in the specified mailbox
+        or mail spool if not. Only maildir type mailboxes are supported, mbox
+        type will return -1.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1409,8 +1369,8 @@
             </command>
             <option>(n)</option>
         </term>
-        <listitem>Returns CPU #n's frequency in MHz. CPUs are
-        counted from 1. If omitted, the parameter defaults to 1.
+        <listitem>Returns CPU #n's frequency in MHz. CPUs are counted from 1.
+        If omitted, the parameter defaults to 1.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1420,8 +1380,8 @@
             </command>
             <option>(n)</option>
         </term>
-        <listitem>Returns CPU #n's frequency in GHz. CPUs are
-        counted from 1. If omitted, the parameter defaults to 1.
+        <listitem>Returns CPU #n's frequency in GHz. CPUs are counted from 1.
+        If omitted, the parameter defaults to 1.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1442,9 +1402,8 @@
             </command>
             <option>(height),(width) fs</option>
         </term>
-        <listitem>Bar that shows how much space is used on a file
-        system. height is the height in pixels. fs is any file on
-        that file system.
+        <listitem>Bar that shows how much space is used on a file system.
+        height is the height in pixels. fs is any file on that file system.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1454,9 +1413,8 @@
             </command>
             <option>(height),(width) fs</option>
         </term>
-        <listitem>Bar that shows how much space is free on a file
-        system. height is the height in pixels. fs is any file on
-        that file system.
+        <listitem>Bar that shows how much space is free on a file system.
+        height is the height in pixels. fs is any file on that file system.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1476,8 +1434,8 @@
             </command>
             <option>(fs)</option>
         </term>
-        <listitem>Free percentage of space on a file system
-        available for users.
+        <listitem>Free percentage of space on a file system available for
+        users.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1526,7 +1484,8 @@
                 <option>github_notifications</option>
             </command>
         </term>
-        <listitem>Number of GitHub notifications.<para /></listitem>
+        <listitem>Number of GitHub notifications.
+        <para /></listitem>
     </varlistentry>
     <varlistentry>
         <term>
@@ -1544,8 +1503,8 @@
                 <option>gw_iface</option>
             </command>
         </term>
-        <listitem>Displays the default route's interface or
-        "multiple"/"none" accordingly.
+        <listitem>Displays the default route's interface or "multiple"/"none"
+        accordingly.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1554,8 +1513,8 @@
                 <option>gw_ip</option>
             </command>
         </term>
-        <listitem>Displays the default gateway's IP or
-        "multiple"/"none" accordingly.
+        <listitem>Displays the default gateway's IP or "multiple"/"none"
+        accordingly.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1565,11 +1524,10 @@
             </command>
             <option>(dev)</option>
         </term>
-        <listitem>Displays temperature of a selected hard disk
-		drive as reported by the hddtemp daemon. Use hddtemp_host
-		and hddtemp_port to specify a host and port for all hddtemp
-		objects. If no dev parameter is given, the first disk returned
-		by the hddtemp daemon is used.
+        <listitem>Displays temperature of a selected hard disk drive as
+        reported by the hddtemp daemon. Use hddtemp_host and hddtemp_port to
+        specify a host and port for all hddtemp objects. If no dev parameter
+        is given, the first disk returned by the hddtemp daemon is used.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1579,10 +1537,10 @@
             </command>
             <option>logfile lines (next_check)</option>
         </term>
-        <listitem>Displays first N lines of supplied text file. The
-        file is checked every 'next_check' update. If next_check is
-        not supplied, Conky defaults to 2. Max of 30 lines can be
-        displayed, or until the text buffer is filled.
+        <listitem>Displays first N lines of supplied text file. The file is
+        checked every 'next_check' update. If next_check is not supplied,
+        Conky defaults to 2. Max of 30 lines can be displayed, or until the
+        text buffer is filled.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1602,16 +1560,15 @@
             </command>
             <option>(dev) type n (factor offset)</option>
         </term>
-        <listitem>Hwmon sensor from sysfs (Linux 2.6). Parameter
-        dev may be omitted if you have only one hwmon device.
-        Parameter type is either 'in' or 'vol' meaning voltage;
-        'fan' meaning fan; 'temp' meaning temperature. Parameter n
-        is number of the sensor. See /sys/class/hwmon/ on your
-        local computer. The optional arguments 'factor' and
-        'offset' allow precalculation of the raw input, which is
-        being modified as follows: 'input = input * factor +
-        offset'. Note that they have to be given as decimal values
-        (i.e. contain at least one decimal place).
+        <listitem>Hwmon sensor from sysfs (Linux 2.6). Parameter dev may be
+        omitted if you have only one hwmon device. Parameter type is either
+        'in' or 'vol' meaning voltage; 'fan' meaning fan; 'temp' meaning
+        temperature. Parameter n is number of the sensor. See
+        /sys/class/hwmon/ on your local computer. The optional arguments
+        'factor' and 'offset' allow precalculation of the raw input, which is
+        being modified as follows: 'input = input * factor + offset'. Note
+        that they have to be given as decimal values (i.e. contain at least
+        one decimal place).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1631,16 +1588,15 @@
             </command>
             <option>(dev) type n (factor offset)</option>
         </term>
-        <listitem>I2C sensor from sysfs (Linux 2.6). Parameter dev
-        may be omitted if you have only one I2C device. Parameter
-        type is either 'in' or 'vol' meaning voltage; 'fan' meaning
-        fan; 'temp' meaning temperature. Parameter n is number of
-        the sensor. See /sys/bus/i2c/devices/ on your local
-        computer. The optional arguments 'factor' and 'offset'
-        allow precalculation of the raw input, which is being
-        modified as follows: 'input = input * factor + offset'.
-        Note that they have to be given as decimal values (i.e.
-        contain at least one decimal place).
+        <listitem>I2C sensor from sysfs (Linux 2.6). Parameter dev may be
+        omitted if you have only one I2C device. Parameter type is either 'in'
+        or 'vol' meaning voltage; 'fan' meaning fan; 'temp' meaning
+        temperature. Parameter n is number of the sensor. See
+        /sys/bus/i2c/devices/ on your local computer. The optional arguments
+        'factor' and 'offset' allow precalculation of the raw input, which is
+        being modified as follows: 'input = input * factor + offset'. Note
+        that they have to be given as decimal values (i.e. contain at least
+        one decimal place).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1650,10 +1606,10 @@
             </command>
             <option />
         </term>
-        <listitem>If running the i8k kernel driver for Inspiron
-        laptops, displays whether ac power is on, as listed in
-        /proc/i8k (translated to human-readable). Beware that this
-        is by default not enabled by i8k itself.
+        <listitem>If running the i8k kernel driver for Inspiron laptops,
+        displays whether ac power is on, as listed in /proc/i8k (translated to
+        human-readable). Beware that this is by default not enabled by i8k
+        itself.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1663,8 +1619,8 @@
             </command>
             <option />
         </term>
-        <listitem>If running the i8k kernel driver for Inspiron
-        laptops, displays the bios version as listed in /proc/i8k.
+        <listitem>If running the i8k kernel driver for Inspiron laptops,
+        displays the bios version as listed in /proc/i8k.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1674,9 +1630,8 @@
             </command>
             <option />
         </term>
-        <listitem>If running the i8k kernel driver for Inspiron
-        laptops, displays the volume buttons status as listed in
-        /proc/i8k.
+        <listitem>If running the i8k kernel driver for Inspiron laptops,
+        displays the volume buttons status as listed in /proc/i8k.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1686,9 +1641,8 @@
             </command>
             <option />
         </term>
-        <listitem>If running the i8k kernel driver for Inspiron
-        laptops, displays the cpu temperature in Celsius, as
-        reported by /proc/i8k.
+        <listitem>If running the i8k kernel driver for Inspiron laptops,
+        displays the cpu temperature in Celsius, as reported by /proc/i8k.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1698,10 +1652,10 @@
             </command>
             <option />
         </term>
-        <listitem>If running the i8k kernel driver for Inspiron
-        laptops, displays the left fan's rate of rotation, in
-        revolutions per minute as listed in /proc/i8k. Beware, some
-        laptops i8k reports these fans in reverse order.
+        <listitem>If running the i8k kernel driver for Inspiron laptops,
+        displays the left fan's rate of rotation, in revolutions per minute as
+        listed in /proc/i8k. Beware, some laptops i8k reports these fans in
+        reverse order.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1711,10 +1665,10 @@
             </command>
             <option />
         </term>
-        <listitem>If running the i8k kernel driver for Inspiron
-        laptops, displays the left fan status as listed in
-        /proc/i8k (translated to human-readable). Beware, some
-        laptops i8k reports these fans in reverse order.
+        <listitem>If running the i8k kernel driver for Inspiron laptops,
+        displays the left fan status as listed in /proc/i8k (translated to
+        human-readable). Beware, some laptops i8k reports these fans in
+        reverse order.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1724,10 +1678,10 @@
             </command>
             <option />
         </term>
-        <listitem>If running the i8k kernel driver for Inspiron
-        laptops, displays the right fan's rate of rotation, in
-        revolutions per minute as listed in /proc/i8k. Beware, some
-        laptops i8k reports these fans in reverse order.
+        <listitem>If running the i8k kernel driver for Inspiron laptops,
+        displays the right fan's rate of rotation, in revolutions per minute
+        as listed in /proc/i8k. Beware, some laptops i8k reports these fans in
+        reverse order.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1737,10 +1691,10 @@
             </command>
             <option />
         </term>
-        <listitem>If running the i8k kernel driver for Inspiron
-        laptops, displays the right fan status as listed in
-        /proc/i8k (translated to human-readable). Beware, some
-        laptops i8k reports these fans in reverse order.
+        <listitem>If running the i8k kernel driver for Inspiron laptops,
+        displays the right fan status as listed in /proc/i8k (translated to
+        human-readable). Beware, some laptops i8k reports these fans in
+        reverse order.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1750,9 +1704,8 @@
             </command>
             <option />
         </term>
-        <listitem>If running the i8k kernel driver for Inspiron
-        laptops, displays your laptop serial number as listed in
-        /proc/i8k.
+        <listitem>If running the i8k kernel driver for Inspiron laptops,
+        displays your laptop serial number as listed in /proc/i8k.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1762,8 +1715,8 @@
             </command>
             <option />
         </term>
-        <listitem>If running the i8k kernel driver for Inspiron
-        laptops, displays the version formatting of /proc/i8k.
+        <listitem>If running the i8k kernel driver for Inspiron laptops,
+        displays the version formatting of /proc/i8k.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1772,8 +1725,8 @@
                 <option>ibm_brightness</option>
             </command>
         </term>
-        <listitem>If running the IBM ACPI, displays the brigtness
-        of the laptops's LCD (0-7).
+        <listitem>If running the IBM ACPI, displays the brigtness of the
+        laptops's LCD (0-7).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1792,9 +1745,9 @@
             </command>
             <option>N</option>
         </term>
-        <listitem>If running the IBM ACPI, displays the
-        temperatures from the IBM temperature sensors (N=0..7)
-        Sensor 0 is on the CPU, 3 is on the GPU.
+        <listitem>If running the IBM ACPI, displays the temperatures from the
+        IBM temperature sensors (N=0..7) Sensor 0 is on the CPU, 3 is on the
+        GPU.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1804,8 +1757,8 @@
             </command>
         </term>
         <listitem>If running the IBM ACPI, displays the status of your
-            ThinkLight™. Value is either 'on', 'off' or 'unknown'.
-            <para /></listitem>
+        ThinkLight™. Value is either 'on', 'off' or 'unknown'.
+        <para /></listitem>
     </varlistentry>
     <varlistentry>
         <term>
@@ -1813,8 +1766,8 @@
                 <option>ibm_volume</option>
             </command>
         </term>
-        <listitem>If running the IBM ACPI, displays the "master"
-        volume, controlled by the volume keys (0-14).
+        <listitem>If running the IBM ACPI, displays the "master" volume,
+        controlled by the volume keys (0-14).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1824,11 +1777,11 @@
             </command>
             <option>number file</option>
         </term>
-        <listitem>Shows title of event number 'number' in the ical (RFC 5545) file
-        'file'. The events are first ordered by starting time, events that started
-        in the past are  ignored. The events that are shown are the VEVENTS, the
-        title that is shown is the SUMMARY and the starting time used for sorting
-        is DTSTART .
+        <listitem>Shows title of event number 'number' in the ical (RFC 5545)
+        file 'file'. The events are first ordered by starting time, events
+        that started in the past are ignored. The events that are shown are
+        the VEVENTS, the title that is shown is the SUMMARY and the starting
+        time used for sorting is DTSTART .
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1851,8 +1804,8 @@
             </command>
             <option>codeset_from codeset_to</option>
         </term>
-        <listitem>Convert text from one codeset to another using
-        GNU iconv. Needs to be stopped with iconv_stop.
+        <listitem>Convert text from one codeset to another using GNU iconv.
+        Needs to be stopped with iconv_stop.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1872,8 +1825,8 @@
             </command>
             <option>(var)</option>
         </term>
-        <listitem>if conky variable VAR is empty, display
-        everything between $if_empty and the matching $endif
+        <listitem>if conky variable VAR is empty, display everything between
+        $if_empty and the matching $endif
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1883,11 +1836,10 @@
             </command>
             <option>file (string)</option>
         </term>
-        <listitem>if FILE exists, display everything between
-        if_existing and the matching $endif. The optional second
-        parameter checks for FILE containing the specified string
-        and prints everything between $if_existing and the matching
-        $endif.
+        <listitem>if FILE exists, display everything between if_existing and
+        the matching $endif. The optional second parameter checks for FILE
+        containing the specified string and prints everything between
+        $if_existing and the matching $endif.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1896,8 +1848,8 @@
                 <option>if_gw</option>
             </command>
         </term>
-        <listitem>if there is at least one default gateway, display
-        everything between $if_gw and the matching $endif
+        <listitem>if there is at least one default gateway, display everything
+        between $if_gw and the matching $endif
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1907,25 +1859,23 @@
             </command>
             <option>expression</option>
         </term>
-        <listitem>Evaluates the given boolean expression, printing
-        everything between $if_match and the matching $endif
-        depending on whether the evaluation returns true or not.
-        Valid expressions consist of a left side, an operator and a
-        right side. Left and right sides are being parsed for
-        contained text objects before evaluation. Recognised left
+        <listitem>Evaluates the given boolean expression, printing everything
+        between $if_match and the matching $endif depending on whether the
+        evaluation returns true or not. Valid expressions consist of a left
+        side, an operator and a right side. Left and right sides are being
+        parsed for contained text objects before evaluation. Recognised left
         and right side types are:
         <simplelist>
             <member>
-            <command>double</command>Argument consists of only
-            digits and a single dot.</member>
+            <command>double</command>Argument consists of only digits and a
+            single dot.</member>
             <member>
-            <command>long</command>Argument consists of only
-            digits.</member>
+            <command>long</command>Argument consists of only digits.</member>
             <member>
-            <command>string</command>Argument is enclosed in
-            quotation marks (")</member>
-        </simplelist>Valid operands are: '&gt;', '&lt;', '&gt;=',
-        '&lt;=', '==', '!='.
+            <command>string</command>Argument is enclosed in quotation marks
+            (")</member>
+        </simplelist>Valid operands are: '&gt;', '&lt;', '&gt;=', '&lt;=',
+        '==', '!='.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1935,9 +1885,8 @@
             </command>
             <option>(mixer)</option>
         </term>
-        <listitem>If mixer exists, display everything between
-        $if_mixer_mute and the matching $endif. If no mixer is
-        specified, "Vol" is used.
+        <listitem>If mixer exists, display everything between $if_mixer_mute
+        and the matching $endif. If no mixer is specified, "Vol" is used.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1947,8 +1896,8 @@
             </command>
             <option>(mountpoint)</option>
         </term>
-        <listitem>if MOUNTPOINT is mounted, display everything
-        between $if_mounted and the matching $endif
+        <listitem>if MOUNTPOINT is mounted, display everything between
+        $if_mounted and the matching $endif
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1957,8 +1906,8 @@
                 <option>if_mpd_playing</option>
             </command>
         </term>
-        <listitem>if mpd is playing or paused, display everything
-        between $if_mpd_playing and the matching $endif
+        <listitem>if mpd is playing or paused, display everything between
+        $if_mpd_playing and the matching $endif
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -1969,8 +1918,8 @@
         </term>
         <listitem>If Pulseaudio's default sink is muted, display everything
         between $if_pa_sink_muted and the corresponding $else or $endif.
-         <para /></listitem>
-     </varlistentry>
+        <para /></listitem>
+    </varlistentry>
     <varlistentry>
         <term>
             <command>
@@ -1978,21 +1927,20 @@
             </command>
             <option>(process)</option>
         </term>
-        <listitem>If PROCESS is running, display everything
-        between $if_running and the corresponding $else or $endif.
-        Note that PROCESS may be either a full command line with
-        arguments (without the directory prefix), or simply the name
-        of an executable. For example, either of the following will
-        be true if there is a running process with the command line
+        <listitem>If PROCESS is running, display everything between
+        $if_running and the corresponding $else or $endif. Note that PROCESS
+        may be either a full command line with arguments (without the
+        directory prefix), or simply the name of an executable. For example,
+        either of the following will be true if there is a running process
+        with the command line
         <command>/usr/bin/conky -u 5</command>:
         <simplelist>
             <member>
-                <command>${if_running conky -u 5}</command> or
-                <command>${if_running conky}</command>
-            </member>
-        </simplelist>
-        It is important not to include trailing spaces. For example,
-        <command>${if_running conky }</command> will be false.
+            <command>${if_running conky -u 5}</command>or
+            <command>${if_running conky}</command></member>
+        </simplelist>It is important not to include trailing spaces. For
+        example,
+        <command>${if_running conky }</command>will be false.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2002,9 +1950,9 @@
             </command>
             <option>(INDEX)</option>
         </term>
-        <listitem>when using smapi, if the battery with index INDEX
-        is installed, display everything between
-        $if_smapi_bat_installed and the matching $endif
+        <listitem>when using smapi, if the battery with index INDEX is
+        installed, display everything between $if_smapi_bat_installed and the
+        matching $endif
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2014,8 +1962,8 @@
             </command>
             <option>(interface)</option>
         </term>
-        <listitem>if INTERFACE exists and is up, display everything
-        between $if_up and the matching $endif
+        <listitem>if INTERFACE exists and is up, display everything between
+        $if_up and the matching $endif
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2025,12 +1973,11 @@
             </command>
             <option>(updatenr)</option>
         </term>
-        <listitem>If it's the UPDATENR-th time that conky updates,
-        display everything between $if_updatenr and the matching
-        $endif. The counter resets when the highest UPDATENR is
-        reached. Example : "{$if_updatenr 1}foo$endif{$if_updatenr
-        2}bar$endif{$if_updatenr 4}$endif" shows foo 25% of the
-        time followed by bar 25% of the time followed by nothing
+        <listitem>If it's the UPDATENR-th time that conky updates, display
+        everything between $if_updatenr and the matching $endif. The counter
+        resets when the highest UPDATENR is reached. Example : "{$if_updatenr
+        1}foo$endif{$if_updatenr 2}bar$endif{$if_updatenr 4}$endif" shows foo
+        25% of the time followed by bar 25% of the time followed by nothing
         the other half of the time.
         <para /></listitem>
     </varlistentry>
@@ -2040,8 +1987,8 @@
                 <option>if_xmms2_connected</option>
             </command>
         </term>
-        <listitem>Display everything between $if_xmms2_connected
-        and the matching $endif if xmms2 is running.
+        <listitem>Display everything between $if_xmms2_connected and the
+        matching $endif if xmms2 is running.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2049,24 +1996,22 @@
             <command>
                 <option>image</option>
             </command>
-            <option>&lt;path to image&gt; (-p x,y) (-s WxH) (-n)
-            (-f interval)</option>
+            <option>&lt;path to image&gt; (-p x,y) (-s WxH) (-n) (-f
+            interval)</option>
         </term>
-        <listitem>Renders an image from the path specified using
-        Imlib2. Takes 4 optional arguments: a position, a size, a
-        no-cache switch, and a cache flush interval. Changing the
-        x,y position will move the position of the image, and
-        changing the WxH will scale the image. If you specify the
-        no-cache flag (-n), the image will not be cached.
-        Alternately, you can specify the -f int switch to specify a
-        cache flush interval for a particular image. Example:
-        ${image /home/brenden/cheeseburger.jpg -p 20,20 -s 200x200}
-        will render 'cheeseburger.jpg' at (20,20) scaled to 200x200
-        pixels. Conky does not make any attempt to adjust the
-        position (or any other formatting) of images, they are just
-        rendered as per the arguments passed. The only reason
-        $image is part of the conky.text section, is to allow for runtime
-        modifications, through $execp $lua_parse, or some other
+        <listitem>Renders an image from the path specified using Imlib2. Takes
+        4 optional arguments: a position, a size, a no-cache switch, and a
+        cache flush interval. Changing the x,y position will move the position
+        of the image, and changing the WxH will scale the image. If you
+        specify the no-cache flag (-n), the image will not be cached.
+        Alternately, you can specify the -f int switch to specify a cache
+        flush interval for a particular image. Example: ${image
+        /home/brenden/cheeseburger.jpg -p 20,20 -s 200x200} will render
+        'cheeseburger.jpg' at (20,20) scaled to 200x200 pixels. Conky does not
+        make any attempt to adjust the position (or any other formatting) of
+        images, they are just rendered as per the arguments passed. The only
+        reason $image is part of the conky.text section, is to allow for
+        runtime modifications, through $execp $lua_parse, or some other
         method.
         <para /></listitem>
     </varlistentry>
@@ -2077,15 +2022,14 @@
             </command>
             <option>(args)</option>
         </term>
-        <listitem>Displays the number of messages in your global
-        IMAP inbox by default. You can define individual IMAP
-        inboxes separately by passing arguments to this object.
-        Arguments are: "host user pass [-i interval (in seconds)]
-        [-f 'folder'] [-p port] [-e 'command'] [-r retries]". Default
-        port is 143, default folder is 'INBOX', default interval is
-        5 minutes, and default number of retries before giving up
-        is 5. If the password is supplied as '*', you will be
-        prompted to enter the password when Conky starts.
+        <listitem>Displays the number of messages in your global IMAP inbox by
+        default. You can define individual IMAP inboxes separately by passing
+        arguments to this object. Arguments are: "host user pass [-i interval
+        (in seconds)] [-f 'folder'] [-p port] [-e 'command'] [-r retries]".
+        Default port is 143, default folder is 'INBOX', default interval is 5
+        minutes, and default number of retries before giving up is 5. If the
+        password is supplied as '*', you will be prompted to enter the
+        password when Conky starts.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2095,15 +2039,14 @@
             </command>
             <option>(args)</option>
         </term>
-        <listitem>Displays the number of unseen messages in your
-        global IMAP inbox by default. You can define individual
-        IMAP inboxes separately by passing arguments to this
-        object. Arguments are: "host user pass [-i interval (in
-        seconds)] [-f 'folder'] [-p port] [-e 'command'] [-r retries]".
-        Default port is 143, default folder is 'INBOX', default
-        interval is 5 minutes, and default number of retries before
-        giving up is 5. If the password is supplied as '*', you
-        will be prompted to enter the password when Conky starts.
+        <listitem>Displays the number of unseen messages in your global IMAP
+        inbox by default. You can define individual IMAP inboxes separately by
+        passing arguments to this object. Arguments are: "host user pass [-i
+        interval (in seconds)] [-f 'folder'] [-p port] [-e 'command'] [-r
+        retries]". Default port is 143, default folder is 'INBOX', default
+        interval is 5 minutes, and default number of retries before giving up
+        is 5. If the password is supplied as '*', you will be prompted to
+        enter the password when Conky starts.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2113,8 +2056,8 @@
             </command>
             <option>disk</option>
         </term>
-        <listitem>Prints the current ioscheduler used for the given
-        disk name (i.e. e.g. "hda" or "sdb")
+        <listitem>Prints the current ioscheduler used for the given disk name
+        (i.e. e.g. "hda" or "sdb")
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2126,9 +2069,9 @@
         </term>
         <listitem>Displays last N lines of the systemd journal. The optional
         type can be 'user' or 'system' which will show only the user or system
-        journal respectively. By default, all journal lines visible to the user
-        are shown. A maximum of 200 lines can be displayed, or until the text
-        buffer is filled.
+        journal respectively. By default, all journal lines visible to the
+        user are shown. A maximum of 200 lines can be displayed, or until the
+        text buffer is filled.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2211,9 +2154,9 @@
             </command>
             <option>(1|2|3)</option>
         </term>
-        <listitem>System load average, 1 is for past 1 minute, 2
-	for past 5 minutes and 3 for past 15 minutes. Without argument, prints
-	all three values separated by whitespace.
+        <listitem>System load average, 1 is for past 1 minute, 2 for past 5
+        minutes and 3 for past 15 minutes. Without argument, prints all three
+        values separated by whitespace.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2221,15 +2164,14 @@
             <command>
                 <option>loadgraph</option>
             </command>
-            <option>(height),(width) (gradient colour 1)
-            (gradient colour 2) (scale) (-t) (-l)</option>
+            <option>(height),(width) (gradient colour 1) (gradient colour 2)
+            (scale) (-t) (-l)</option>
         </term>
-        <listitem>Load1 average graph, similar to xload, with
-        optional colours in hex, minus the #. Uses a logarithmic
-        scale (to see small numbers) when you use the -l switch.
-        Takes the switch '-t' to use a temperature gradient, which
-        makes the gradient values change depending on the amplitude
-        of a particular graph value (try it and see).
+        <listitem>Load1 average graph, similar to xload, with optional colours
+        in hex, minus the #. Uses a logarithmic scale (to see small numbers)
+        when you use the -l switch. Takes the switch '-t' to use a temperature
+        gradient, which makes the gradient values change depending on the
+        amplitude of a particular graph value (try it and see).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2239,11 +2181,10 @@
             </command>
             <option>function_name (function parameters)</option>
         </term>
-        <listitem>Executes a Lua function with given parameters,
-        then prints the returned string. See also 'lua_load' on how
-        to load scripts. Conky puts 'conky_' in front of
-        function_name to prevent accidental calls to the wrong
-        function unless you put you place 'conky_' in front of it
+        <listitem>Executes a Lua function with given parameters, then prints
+        the returned string. See also 'lua_load' on how to load scripts. Conky
+        puts 'conky_' in front of function_name to prevent accidental calls to
+        the wrong function unless you put you place 'conky_' in front of it
         yourself.
         <para /></listitem>
     </varlistentry>
@@ -2255,12 +2196,11 @@
             <option>(height, width) function_name (function
             parameters)</option>
         </term>
-        <listitem>Executes a Lua function with given parameters and
-        draws a bar. Expects result value to be an integer between
-        0 and 100. See also 'lua_load' on how to load scripts.
-        Conky puts 'conky_' in front of function_name to prevent
-        accidental calls to the wrong function unless you put you
-        place 'conky_' in front of it yourself.
+        <listitem>Executes a Lua function with given parameters and draws a
+        bar. Expects result value to be an integer between 0 and 100. See also
+        'lua_load' on how to load scripts. Conky puts 'conky_' in front of
+        function_name to prevent accidental calls to the wrong function unless
+        you put you place 'conky_' in front of it yourself.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2271,12 +2211,11 @@
             <option>(height, width) function_name (function
             parameters)</option>
         </term>
-        <listitem>Executes a Lua function with given parameters and
-        draws a gauge. Expects result value to be an integer
-        between 0 and 100. See also 'lua_load' on how to load
-        scripts. Conky puts 'conky_' in front of function_name to
-        prevent accidental calls to the wrong function unless you
-        put you place 'conky_' in front of it yourself.
+        <listitem>Executes a Lua function with given parameters and draws a
+        gauge. Expects result value to be an integer between 0 and 100. See
+        also 'lua_load' on how to load scripts. Conky puts 'conky_' in front
+        of function_name to prevent accidental calls to the wrong function
+        unless you put you place 'conky_' in front of it yourself.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2284,18 +2223,17 @@
             <command>
                 <option>lua_graph</option>
             </command>
-            <option>function_name (height),(width) (gradient colour
-            1) (gradient colour 2) (scale) (-t) (-l)</option>
+            <option>function_name (height),(width) (gradient colour 1)
+            (gradient colour 2) (scale) (-t) (-l)</option>
         </term>
-        <listitem>Executes a Lua function with and draws a graph.
-        Expects result value to be any number, and by default will
-        scale to show the full range. See also 'lua_load' on how to
-        load scripts. Takes the switch '-t' to use a temperature
-        gradient, which makes the gradient values change depending
-        on the amplitude of a particular graph value (try it and
-        see). Conky puts 'conky_' in front of function_name to
-        prevent accidental calls to the wrong function unless you
-        put you place 'conky_' in front of it yourself.
+        <listitem>Executes a Lua function with and draws a graph. Expects
+        result value to be any number, and by default will scale to show the
+        full range. See also 'lua_load' on how to load scripts. Takes the
+        switch '-t' to use a temperature gradient, which makes the gradient
+        values change depending on the amplitude of a particular graph value
+        (try it and see). Conky puts 'conky_' in front of function_name to
+        prevent accidental calls to the wrong function unless you put you
+        place 'conky_' in front of it yourself.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2305,12 +2243,11 @@
             </command>
             <option>function_name (function parameters)</option>
         </term>
-        <listitem>Executes a Lua function with given parameters as
-        per $lua, then parses and prints the result value as per
-        the syntax for the conky.text section. See also 'lua_load' on
-        how to load scripts. Conky puts 'conky_' in front of
-        function_name to prevent accidental calls to the wrong
-        function unless you put you place 'conky_' in front of it
+        <listitem>Executes a Lua function with given parameters as per $lua,
+        then parses and prints the result value as per the syntax for the
+        conky.text section. See also 'lua_load' on how to load scripts. Conky
+        puts 'conky_' in front of function_name to prevent accidental calls to
+        the wrong function unless you put you place 'conky_' in front of it
         yourself.
         <para /></listitem>
     </varlistentry>
@@ -2331,11 +2268,10 @@
             <option>(mailbox)</option>
             <option>(interval)</option>
         </term>
-        <listitem>Mail count in the specified mailbox or your mail
-        spool if not. Both mbox and maildir type mailboxes are
-        supported. You can use a program like fetchmail to get
-        mails from some server using your favourite protocol. See
-        also new_mails.
+        <listitem>Mail count in the specified mailbox or your mail spool if
+        not. Both mbox and maildir type mailboxes are supported. You can use a
+        program like fetchmail to get mails from some server using your
+        favourite protocol. See also new_mails.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2343,13 +2279,12 @@
             <command>
                 <option>mboxscan</option>
             </command>
-            <option>(-n number of messages to print) (-fw from
-            width) (-sw subject width) mbox</option>
+            <option>(-n number of messages to print) (-fw from width) (-sw
+            subject width) mbox</option>
         </term>
-        <listitem>Print a summary of recent messages in an mbox
-        format mailbox. mbox parameter is the filename of the
-        mailbox (can be encapsulated using '"', ie. ${mboxscan -n
-        10 "/home/brenden/some box"}
+        <listitem>Print a summary of recent messages in an mbox format
+        mailbox. mbox parameter is the filename of the mailbox (can be
+        encapsulated using '"', ie. ${mboxscan -n 10 "/home/brenden/some box"}
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2367,7 +2302,8 @@
                 <option>memwithbuffers</option>
             </command>
         </term>
-        <listitem>Amount of memory in use, including that used by system buffers and caches
+        <listitem>Amount of memory in use, including that used by system
+        buffers and caches
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2387,7 +2323,8 @@
             </command>
             <option>(height),(width)</option>
         </term>
-        <listitem>Bar that shows amount of memory in use (including memory used by system buffers and caches)
+        <listitem>Bar that shows amount of memory in use (including memory
+        used by system buffers and caches)
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2395,14 +2332,14 @@
             <command>
                 <option>memwithbuffersgraph</option>
             </command>
-            <option>(height),(width) (gradient colour 1) (gradient
-            colour 2) (scale) (-t) (-l)</option>
+            <option>(height),(width) (gradient colour 1) (gradient colour 2)
+            (scale) (-t) (-l)</option>
         </term>
-        <listitem>Memory usage graph including memory used by system buffers and
-            cache. Uses a logarithmic scale (to see small numbers) when you use
-            the -l switch. Takes the switch '-t' to use a temperature gradient,
-            which makes the gradient values change depending on the amplitude of
-            a particular graph value (try it and see).
+        <listitem>Memory usage graph including memory used by system buffers
+        and cache. Uses a logarithmic scale (to see small numbers) when you
+        use the -l switch. Takes the switch '-t' to use a temperature
+        gradient, which makes the gradient values change depending on the
+        amplitude of a particular graph value (try it and see).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2420,8 +2357,8 @@
                 <option>memeasyfree</option>
             </command>
         </term>
-        <listitem>Amount of free memory including the memory that
-        is very easily freed (buffers/cache)
+        <listitem>Amount of free memory including the memory that is very
+        easily freed (buffers/cache)
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2440,8 +2377,7 @@
             </command>
             <option>(height),(width)</option>
         </term>
-        <listitem>Gauge that shows amount of memory in use (see
-        cpugauge)
+        <listitem>Gauge that shows amount of memory in use (see cpugauge)
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2449,14 +2385,13 @@
             <command>
                 <option>memgraph</option>
             </command>
-            <option>(height),(width) (gradient colour 1) (gradient
-            colour 2) (scale) (-t) (-l)</option>
+            <option>(height),(width) (gradient colour 1) (gradient colour 2)
+            (scale) (-t) (-l)</option>
         </term>
-        <listitem>Memory usage graph. Uses a logarithmic scale (to
-        see small numbers) when you use the -l switch. Takes the
-        switch '-t' to use a temperature gradient, which makes the
-        gradient values change depending on the amplitude of a
-        particular graph value (try it and see).
+        <listitem>Memory usage graph. Uses a logarithmic scale (to see small
+        numbers) when you use the -l switch. Takes the switch '-t' to use a
+        temperature gradient, which makes the gradient values change depending
+        on the amplitude of a particular graph value (try it and see).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2484,15 +2419,13 @@
             </command>
             <option>(device)</option>
         </term>
-        <listitem>Prints the mixer value as reported by the OS.
-        On Linux, this variable uses the OSS emulation, so you
-        need the proper kernel module loaded.
-        Default mixer is "Vol", but you can specify one of the
-        available OSS controls: "Vol", "Bass", "Trebl", "Synth",
-        "Pcm", "Spkr", "Line", "Mic", "CD", "Mix", "Pcm2 ", "Rec",
-        "IGain", "OGain", "Line1", "Line2", "Line3", "Digital1",
-        "Digital2", "Digital3", "PhoneIn", "PhoneOut", "Video",
-        "Radio" and "Monitor".
+        <listitem>Prints the mixer value as reported by the OS. On Linux, this
+        variable uses the OSS emulation, so you need the proper kernel module
+        loaded. Default mixer is "Vol", but you can specify one of the
+        available OSS controls: "Vol", "Bass", "Trebl", "Synth", "Pcm",
+        "Spkr", "Line", "Mic", "CD", "Mix", "Pcm2 ", "Rec", "IGain", "OGain",
+        "Line1", "Line2", "Line3", "Digital1", "Digital2", "Digital3",
+        "PhoneIn", "PhoneOut", "Video", "Radio" and "Monitor".
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2502,8 +2435,8 @@
             </command>
             <option>(device)</option>
         </term>
-        <listitem>Displays mixer value in a bar as reported by the
-        OS. See docs for $mixer for details on arguments.
+        <listitem>Displays mixer value in a bar as reported by the OS. See
+        docs for $mixer for details on arguments.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2513,8 +2446,8 @@
             </command>
             <option>(device)</option>
         </term>
-        <listitem>Prints the left channel mixer value as reported
-        by the OS. See docs for $mixer for details on arguments.
+        <listitem>Prints the left channel mixer value as reported by the OS.
+        See docs for $mixer for details on arguments.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2524,9 +2457,8 @@
             </command>
             <option>(device)</option>
         </term>
-        <listitem>Displays the left channel mixer value in a bar as
-        reported by the OS. See docs for $mixer for details on
-        arguments.
+        <listitem>Displays the left channel mixer value in a bar as reported
+        by the OS. See docs for $mixer for details on arguments.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2536,8 +2468,8 @@
             </command>
             <option>(device)</option>
         </term>
-        <listitem>Prints the right channel mixer value as reported
-        by the OS. See docs for $mixer for details on arguments.
+        <listitem>Prints the right channel mixer value as reported by the OS.
+        See docs for $mixer for details on arguments.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2547,9 +2479,8 @@
             </command>
             <option>(device)</option>
         </term>
-        <listitem>Displays the right channel mixer value in a bar
-        as reported by the OS. See docs for $mixer for details on
-        arguments.
+        <listitem>Displays the right channel mixer value in a bar as reported
+        by the OS. See docs for $mixer for details on arguments.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2657,8 +2588,8 @@
                 <option>monitor</option>
             </command>
         </term>
-        <listitem>Number of the monitor on which conky is running
-        or the message "Not running in X" if this is the case.
+        <listitem>Number of the monitor on which conky is running or the
+        message "Not running in X" if this is the case.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2667,8 +2598,8 @@
                 <option>monitor_number</option>
             </command>
         </term>
-        <listitem>Number of monitors or the message "Not running in
-        X" if this is the case.
+        <listitem>Number of monitors or the message "Not running in X" if this
+        is the case.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2695,8 +2626,7 @@
                 <option>mpd_artist</option>
             </command>
         </term>
-        <listitem>Artist in current MPD song must be enabled at
-        compile
+        <listitem>Artist in current MPD song must be enabled at compile
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2806,8 +2736,8 @@
             </command>
             <option>(max length)</option>
         </term>
-        <listitem>Prints the song name in either the form "artist -
-        title" or file name, depending on whats available
+        <listitem>Prints the song name in either the form "artist - title" or
+        file name, depending on whats available
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2854,8 +2784,8 @@
             </command>
             <option>query</option>
         </term>
-        <listitem>Shows the first field of the first row of the
-        result of the query.
+        <listitem>Shows the first field of the first row of the result of the
+        query.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2865,8 +2795,8 @@
             </command>
             <option>(index)</option>
         </term>
-        <listitem>Print a nameserver from /etc/resolv.conf. Index
-        starts at and defaults to 0.
+        <listitem>Print a nameserver from /etc/resolv.conf. Index starts at
+        and defaults to 0.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2877,9 +2807,8 @@
             <option>(mailbox)</option>
             <option>(interval)</option>
         </term>
-        <listitem>Unread mail count in the specified mailbox or
-        mail spool if not. Both mbox and maildir type mailboxes are
-        supported.
+        <listitem>Unread mail count in the specified mailbox or mail spool if
+        not. Both mbox and maildir type mailboxes are supported.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2907,10 +2836,10 @@
             </command>
             <option>text</option>
         </term>
-        <listitem>Shows text and parses the vars in it, but doesn't
-        update them. Use this for things that do not change while conky
-        is running, like $machine, $conky_version,... By not updating
-        this you can save some resources.
+        <listitem>Shows text and parses the vars in it, but doesn't update
+        them. Use this for things that do not change while conky is running,
+        like $machine, $conky_version,... By not updating this you can save
+        some resources.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2921,39 +2850,34 @@
             <option>argument</option>
             <option>(GPU_ID)</option>
         </term>
-        <listitem>Nvidia graphics card information via the XNVCtrl
-        library.
+        <listitem>Nvidia graphics card information via the XNVCtrl library.
         <para>
-        <emphasis>GPU_ID:</emphasis> Optional parameter to choose the GPU to be used as 0,1,2,3,.. Default parameter is 0
-        </para>
+        <emphasis>GPU_ID:</emphasis>Optional parameter to choose the GPU to be
+        used as 0,1,2,3,.. Default parameter is 0</para>
         <para>
-        <emphasis>Possible arguments:</emphasis> (Temperatures are
-        printed as float, all other values as integer. Bracketed
-        arguments are aliases)
+        <emphasis>Possible arguments:</emphasis>(Temperatures are printed as
+        float, all other values as integer. Bracketed arguments are aliases)
         <simplelist type='horiz' columns='2'>
             <!-- Temperatures -->
             <member>
-                <command>gputemp</command>
-                (<command>temp</command>)
-                <option>GPU temperature</option>
-            </member>
+            <command>gputemp</command>(
+            <command>temp</command>)
+            <option>GPU temperature</option></member>
             <member>
-                <command>gputempthreshold</command>
-                (<command>threshold</command>)
-                <option>Temperature threshold where the GPU will reduce it's clock speed</option>
-            </member>
+            <command>gputempthreshold</command>(
+            <command>threshold</command>)
+            <option>Temperature threshold where the GPU will reduce it's clock
+            speed</option></member>
             <member>
-                <command>ambienttemp</command>
-                (<command>ambient</command>)
-                <option>Ambient temperature outside the graphics card</option>
-            </member>
-
+            <command>ambienttemp</command>(
+            <command>ambient</command>)
+            <option>Ambient temperature outside the graphics
+            card</option></member>
             <!-- GPU frequency -->
             <member>
-                <command>gpufreqcur</command>
-                (<command>gpufreq</command>)
-                <option>Current GPU clock speed</option>
-            </member>
+            <command>gpufreqcur</command>(
+            <command>gpufreq</command>)
+            <option>Current GPU clock speed</option></member>
             <member>
                 <command>gpufreqmin</command>
                 <option>Minimum GPU clock speed</option>
@@ -2962,13 +2886,11 @@
                 <command>gpufreqmax</command>
                 <option>Maximum GPU clock speed</option>
             </member>
-
             <!-- Memory frequency -->
             <member>
-                <command>memfreqcur</command>
-                (<command>memfreq</command>)
-                <option>Current memory clock speed</option>
-            </member>
+            <command>memfreqcur</command>(
+            <command>memfreq</command>)
+            <option>Current memory clock speed</option></member>
             <member>
                 <command>memfreqmin</command>
                 <option>Minimum memory clock speed</option>
@@ -2977,13 +2899,11 @@
                 <command>memfreqmax</command>
                 <option>Maximum memory clock speed</option>
             </member>
-
             <!-- Memory transfer rate frequency -->
             <member>
-                <command>mtrfreqcur</command>
-                (<command>mtrfreq</command>)
-                <option>Current memory transfer rate clock speed</option>
-            </member>
+            <command>mtrfreqcur</command>(
+            <command>mtrfreq</command>)
+            <option>Current memory transfer rate clock speed</option></member>
             <member>
                 <command>mtrfreqmin</command>
                 <option>Minimum memory transfer rate clock speed</option>
@@ -2992,13 +2912,11 @@
                 <command>mtrfreqmax</command>
                 <option>Maximum memory transfer rate clock speed</option>
             </member>
-
             <!-- Performance levels -->
             <member>
-                <command>perflevelcur</command>
-                (<command>perflevel</command>)
-                <option>Current performance level</option>
-            </member>
+            <command>perflevelcur</command>(
+            <command>perflevel</command>)
+            <option>Current performance level</option></member>
             <member>
                 <command>perflevelmin</command>
                 <option>Lowest performance level</option>
@@ -3011,7 +2929,6 @@
                 <command>perfmode</command>
                 <option>Performance mode</option>
             </member>
-
             <!-- Load/utilization -->
             <member>
                 <command>gpuutil</command>
@@ -3023,35 +2940,30 @@
             </member>
             <member>
                 <command>videoutil</command>
-                <option>Video engine utilization %</option><!-- ??? -->
+                <option>Video engine utilization %</option>
+                <!-- ??? -->
             </member>
             <member>
                 <command>pcieutil</command>
                 <option>PCIe bandwidth utilization %</option>
             </member>
-
             <!-- RAM statistics -->
             <member>
-                <command>memused</command>
-                (<command>mem</command>)
-                <option>Amount of used memory</option>
-            </member>
+            <command>memused</command>(
+            <command>mem</command>)
+            <option>Amount of used memory</option></member>
             <member>
-                <command>memfree</command>
-                (<command>memavail</command>)
-                <option>Amount of free memory</option>
-            </member>
+            <command>memfree</command>(
+            <command>memavail</command>)
+            <option>Amount of free memory</option></member>
             <member>
-                <command>memmax</command>
-                (<command>memtotal</command>)
-                <option>Total amount of memory</option>
-            </member>
+            <command>memmax</command>(
+            <command>memtotal</command>)
+            <option>Total amount of memory</option></member>
             <member>
-                <command>memutil</command>
-                (<command>memperc</command>)
-                <option>Memory utilization %</option>
-            </member>
-
+            <command>memutil</command>(
+            <command>memperc</command>)
+            <option>Memory utilization %</option></member>
             <!-- Fan/cooler -->
             <member>
                 <command>fanspeed</command>
@@ -3061,7 +2973,6 @@
                 <command>fanlevel</command>
                 <option>Fan level %</option>
             </member>
-
             <!-- Miscellaneous -->
             <member>
                 <command>imagequality</command>
@@ -3071,8 +2982,7 @@
                 <command>modelname</command>
                 <option>name of the GPU card</option>
             </member>
-        </simplelist>
-        </para></listitem>
+        </simplelist></para></listitem>
     </varlistentry>
     <varlistentry>
         <term>
@@ -3083,55 +2993,54 @@
             <option>argument</option>
             <option>(GPU_ID)</option>
         </term>
-        <listitem>Same as nvidia, except it draws its output in a
-        horizontal bar. The height and width parameters are optional,
-        and default to the default_bar_height and default_bar_width
-        config settings, respectively.
+        <listitem>Same as nvidia, except it draws its output in a horizontal
+        bar. The height and width parameters are optional, and default to the
+        default_bar_height and default_bar_width config settings,
+        respectively.
         <para>
-        <emphasis>GPU_ID:</emphasis> Optional parameter to choose the GPU to be used as 0,1,2,3,.. Default parameter is 0
-        </para>
+        <emphasis>GPU_ID:</emphasis>Optional parameter to choose the GPU to be
+        used as 0,1,2,3,.. Default parameter is 0</para>
         <para>
-        <emphasis>Note the following arguments are incompatible:</emphasis>
-        <simplelist type='horiz' columns='3'>
-            <member>
-                <command>gputempthreshold</command>
-                (<command>threshold</command>)
-            </member>
-            <member>
-                <command>gpufreqmin</command>
-            </member>
-            <member>
-                <command>gpufreqmax</command>
-            </member>
-            <member>
-                <command>memfreqmin</command>
-            </member>
-            <member>
-                <command>memfreqmax</command>
-            </member>
-            <member>
-                <command>mtrfreqmin</command>
-            </member>
-            <member>
-                <command>mtrfreqmax</command>
-            </member>
-            <member>
-                <command>perflevelmin</command>
-            </member>
-            <member>
-                <command>perflevelmax</command>
-            </member>
-            <member>
-                <command>perfmode</command>
-            </member>
-            <member>
-                <command>memtotal</command>
-                (<command>memmax</command>)
-            </member>
-            <member>
-                <command>fanspeed</command>
-            </member>
-        </simplelist>
+            <emphasis>Note the following arguments are
+            incompatible:</emphasis>
+            <simplelist type='horiz' columns='3'>
+                <member>
+                <command>gputempthreshold</command>(
+                <command>threshold</command>)</member>
+                <member>
+                    <command>gpufreqmin</command>
+                </member>
+                <member>
+                    <command>gpufreqmax</command>
+                </member>
+                <member>
+                    <command>memfreqmin</command>
+                </member>
+                <member>
+                    <command>memfreqmax</command>
+                </member>
+                <member>
+                    <command>mtrfreqmin</command>
+                </member>
+                <member>
+                    <command>mtrfreqmax</command>
+                </member>
+                <member>
+                    <command>perflevelmin</command>
+                </member>
+                <member>
+                    <command>perflevelmax</command>
+                </member>
+                <member>
+                    <command>perfmode</command>
+                </member>
+                <member>
+                <command>memtotal</command>(
+                <command>memmax</command>)</member>
+                <member>
+                    <command>fanspeed</command>
+                </member>
+            </simplelist>
         </para></listitem>
     </varlistentry>
     <varlistentry>
@@ -3143,17 +3052,15 @@
             <option>argument</option>
             <option>(GPU_ID)</option>
         </term>
-        <listitem>Same as nvidiabar, except  a round gauge
-        (much like a vehicle speedometer). The height
-        and width parameters are optional, and default to the
-        default_gauge_height and default_gauge_width config
+        <listitem>Same as nvidiabar, except a round gauge (much like a vehicle
+        speedometer). The height and width parameters are optional, and
+        default to the default_gauge_height and default_gauge_width config
         settings, respectively.
         <para>
-        <emphasis>GPU_ID:</emphasis> Optional parameter to choose the GPU to be used as 0,1,2,3,.. Default parameter is 0
-        </para>
-        <para>
-        For possible arguments see nvidia and nvidiabar.
-        </para></listitem>
+        <emphasis>GPU_ID:</emphasis>Optional parameter to choose the GPU to be
+        used as 0,1,2,3,.. Default parameter is 0</para>
+        <para>For possible arguments see nvidia and
+        nvidiabar.</para></listitem>
     </varlistentry>
     <varlistentry>
         <term>
@@ -3169,19 +3076,16 @@
             <option>(-l)</option>
             <option>GPU_ID</option>
         </term>
-        <listitem>Same as nvidiabar, except a horizontally
-        scrolling graph with values from 0-100 plotted on the
-        vertical axis. The height and width parameters are
-        optional, and default to the default_graph_height and
-        default_graph_width config settings, respectively.
+        <listitem>Same as nvidiabar, except a horizontally scrolling graph
+        with values from 0-100 plotted on the vertical axis. The height and
+        width parameters are optional, and default to the default_graph_height
+        and default_graph_width config settings, respectively.
         <para>
-        <emphasis>GPU_ID:</emphasis> NOT optional. This parameter allows to choose the GPU to be used as 0,1,2,3,..
-        </para>
-        <para>
-        For possible arguments see nvidia and nvidiabar. To learn more
-        about the -t -l and gradient color options,
-        see execgraph.
-        </para></listitem>
+        <emphasis>GPU_ID:</emphasis>NOT optional. This parameter allows to
+        choose the GPU to be used as 0,1,2,3,..</para>
+        <para>For possible arguments see nvidia and nvidiabar. To learn more
+        about the -t -l and gradient color options, see
+        execgraph.</para></listitem>
     </varlistentry>
     <varlistentry>
         <term>
@@ -3274,7 +3178,7 @@
             </command>
         </term>
         <listitem>Pulseaudio's default card active profile.
-         <para /></listitem>
+        <para /></listitem>
     </varlistentry>
     <varlistentry>
         <term>
@@ -3283,30 +3187,27 @@
             </command>
             <option>item</option>
         </term>
-        <listitem>If running on Apple powerbook/ibook, display
-        information on battery status. The item parameter
-        specifies, what information to display. Exactly one item
-        must be specified. Valid items are:
+        <listitem>If running on Apple powerbook/ibook, display information on
+        battery status. The item parameter specifies, what information to
+        display. Exactly one item must be specified. Valid items are:
         <simplelist>
             <member>
                 <command>status</command>
-                <option>Display if battery is fully charged,
-                charging, discharging or absent (running on
-                AC)</option>
+                <option>Display if battery is fully charged, charging,
+                discharging or absent (running on AC)</option>
             </member>
             <member>
                 <command>percent</command>
-                <option>Display charge of battery in percent, if
-                charging or discharging. Nothing will be displayed,
-                if battery is fully charged or absent.</option>
+                <option>Display charge of battery in percent, if charging or
+                discharging. Nothing will be displayed, if battery is fully
+                charged or absent.</option>
             </member>
             <member>
                 <command>time</command>
-                <option>Display the time remaining until the
-                battery will be fully charged or discharged at
-                current rate. Nothing is displayed, if battery is
-                absent or if it's present but fully charged and not
-                discharging.</option>
+                <option>Display the time remaining until the battery will be
+                fully charged or discharged at current rate. Nothing is
+                displayed, if battery is absent or if it's present but fully
+                charged and not discharging.</option>
             </member>
         </simplelist>
         <para /></listitem>
@@ -3318,8 +3219,8 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>Directory used as rootdirectory by the process
-	(this will be "/" unless the process did a chroot syscall)
+        <listitem>Directory used as rootdirectory by the process (this will be
+        "/" unless the process did a chroot syscall)
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3439,10 +3340,10 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>One of the chars in "RSDZTW" representing the state
-	of the process where R is running, S is sleeping in an
-	interruptible wait, D is waiting in uninterruptible disk sleep,
-	Z is zombie, T is traced or stopped (on a signal), and W is paging
+        <listitem>One of the chars in "RSDZTW" representing the state of the
+        process where R is running, S is sleeping in an interruptible wait, D
+        is waiting in uninterruptible disk sleep, Z is zombie, T is traced or
+        stopped (on a signal), and W is paging
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3502,7 +3403,8 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>Amount of time that the process has been scheduled in kernel mode in seconds
+        <listitem>Amount of time that the process has been scheduled in kernel
+        mode in seconds
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3512,7 +3414,8 @@
             </command>
             <option>pid</option>
         </term>
-        <listitem>Amount of time that the process has been scheduled in user mode in seconds
+        <listitem>Amount of time that the process has been scheduled in user
+        mode in seconds
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3722,16 +3625,15 @@
             </command>
             <option>(dev) type n (factor offset)</option>
         </term>
-        <listitem>Platform sensor from sysfs (Linux 2.6). Parameter
-        dev may be omitted if you have only one platform device.
-        Platform type is either 'in' or 'vol' meaning voltage;
-        'fan' meaning fan; 'temp' meaning temperature. Parameter n
-        is number of the sensor. See /sys/bus/platform/devices/ on
-        your local computer. The optional arguments 'factor' and
-        'offset' allow precalculation of the raw input, which is
-        being modified as follows: 'input = input * factor +
-        offset'. Note that they have to be given as decimal values
-        (i.e. contain at least one decimal place).
+        <listitem>Platform sensor from sysfs (Linux 2.6). Parameter dev may be
+        omitted if you have only one platform device. Platform type is either
+        'in' or 'vol' meaning voltage; 'fan' meaning fan; 'temp' meaning
+        temperature. Parameter n is number of the sensor. See
+        /sys/bus/platform/devices/ on your local computer. The optional
+        arguments 'factor' and 'offset' allow precalculation of the raw input,
+        which is being modified as follows: 'input = input * factor + offset'.
+        Note that they have to be given as decimal values (i.e. contain at
+        least one decimal place).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3741,15 +3643,13 @@
             </command>
             <option>(args)</option>
         </term>
-        <listitem>Displays the number of unseen messages in your
-        global POP3 inbox by default. You can define individual
-        POP3 inboxes separately by passing arguments to this
-        object. Arguments are: "host user pass [-i interval (in
-        seconds)] [-p port] [-e 'command'] [-r retries]". Default
-        port is 110, default interval is 5 minutes, and default
-        number of retries before giving up is 5. If the password is
-        supplied as '*', you will be prompted to enter the password
-        when Conky starts.
+        <listitem>Displays the number of unseen messages in your global POP3
+        inbox by default. You can define individual POP3 inboxes separately by
+        passing arguments to this object. Arguments are: "host user pass [-i
+        interval (in seconds)] [-p port] [-e 'command'] [-r retries]". Default
+        port is 110, default interval is 5 minutes, and default number of
+        retries before giving up is 5. If the password is supplied as '*', you
+        will be prompted to enter the password when Conky starts.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3759,15 +3659,14 @@
             </command>
             <option>(args)</option>
         </term>
-        <listitem>Displays the amount of space (in MiB, 2^20) used
-        in your global POP3 inbox by default. You can define
-        individual POP3 inboxes separately by passing arguments to
-        this object. Arguments are: "host user pass [-i interval
-        (in seconds)] [-p port] [-e 'command'] [-r retries]". Default
-        port is 110, default interval is 5 minutes, and default
-        number of retries before giving up is 5. If the password is
-        supplied as '*', you will be prompted to enter the password
-        when Conky starts.
+        <listitem>Displays the amount of space (in MiB, 2^20) used in your
+        global POP3 inbox by default. You can define individual POP3 inboxes
+        separately by passing arguments to this object. Arguments are: "host
+        user pass [-i interval (in seconds)] [-p port] [-e 'command'] [-r
+        retries]". Default port is 110, default interval is 5 minutes, and
+        default number of retries before giving up is 5. If the password is
+        supplied as '*', you will be prompted to enter the password when Conky
+        starts.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3786,9 +3685,8 @@
             </command>
             <option>(host) port</option>
         </term>
-        <listitem>Connects to a tcp port on a host (default is
-        localhost), reads every char available at the moment and
-        shows them.
+        <listitem>Connects to a tcp port on a host (default is localhost),
+        reads every char available at the moment and shows them.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3798,9 +3696,8 @@
             </command>
             <option>(host) port</option>
         </term>
-        <listitem>Connects to a udp port on a host (default is
-        localhost), reads every char available at the moment and
-        shows them.
+        <listitem>Connects to a udp port on a host (default is localhost),
+        reads every char available at the moment and shows them.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3811,9 +3708,9 @@
             <option>(maildir)</option>
             <option>(interval)</option>
         </term>
-        <listitem>Number of mails marked as replied in the
-        specified mailbox or mail spool if not. Only maildir type
-        mailboxes are supported, mbox type will return -1.
+        <listitem>Number of mails marked as replied in the specified mailbox
+        or mail spool if not. Only maildir type mailboxes are supported, mbox
+        type will return -1.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3824,17 +3721,14 @@
             <option>uri interval_in_seconds action (num_par
             (spaces_in_front))</option>
         </term>
-        <listitem>
-            Download and parse RSS feeds. The interval may be
-            a (floating point) value greater than 0.
-            Action may be one of the following: feed_title, item_title (with num par),
-            item_desc (with num par) and item_titles (when using
-            this action and spaces_in_front is given conky places
-            that many spaces in front of each item). This object is
-            threaded, and once a thread is created it can't be
-            explicitly destroyed. One thread will run for each URI
-            specified. You can use any protocol that Curl
-            supports.
+        <listitem>Download and parse RSS feeds. The interval may be a
+        (floating point) value greater than 0. Action may be one of the
+        following: feed_title, item_title (with num par), item_desc (with num
+        par) and item_titles (when using this action and spaces_in_front is
+        given conky places that many spaces in front of each item). This
+        object is threaded, and once a thread is created it can't be
+        explicitly destroyed. One thread will run for each URI specified. You
+        can use any protocol that Curl supports.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3843,8 +3737,7 @@
                 <option>running_processes</option>
             </command>
         </term>
-        <listitem>Running processes (not sleeping), requires Linux
-        2.6
+        <listitem>Running processes (not sleeping), requires Linux 2.6
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3863,20 +3756,18 @@
             </command>
             <option>(direction) length (step) (interval) text</option>
         </term>
-        <listitem>Scroll 'text' by 'step' characters to the left
-	or right (set 'direction' to 'left' or 'right' or 'wait')
-	showing 'length' number of characters at the same time. The
-	text may also contain variables. 'step' is optional and
-	defaults to 1 if not set. 'direction' is optional and defaults
-	to left if not set.  When direction is 'wait' then text will
-	scroll left and wait for 'interval' itertations at the
-	beginning and end of the text.  If a var creates output on
-	multiple lines then the lines are placed behind each other
-	separated with a '|'-sign.  If you change the textcolor inside
-	$scroll it will automatically have it's old value back at the
-	end of $scroll.  The end and the start of text will be
-	separated by 'length' number of spaces unless direction is
-	'wait'.
+        <listitem>Scroll 'text' by 'step' characters to the left or right (set
+        'direction' to 'left' or 'right' or 'wait') showing 'length' number of
+        characters at the same time. The text may also contain variables.
+        'step' is optional and defaults to 1 if not set. 'direction' is
+        optional and defaults to left if not set. When direction is 'wait'
+        then text will scroll left and wait for 'interval' itertations at the
+        beginning and end of the text. If a var creates output on multiple
+        lines then the lines are placed behind each other separated with a
+        '|'-sign. If you change the textcolor inside $scroll it will
+        automatically have it's old value back at the end of $scroll. The end
+        and the start of text will be separated by 'length' number of spaces
+        unless direction is 'wait'.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3887,9 +3778,9 @@
             <option>(maildir)</option>
             <option>(interval)</option>
         </term>
-        <listitem>Number of mails marked as seen in the specified
-        mailbox or mail spool if not. Only maildir type mailboxes
-        are supported, mbox type will return -1.
+        <listitem>Number of mails marked as seen in the specified mailbox or
+        mail spool if not. Only maildir type mailboxes are supported, mbox
+        type will return -1.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3899,40 +3790,25 @@
             </command>
             <option>(switch)</option>
         </term>
-        <listitem>Prints info regarding System Integrity Protection (SIP) on macOS.
-
-            If no switch is provided, prints SIP status (enabled / disabled),  else,
-            status of the specific SIP feature corresponding to the switch provided.
-
-            Below are shown the available switches:
-
-            SWITCH--------------------------RESULT--------------------------STATUS
-            0                           apple internal                      YES/NO
-            1                           forbid untrusted kexts              YES/NO
-            2                           forbid task-for-pid                 YES/NO
-            3                           restrict filesystem                 YES/NO
-            4                           forbid kernel-debugger              YES/NO
-            5                           restrict dtrace                     YES/NO
-            6                           restrict nvram                      YES/NO
-            7                           forbid device-configuration         YES/NO
-            8                           forbid any-recovery-os              YES/NO
-            9                           forbid user-approved-kexts          YES/NO
-            a                           uses unsupported configuration?        (*)
-
-            (*):    If yes, prints "unsupported configuration, beware!"
-                    Else, prints "configuration is ok".
-            ----------------------------------------------------------------------
-
-            USAGE:
-            conky -t '${sip_status}'    # print SIP status
-            conky -t '${sip_status 0}'  # print allows apple-internal?  Yes or No?
-
-            NOTES:
-                * Available for all macOS versions (even the ones prior El Capitan
-                  where SIP was first introduced)
-                * If run on versions prior El Capitan SIP is unavailable,  so  all
-                  you will get is "unsupported"
-            <para /></listitem>
+        <listitem>Prints info regarding System Integrity Protection (SIP) on
+        macOS. If no switch is provided, prints SIP status (enabled /
+        disabled), else, status of the specific SIP feature corresponding to
+        the switch provided. Below are shown the available switches:
+        SWITCH--------------------------RESULT--------------------------STATUS
+        0 apple internal YES/NO 1 forbid untrusted kexts YES/NO 2 forbid
+        task-for-pid YES/NO 3 restrict filesystem YES/NO 4 forbid
+        kernel-debugger YES/NO 5 restrict dtrace YES/NO 6 restrict nvram
+        YES/NO 7 forbid device-configuration YES/NO 8 forbid any-recovery-os
+        YES/NO 9 forbid user-approved-kexts YES/NO a uses unsupported
+        configuration? (*) (*): If yes, prints "unsupported configuration,
+        beware!" Else, prints "configuration is ok".
+        ----------------------------------------------------------------------
+        USAGE: conky -t '${sip_status}' # print SIP status conky -t
+        '${sip_status 0}' # print allows apple-internal? Yes or No? NOTES: *
+        Available for all macOS versions (even the ones prior El Capitan where
+        SIP was first introduced) * If run on versions prior El Capitan SIP is
+        unavailable, so all you will get is "unsupported"
+        <para /></listitem>
     </varlistentry>
     <varlistentry>
         <term>
@@ -3952,11 +3828,10 @@
             <option>(ARGS)</option>
         </term>
         <listitem>when using smapi, display contents of the
-        /sys/devices/platform/smapi directory. ARGS are either
-        '(FILENAME)' or 'bat (INDEX) (FILENAME)' to display the
-        corresponding files' content. This is a very raw method of
-        accessing the smapi values. When available, better use one
-        of the smapi_* variables instead.
+        /sys/devices/platform/smapi directory. ARGS are either '(FILENAME)' or
+        'bat (INDEX) (FILENAME)' to display the corresponding files' content.
+        This is a very raw method of accessing the smapi values. When
+        available, better use one of the smapi_* variables instead.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3966,8 +3841,8 @@
             </command>
             <option>(INDEX),(height),(width)</option>
         </term>
-        <listitem>when using smapi, display the remaining capacity
-        of the battery with index INDEX as a bar.
+        <listitem>when using smapi, display the remaining capacity of the
+        battery with index INDEX as a bar.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3977,10 +3852,9 @@
             </command>
             <option>(INDEX)</option>
         </term>
-        <listitem>when using smapi, display the remaining capacity
-        in percent of the battery with index INDEX. This is a
-        separate variable because it supports the 'use_spacer'
-        configuration option.
+        <listitem>when using smapi, display the remaining capacity in percent
+        of the battery with index INDEX. This is a separate variable because
+        it supports the 'use_spacer' configuration option.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -3990,11 +3864,10 @@
             </command>
             <option>INDEX</option>
         </term>
-        <listitem>when using smapi, display the current power of
-        the battery with index INDEX in watt. This is a separate
-        variable because the original read out value is being
-        converted from mW. The sign of the output reflects charging
-        (positive) or discharging (negative) state.
+        <listitem>when using smapi, display the current power of the battery
+        with index INDEX in watt. This is a separate variable because the
+        original read out value is being converted from mW. The sign of the
+        output reflects charging (positive) or discharging (negative) state.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4004,10 +3877,10 @@
             </command>
             <option>INDEX</option>
         </term>
-        <listitem>when using smapi, display the current temperature
-        of the battery with index INDEX in degree Celsius. This is
-        a separate variable because the original read out value is
-        being converted from milli degree Celsius.
+        <listitem>when using smapi, display the current temperature of the
+        battery with index INDEX in degree Celsius. This is a separate
+        variable because the original read out value is being converted from
+        milli degree Celsius.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4016,8 +3889,8 @@
                 <option>sony_fanspeed</option>
             </command>
         </term>
-        <listitem>Displays the Sony VAIO fanspeed information if
-        sony-laptop kernel support is enabled. Linux only.
+        <listitem>Displays the Sony VAIO fanspeed information if sony-laptop
+        kernel support is enabled. Linux only.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4027,7 +3900,8 @@
             </command>
             <option>text</option>
         </term>
-        <listitem>All words capitalized regardless.<para /></listitem>
+        <listitem>All words capitalized regardless.
+        <para /></listitem>
     </varlistentry>
     <varlistentry>
         <term>
@@ -4046,8 +3920,35 @@
             </command>
             <option>symbol data</option>
         </term>
-        <listitem>Displays the data of a stock symbol. The following data
-        is supported: adv(Average Daily Volume), ask, asksize, bid, askrt(ask realtime), bidrt(bid realtime), bookvalue, bidsize, change, commission, changert(change realtime), ahcrt(After Hours Change realtime), ds(dividend/share), ltd(Last Trade Date), tradedate, es(earnings/share), ei(error indication), epsecy(EPS Estimate Current Year), epseny(EPS Estimate Next Year), epsenq(EPS Estimate Next Quarter), floatshares, dayslow, dayshigh, 52weeklow, 52weekhigh, hgp(Holdings Gain Percent), ag(Annualized Gain), hg(Holdings Gain), hgprt(Holdings Gain Percent realtime), hgrt(Holdings Gain realtime), moreinfo, obrt(Order Book realtime), mc(Market Capitalization), mcrt(Market Cap realtime), ebitda, c52wlow(Change From 52-week Low), pc52wlow(Percent Change From 52-week Low), cprt(change percent realtime), lts(Last Trade Size), c52whigh(Change from 52-week high), pc52whigh(percent change from 52-week high), ltp(last trade price), hl(high limit), ll(low limit), dr(day's range), drrt(day's range realtime), 50ma(50-day Moving Average), 200ma(200-day Moving Average), c200ma(Change From 200-day Moving Average), pc200ma(Percent Change From 200-day Moving Average), c50ma(Change From 50-day Moving Average), pc50ma(Percent Change From 50-day Moving Average), name, notes, open, pc(previous close), pricepaid, cip(change in percent), ps(price/sales), pb(price/book), edv(Ex-Dividend Date), per(P/E Ratio), dpd(Dividend Pay Date), perrt(P/E Ratio realtime), pegr(PEG Ratio), pepsecy(Price/EPS Estimate Current Year), pepseny(Price/EPS Estimate Next Year), symbol, sharesowned, shortratio, ltt(Last Trade Time), tradelinks, tt(Ticker Trend), 1ytp(1 yr Target Price), volume, hv(Holdings Value), hvrt(Holdings Value realtime), 52weekrange, dvc(Day's Value Change), dvcrt(Day's Value Change realtime), se(Stock Exchange), dy(Dividend Yield)
+        <listitem>Displays the data of a stock symbol. The following data is
+        supported: adv(Average Daily Volume), ask, asksize, bid, askrt(ask
+        realtime), bidrt(bid realtime), bookvalue, bidsize, change,
+        commission, changert(change realtime), ahcrt(After Hours Change
+        realtime), ds(dividend/share), ltd(Last Trade Date), tradedate,
+        es(earnings/share), ei(error indication), epsecy(EPS Estimate Current
+        Year), epseny(EPS Estimate Next Year), epsenq(EPS Estimate Next
+        Quarter), floatshares, dayslow, dayshigh, 52weeklow, 52weekhigh,
+        hgp(Holdings Gain Percent), ag(Annualized Gain), hg(Holdings Gain),
+        hgprt(Holdings Gain Percent realtime), hgrt(Holdings Gain realtime),
+        moreinfo, obrt(Order Book realtime), mc(Market Capitalization),
+        mcrt(Market Cap realtime), ebitda, c52wlow(Change From 52-week Low),
+        pc52wlow(Percent Change From 52-week Low), cprt(change percent
+        realtime), lts(Last Trade Size), c52whigh(Change from 52-week high),
+        pc52whigh(percent change from 52-week high), ltp(last trade price),
+        hl(high limit), ll(low limit), dr(day's range), drrt(day's range
+        realtime), 50ma(50-day Moving Average), 200ma(200-day Moving Average),
+        c200ma(Change From 200-day Moving Average), pc200ma(Percent Change
+        From 200-day Moving Average), c50ma(Change From 50-day Moving
+        Average), pc50ma(Percent Change From 50-day Moving Average), name,
+        notes, open, pc(previous close), pricepaid, cip(change in percent),
+        ps(price/sales), pb(price/book), edv(Ex-Dividend Date), per(P/E
+        Ratio), dpd(Dividend Pay Date), perrt(P/E Ratio realtime), pegr(PEG
+        Ratio), pepsecy(Price/EPS Estimate Current Year), pepseny(Price/EPS
+        Estimate Next Year), symbol, sharesowned, shortratio, ltt(Last Trade
+        Time), tradelinks, tt(Ticker Trend), 1ytp(1 yr Target Price), volume,
+        hv(Holdings Value), hvrt(Holdings Value realtime), 52weekrange,
+        dvc(Day's Value Change), dvcrt(Day's Value Change realtime), se(Stock
+        Exchange), dy(Dividend Yield)
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4122,8 +4023,8 @@
             </command>
             <option>(width, (start))</option>
         </term>
-        <listitem>Puts a tab of the specified width, starting from
-        column 'start'. The unit is pixels for both arguments.
+        <listitem>Puts a tab of the specified width, starting from column
+        'start'. The unit is pixels for both arguments.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4133,10 +4034,10 @@
             </command>
             <option>logfile lines (next_check)</option>
         </term>
-        <listitem>Displays last N lines of supplied text file. The
-        file is checked every 'next_check' update. If next_check is
-        not supplied, Conky defaults to 2. Max of 30 lines can be
-        displayed, or until the text buffer is filled.
+        <listitem>Displays last N lines of supplied text file. The file is
+        checked every 'next_check' update. If next_check is not supplied,
+        Conky defaults to 2. Max of 30 lines can be displayed, or until the
+        text buffer is filled.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4146,12 +4047,12 @@
             </command>
             <option>host (port)</option>
         </term>
-        <listitem>Displays the number of microseconds it takes to
-        get a reply on a ping to to tcp 'port' on 'host'. 'port' is optional
-        and has 80 as default. This works on both open and closed
-        ports, just make sure that the port is not behind a firewall or you
-        will get 'down' as answer. It's best to test a closed port instead
-        of an open port, you will get a quicker response.
+        <listitem>Displays the number of microseconds it takes to get a reply
+        on a ping to to tcp 'port' on 'host'. 'port' is optional and has 80 as
+        default. This works on both open and closed ports, just make sure that
+        the port is not behind a firewall or you will get 'down' as answer.
+        It's best to test a closed port instead of an open port, you will get
+        a quicker response.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4162,14 +4063,13 @@
             <option>port_begin port_end item (index)</option>
         </term>
         <listitem>
-            <para>TCP port (both IPv6 and IPv4) monitor for
-            specified local ports. Port numbers must be in
-            the range 1 to 65535. Valid items are:</para>
+            <para>TCP port (both IPv6 and IPv4) monitor for specified local
+            ports. Port numbers must be in the range 1 to 65535. Valid items
+            are:</para>
             <simplelist>
                 <member>
                     <command>count</command>
-                    <option>Total number of connections in the
-                    range</option>
+                    <option>Total number of connections in the range</option>
                 </member>
                 <member>
                     <command>rip</command>
@@ -4185,8 +4085,7 @@
                 </member>
                 <member>
                     <command>rservice</command>
-                    <option>Remote service name from
-                    /etc/services</option>
+                    <option>Remote service name from /etc/services</option>
                 </member>
                 <member>
                     <command>lip</command>
@@ -4202,60 +4101,53 @@
                 </member>
                 <member>
                     <command>lservice</command>
-                    <option>Local service name from
-                    /etc/services</option>
+                    <option>Local service name from /etc/services</option>
                 </member>
             </simplelist>
-            <para>The connection index provides you with access to
-            each connection in the port monitor. The monitor will
-            return information for index values from 0 to n-1
-            connections. Values higher than n-1 are simply ignored.
-            For the "count" item, the connection index must be
-            omitted. It is required for all other items.</para>
+            <para>The connection index provides you with access to each
+            connection in the port monitor. The monitor will return
+            information for index values from 0 to n-1 connections. Values
+            higher than n-1 are simply ignored. For the "count" item, the
+            connection index must be omitted. It is required for all other
+            items.</para>
             <para>Examples:</para>
             <simplelist>
                 <member>
-                    <command>${tcp_portmon 6881 6999
-                    count}</command>
-                    <option>Displays the number of connections in
-                    the bittorrent port range</option>
+                    <command>${tcp_portmon 6881 6999 count}</command>
+                    <option>Displays the number of connections in the
+                    bittorrent port range</option>
                 </member>
                 <member>
                     <command>${tcp_portmon 22 22 rip 0}</command>
-                    <option>Displays the remote host ip of the
-                    first sshd connection</option>
+                    <option>Displays the remote host ip of the first sshd
+                    connection</option>
                 </member>
                 <member>
                     <command>${tcp_portmon 22 22 rip 9}</command>
-                    <option>Displays the remote host ip of the
-                    tenth sshd connection</option>
+                    <option>Displays the remote host ip of the tenth sshd
+                    connection</option>
                 </member>
                 <member>
-                    <command>${tcp_portmon 1 1024 rhost
-                    0}</command>
-                    <option>Displays the remote host name of the
-                    first connection on a privileged port</option>
+                    <command>${tcp_portmon 1 1024 rhost 0}</command>
+                    <option>Displays the remote host name of the first
+                    connection on a privileged port</option>
                 </member>
                 <member>
-                    <command>${tcp_portmon 1 1024 rport
-                    4}</command>
-                    <option>Displays the remote host port of the
-                    fifth connection on a privileged port</option>
+                    <command>${tcp_portmon 1 1024 rport 4}</command>
+                    <option>Displays the remote host port of the fifth
+                    connection on a privileged port</option>
                 </member>
                 <member>
-                    <command>${tcp_portmon 1 65535 lservice
-                    14}</command>
-                    <option>Displays the local service name of the
-                    fifteenth connection in the range of all
-                    ports</option>
+                    <command>${tcp_portmon 1 65535 lservice 14}</command>
+                    <option>Displays the local service name of the fifteenth
+                    connection in the range of all ports</option>
                 </member>
             </simplelist>
-            <para>Note that port monitor variables which share the
-            same port range actually refer to the same monitor, so
-            many references to a single port range for different
-            items and different indexes all use the same monitor
-            internally. In other words, the program avoids creating
-            redundant monitors.</para>
+            <para>Note that port monitor variables which share the same port
+            range actually refer to the same monitor, so many references to a
+            single port range for different items and different indexes all
+            use the same monitor internally. In other words, the program
+            avoids creating redundant monitors.</para>
         </listitem>
     </varlistentry>
     <varlistentry>
@@ -4268,28 +4160,26 @@
             <option>(arg3 ...)</option>
         </term>
         <listitem>
-            <para>Evaluate the content of the templateN
-            configuration variable (where N is a value between 0
-            and 9, inclusively), applying substitutions as
-            described in the documentation of the corresponding
-            configuration variable. The number of arguments is
-            optional, but must match the highest referred index in
-            the template. You can use the same special sequences in
-            each argument as the ones valid for a template
-            definition, e.g. to allow an argument to contain a
-            whitespace. Also simple nesting of templates is
-            possible this way.</para>
-            <para>Here are some examples of template
-            definitions, note they are placed between [[ ... ]] instead of ' ... ':</para>
+            <para>Evaluate the content of the templateN configuration variable
+            (where N is a value between 0 and 9, inclusively), applying
+            substitutions as described in the documentation of the
+            corresponding configuration variable. The number of arguments is
+            optional, but must match the highest referred index in the
+            template. You can use the same special sequences in each argument
+            as the ones valid for a template definition, e.g. to allow an
+            argument to contain a whitespace. Also simple nesting of templates
+            is possible this way.</para>
+            <para>Here are some examples of template definitions, note they
+            are placed between [[ ... ]] instead of ' ... ':</para>
             <simplelist>
                 <member>template0 = [[$\1\2]]</member>
                 <member>template1 = [[\1: ${fs_used \2} / ${fs_size
                 \2}]]</member>
                 <member>template2 = [[\1 \2]]</member>
             </simplelist>
-            <para>The following list shows sample usage of the
-            templates defined above, with the equivalent syntax
-            when not using any template at all:</para>
+            <para>The following list shows sample usage of the templates
+            defined above, with the equivalent syntax when not using any
+            template at all:</para>
             <table>
                 <tgroup cols="2">
                     <thead>
@@ -4305,20 +4195,13 @@
                         </row>
                         <row>
                             <entry>${template1 root /}</entry>
-                            <entry>root: ${fs_free /} / ${fs_size
-                            /}</entry>
+                            <entry>root: ${fs_free /} / ${fs_size /}</entry>
                         </row>
                         <row>
-                            <entry>
-                                ${template1
-                                ${template2\ disk\ root}
-                                /}
-                            </entry>
-                            <entry>
-                                disk root:
-                                ${fs_free /} / ${fs_size
-                                /}
-                            </entry>
+                            <entry>${template1 ${template2\ disk\ root}
+                            /}</entry>
+                            <entry>disk root: ${fs_free /} / ${fs_size
+                            /}</entry>
                         </row>
                     </tbody>
                 </tgroup>
@@ -4333,17 +4216,15 @@
             <option>interval</option>
             <option>command</option>
         </term>
-        <listitem>Runs a command at an interval inside a thread and
-        displays the output. Same as $execi, except the command is
-        run inside a thread. Use this if you have a slow script to
-        keep Conky updating. You should make the interval slightly
-        longer than the time it takes your script to execute. For
-        example, if you have a script that take 5 seconds to
-        execute, you should make the interval at least 6 seconds.
-        See also $execi. This object will clean up the thread when
-        it is destroyed, so it can safely be used in a nested
-        fashion, though it may not produce the desired behaviour if
-        used this way.
+        <listitem>Runs a command at an interval inside a thread and displays
+        the output. Same as $execi, except the command is run inside a thread.
+        Use this if you have a slow script to keep Conky updating. You should
+        make the interval slightly longer than the time it takes your script
+        to execute. For example, if you have a script that take 5 seconds to
+        execute, you should make the interval at least 6 seconds. See also
+        $execi. This object will clean up the thread when it is destroyed, so
+        it can safely be used in a nested fashion, though it may not produce
+        the desired behaviour if used this way.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4354,8 +4235,7 @@
             <option>interval</option>
             <option>command</option>
         </term>
-        <listitem>Same as execpi, except the command is run inside
-        a thread.
+        <listitem>Same as execpi, except the command is run inside a thread.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4374,8 +4254,8 @@
             </command>
             <option>(format)</option>
         </term>
-        <listitem>Local time, see man strftime to get more
-        information about format
+        <listitem>Local time, see man strftime to get more information about
+        format
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4386,8 +4266,8 @@
             <option>size</option>
         </term>
         <listitem>If 'size' is a number followed by a size-unit
-        (kilobyte,mb,GiB,...) then it converts the size to bytes
-        and shows it without unit, otherwise it just shows 'size'.
+        (kilobyte,mb,GiB,...) then it converts the size to bytes and shows it
+        without unit, otherwise it just shows 'size'.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4397,12 +4277,12 @@
             </command>
             <option>type num</option>
         </term>
-        <listitem>This takes arguments in the form:top (name)
-        (number) Basically, processes are ranked from highest to
-        lowest in terms of cpu usage, which is what (num)
-        represents. The types are: "name", "pid", "cpu", "mem",
-        "mem_res", "mem_vsize", "time", "uid", "user", "io_perc", "io_read" and
-        "io_write". There can be a max of 10 processes listed.
+        <listitem>This takes arguments in the form:top (name) (number)
+        Basically, processes are ranked from highest to lowest in terms of cpu
+        usage, which is what (num) represents. The types are: "name", "pid",
+        "cpu", "mem", "mem_res", "mem_vsize", "time", "uid", "user",
+        "io_perc", "io_read" and "io_write". There can be a max of 10
+        processes listed.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4412,8 +4292,8 @@
             </command>
             <option>type num</option>
         </term>
-        <listitem>Same as top, except sorted by the amount of I/O
-        the process has done during the update interval
+        <listitem>Same as top, except sorted by the amount of I/O the process
+        has done during the update interval
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4423,8 +4303,7 @@
             </command>
             <option>type num</option>
         </term>
-        <listitem>Same as top, except sorted by mem usage instead
-        of cpu
+        <listitem>Same as top, except sorted by mem usage instead of cpu
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4434,8 +4313,8 @@
             </command>
             <option>type num</option>
         </term>
-        <listitem>Same as top, except sorted by total CPU time
-        instead of current CPU usage
+        <listitem>Same as top, except sorted by total CPU time instead of
+        current CPU usage
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4445,10 +4324,9 @@
             </command>
             <option>(net)</option>
         </term>
-        <listitem>Total download, overflows at 4 GB on Linux with
-        32-bit arch and there doesn't seem to be a way to know how
-        many times it has already done that before conky has
-        started.
+        <listitem>Total download, overflows at 4 GB on Linux with 32-bit arch
+        and there doesn't seem to be a way to know how many times it has
+        already done that before conky has started.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4469,9 +4347,9 @@
             <option>(maildir)</option>
             <option>(interval)</option>
         </term>
-        <listitem>Number of mails marked as trashed in the
-        specified mailbox or mail spool if not. Only maildir type
-        mailboxes are supported, mbox type will return -1.
+        <listitem>Number of mails marked as trashed in the specified mailbox
+        or mail spool if not. Only maildir type mailboxes are supported, mbox
+        type will return -1.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4481,11 +4359,10 @@
             </command>
             <option>(timezone (format))</option>
         </term>
-        <listitem>Local time for specified timezone, see man
-        strftime to get more information about format. The timezone
-        argument is specified in similar fashion as TZ environment
-        variable. For hints, look in /usr/share/zoneinfo. e.g.
-        US/Pacific, Europe/Zurich, etc.
+        <listitem>Local time for specified timezone, see man strftime to get
+        more information about format. The timezone argument is specified in
+        similar fashion as TZ environment variable. For hints, look in
+        /usr/share/zoneinfo. e.g. US/Pacific, Europe/Zurich, etc.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4516,9 +4393,9 @@
             <option>(maildir)</option>
             <option>(interval)</option>
         </term>
-        <listitem>Number of mails not marked as flagged in the
-        specified mailbox or mail spool if not. Only maildir type
-        mailboxes are supported, mbox type will return -1.
+        <listitem>Number of mails not marked as flagged in the specified
+        mailbox or mail spool if not. Only maildir type mailboxes are
+        supported, mbox type will return -1.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4529,9 +4406,9 @@
             <option>(maildir)</option>
             <option>(interval)</option>
         </term>
-        <listitem>Number of mails not marked as forwarded in the
-        specified mailbox or mail spool if not. Only maildir type
-        mailboxes are supported, mbox type will return -1.
+        <listitem>Number of mails not marked as forwarded in the specified
+        mailbox or mail spool if not. Only maildir type mailboxes are
+        supported, mbox type will return -1.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4542,9 +4419,9 @@
             <option>(maildir)</option>
             <option>(interval)</option>
         </term>
-        <listitem>Number of mails not marked as replied in the
-        specified mailbox or mail spool if not. Only maildir type
-        mailboxes are supported, mbox type will return -1.
+        <listitem>Number of mails not marked as replied in the specified
+        mailbox or mail spool if not. Only maildir type mailboxes are
+        supported, mbox type will return -1.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4555,9 +4432,9 @@
             <option>(maildir)</option>
             <option>(interval)</option>
         </term>
-        <listitem>Number of new or unseen mails in the specified
-        mailbox or mail spool if not. Only maildir type mailboxes
-        are supported, mbox type will return -1.
+        <listitem>Number of new or unseen mails in the specified mailbox or
+        mail spool if not. Only maildir type mailboxes are supported, mbox
+        type will return -1.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4595,16 +4472,15 @@
             <command>
                 <option>upspeedgraph</option>
             </command>
-            <option>(netdev) (height),(width) (gradient colour 1)
-            (gradient colour 2) (scale) (-t) (-l)</option>
+            <option>(netdev) (height),(width) (gradient colour 1) (gradient
+            colour 2) (scale) (-t) (-l)</option>
         </term>
-        <listitem>Upload speed graph, colours defined in hex, minus
-        the #. If scale is non-zero, it becomes the scale for the
-        graph. Uses a logarithmic scale (to see small numbers) when
-        you use the -l switch. Takes the switch '-t' to use a
-        temperature gradient, which makes the gradient values
-        change depending on the amplitude of a particular graph
-        value (try it and see).
+        <listitem>Upload speed graph, colours defined in hex, minus the #. If
+        scale is non-zero, it becomes the scale for the graph. Uses a
+        logarithmic scale (to see small numbers) when you use the -l switch.
+        Takes the switch '-t' to use a temperature gradient, which makes the
+        gradient values change depending on the amplitude of a particular
+        graph value (try it and see).
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4666,7 +4542,7 @@
             <command>
                 <option>user_time</option>
             </command>
-	    <option>console</option>
+            <option>console</option>
         </term>
         <listitem>Lists how long the user for the given console has been
         logged in for
@@ -4689,10 +4565,10 @@
             </command>
             <option>(-n) (-s) (interface)</option>
         </term>
-        <listitem>IPv6 addresses for an interface, followed by
-        netmask if -n is specified and scope with -s. Scopes are
-        Global(G), Host-local(H), Link-local(L), Site-local(S), Compat(C)
-        and Unspecified(/). Linux only.
+        <listitem>IPv6 addresses for an interface, followed by netmask if -n
+        is specified and scope with -s. Scopes are Global(G), Host-local(H),
+        Link-local(L), Site-local(S), Compat(C) and Unspecified(/). Linux
+        only.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4702,8 +4578,8 @@
             </command>
             <option>(pixels)</option>
         </term>
-        <listitem>Change vertical offset by N pixels. Negative
-        values will cause text to overlap. See also $offset.
+        <listitem>Change vertical offset by N pixels. Negative values will
+        cause text to overlap. See also $offset.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4713,8 +4589,8 @@
             </command>
             <option>(n)</option>
         </term>
-        <listitem>Returns CPU #n's voltage in mV. CPUs are counted
-        from 1. If omitted, the parameter defaults to 1.
+        <listitem>Returns CPU #n's voltage in mV. CPUs are counted from 1. If
+        omitted, the parameter defaults to 1.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4724,8 +4600,8 @@
             </command>
             <option>(n)</option>
         </term>
-        <listitem>Returns CPU #n's voltage in V. CPUs are counted
-        from 1. If omitted, the parameter defaults to 1.
+        <listitem>Returns CPU #n's voltage in V. CPUs are counted from 1. If
+        omitted, the parameter defaults to 1.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -4733,8 +4609,7 @@
             <command>
                 <option>weather</option>
             </command>
-            <option>URI locID data_type
-            (interval_in_minutes)</option>
+            <option>URI locID data_type (interval_in_minutes)</option>
         </term>
         <listitem>
             <para>Download, parse and display METAR data.</para>
@@ -4743,29 +4618,24 @@
                 <member>
                 http://tgftp.nws.noaa.gov/data/observations/metar/stations/</member>
             </simplelist>
-            <para>'locID' must be a valid location identifier for
-            the required uri. For the NOAA site this must be a
-            valid ICAO (see for instance
-            https://pilotweb.nas.faa.gov/qryhtml/icao/). For the
-            weather.com site this must be a valid location ID (see
-            for instance
+            <para>'locID' must be a valid location identifier for the required
+            uri. For the NOAA site this must be a valid ICAO (see for instance
+            https://pilotweb.nas.faa.gov/qryhtml/icao/). For the weather.com
+            site this must be a valid location ID (see for instance
             http://aspnetresources.com/tools/locid.aspx).</para>
             <para>'data_type' must be one of the following:</para>
             <simplelist>
                 <member>
                     <command>last_update</command>
-                    <para>The date and time stamp of the data.
-                    The result depends on the URI used. For the
-                    NOAA site it is date (yyyy/mm/dd) and UTC time.
-                    For the weather.com one it is date
-                    ([m]m/[d]d/yy) and Local Time of the
-                    station.</para>
+                    <para>The date and time stamp of the data. The result
+                    depends on the URI used. For the NOAA site it is date
+                    (yyyy/mm/dd) and UTC time. For the weather.com one it is
+                    date ([m]m/[d]d/yy) and Local Time of the station.</para>
                 </member>
                 <member>
                     <command>temperature</command>
-					<para>Air temperature (you can use the
-                    'temperature_unit' config setting to change
-					units)</para>
+                    <para>Air temperature (you can use the 'temperature_unit'
+                    config setting to change units)</para>
                 </member>
                 <member>
                     <command>cloud_cover</command>
@@ -4793,26 +4663,24 @@
                 </member>
                 <member>
                     <command>weather</command>
-                    <para>Any relevant weather event (rain, snow,
-                    etc.). This is not used if you are querying the
-                    weather.com site since this data is aggregated
-                    into the cloud_cover one</para>
+                    <para>Any relevant weather event (rain, snow, etc.). This
+                    is not used if you are querying the weather.com site since
+                    this data is aggregated into the cloud_cover one</para>
                 </member>
                 <member>
                     <command>icon</command>
-                    <para>Weather icon (only for
-                    www.weather.com). Can be used together with the
-                    icon kit provided upon registering to their
-                    service.</para>
+                    <para>Weather icon (only for www.weather.com). Can be used
+                    together with the icon kit provided upon registering to
+                    their service.</para>
                 </member>
             </simplelist>
-            <para>'delay_in_minutes' (optional, default 30) cannot
-            be less than 30 minutes.</para>
-            <para>This object is threaded, and once a thread is
-            created it can't be explicitly destroyed. One thread
-            will run for each URI specified.</para>
-            <para>Note that these variables are still EXPERIMENTAL
-            and can be subject to many future changes.</para>
+            <para>'delay_in_minutes' (optional, default 30) cannot be less
+            than 30 minutes.</para>
+            <para>This object is threaded, and once a thread is created it
+            can't be explicitly destroyed. One thread will run for each URI
+            specified.</para>
+            <para>Note that these variables are still EXPERIMENTAL and can be
+            subject to many future changes.</para>
         </listitem>
     </varlistentry>
     <varlistentry>
@@ -4820,47 +4688,46 @@
             <command>
                 <option>weather_forecast</option>
             </command>
-            <option>URI locID day data_type
-            (interval_in_minutes)</option>
+            <option>URI locID day data_type (interval_in_minutes)</option>
         </term>
         <listitem>
-            <para>Download, parse and display weather forecast data
-	    for a given day (daytime only).</para>
+            <para>Download, parse and display weather forecast data for a
+            given day (daytime only).</para>
             <para>'locID', see 'weather' above.</para>
-            <para>'day' is a number from 0 (today) to 4 (3 days
-            after tomorrow).</para>
+            <para>'day' is a number from 0 (today) to 4 (3 days after
+            tomorrow).</para>
             <para>'data_type' must be one of the following:</para>
             <simplelist>
                 <member>
                     <command>day</command>
-					<option>Day of the week</option>
-				</member>
+                    <option>Day of the week</option>
+                </member>
                 <member>
                     <command>date</command>
-					<option>Date, in the form MMM DD (ie. Jul 14)</option>
-				</member>
+                    <option>Date, in the form MMM DD (ie. Jul 14)</option>
+                </member>
                 <member>
                     <command>low</command>
-					<option>Minimun temperature (you can use the
+                    <option>Minimun temperature (you can use the
                     'temperature_unit' config setting to change
                     units)</option>
-				</member>
+                </member>
                 <member>
                     <command>hi</command>
-					<option>Maximum temperature (you can use the
+                    <option>Maximum temperature (you can use the
                     'temperature_unit' config setting to change
                     units)</option>
-				</member>
+                </member>
                 <member>
                     <command>icon</command>
-                    <option>Weather icon. Can be used together with the
-                    icon kit provided upon registering to the weather.com
+                    <option>Weather icon. Can be used together with the icon
+                    kit provided upon registering to the weather.com
                     service</option>
-				</member>
+                </member>
                 <member>
                     <command>forecast</command>
                     <option>Weather forecast (sunny, rainy, etc.)</option>
-				</member>
+                </member>
                 <member>
                     <command>wind_speed</command>
                     <option>Wind speed in km/h</option>
@@ -4879,19 +4746,18 @@
                 </member>
                 <member>
                     <command>precipitation</command>
-                    <option>Probability of having a
-					precipitation (in %)</option>
+                    <option>Probability of having a precipitation (in
+                    %)</option>
                 </member>
             </simplelist>
-            <para>'delay_in_minutes' (optional, default 210) cannot
-            be lower than 210 min.</para>
-            <para>This object is threaded, and once a thread is
-            created it can't be explicitly destroyed. One thread
-            will run for each URI specified. You can use any
-            protocol that Curl supports.</para>
-            <para>Note that these variables are still EXPERIMENTAL
-            and can be subject to many future changes.</para>
-	</listitem>
+            <para>'delay_in_minutes' (optional, default 210) cannot be lower
+            than 210 min.</para>
+            <para>This object is threaded, and once a thread is created it
+            can't be explicitly destroyed. One thread will run for each URI
+            specified. You can use any protocol that Curl supports.</para>
+            <para>Note that these variables are still EXPERIMENTAL and can be
+            subject to many future changes.</para>
+        </listitem>
     </varlistentry>
     <varlistentry>
         <term>
@@ -4990,8 +4856,7 @@
             </command>
             <option>(net)</option>
         </term>
-        <listitem>Wireless mode (Managed/Ad-Hoc/Master) (Linux
-        only)
+        <listitem>Wireless mode (Managed/Ad-Hoc/Master) (Linux only)
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -5128,8 +4993,8 @@
                 <option>xmms2_smart</option>
             </command>
         </term>
-        <listitem>Prints the song name in either the form "artist -
-        title" or file name, depending on whats available
+        <listitem>Prints the song name in either the form "artist - title" or
+        file name, depending on whats available
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -5138,8 +5003,7 @@
                 <option>xmms2_status</option>
             </command>
         </term>
-        <listitem>XMMS2 status (Playing, Paused, Stopped, or
-        Disconnected)
+        <listitem>XMMS2 status (Playing, Paused, Stopped, or Disconnected)
         <para /></listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
I assume it has been a while since we last tidy several `xml` files so I'm doing this now for 2019.

I used `tidy --wrap 79 -xml -i --indent-spaces 4` on the following files:
```
doc/command_options.xml
doc/config_settings.xml
doc/conky-howto.xml
doc/docs.xml
doc/lua.xml
doc/variables.xml
```
I skipped out on 85 `docbook-xml/*/*.xml` files.

Thank you for the support and a happy New Year. :-)

EDIT: ~~Do not merge.~~
EDIT: `docs.xml` requires `--preserve-entities yes` for anchoring files.
EDIT: I applied this diff to remove weird characters around the url.
```diff
diff --git a/doc/docs.xml b/doc/docs.xml
index 0984910..b58bca1 100644
--- a/doc/docs.xml
+++ b/doc/docs.xml
@@ -239,10 +239,7 @@
     </refsect1>
     <refsect1>
         <title>See Also</title>
-        <para>
-            <ulink url="https://github.com/brndnmtthws/conky">
-            https://github.com/brndnmtthws/conky</ulink>
-        </para>
+        <para>https://github.com/brndnmtthws/conky</para>
         <para>#conky on irc.freenode.net</para>
     </refsect1>
     <refsect1>
```
EDIT: Do not merge. If you approve, I will merge this when I feel I'm done with cleaning up. 