### PR TITLE
github: add templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,50 @@
+**Issue**
+
+Verify the issue you want to report is not a duplicate. If not, please explain
+your bug or issue here. [DELETE ME]
+
+**Information**
+
+Do we require your OS and/or Conky version? If not, delete this part. Otherwise,
+please report them here. [DELETE ME]
+
+Do we require your config? If no, delete this part. Otherwise, place your
+config inside `lua` triple backticks. [DELETE ME]
+
+
+```lua
+conky.config = {
+    out_to_x = false,
+    out_to_console = true,
+};
+
+conky.text = [[
+Hello, World!
+]];
+```
+
+If you want to report a crash, please try again with `gdb`.
+```bash
+# Start 'conky'
+$ gdb conky
+
+# Run 'conky' with a config.
+(gdb) run -c ~/.your_conky.conf
+
+# Wait for a crash to occur, then run this.
+(gdb) bt full
+
+# Backtrace.
+```
+We want that backtrace inside `gdb` triple backticks.
+```gdb
+$ gdb conky
+GNU gdb (GDB) 8.2
+Copyright (C) 2018 Free Software Foundation, Inc.
+License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.
+...
+```
+
+Please delete all descriptions, unused headers, notes, sections, etc too. Thank you.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+**Descriptions**
+* Describe the changes, why they were necessary, etc
+* Describe how the changes will affect existing behaviour.
+* Describe how you tested and validated your changes.
+* Include any relevant screenshots/evidence demonstrating that the changes work and have been tested.
+
+**Licenses**
+* Any new source files should include a GPLv3 license header.
+* Any contributed code must be GPLv3 licensed.
+
+**Notes**
+* Make sure your code is clean and if you have added a new features, some
+  comments may be appreciated.  Make sure your commit messages are
+  clear/information enough.
+* If you added or altered settings and/or variables, make sure to
+  update the documentation. Do not forget to mention default values or required
+  build flags if this applies to your change.
+* If you added a build flag, make sure to update the `static void print_version(void)` function with your new flag. If you added a new console command, make sure to update the `static void print_help(const char *prog_name)` function with your new command.
+* Add tests for the code, where appropriate.
+
+Please delete all descriptions, headers, notes, sections, etc too. Thank you.


### PR DESCRIPTION
This intends to replace stagnant https://github.com/brndnmtthws/conky/wiki/Development

By consolidating several docs, I have already killed off several stagnant files. Some of them were mostly repetitive and/or copy-and-pasted between various `md`.

The remaining `README.md` contains same several things as this `PULL_REQUEST_TEMPLATE.md` and some comes from `Wiki` too. I don't know which came from which. I just know we reduced several of them. `README.md` also contains `Screenshots` and broken documentation that ought to be pruned in favor of just pointing it to `Wiki`.

Changes always are sticky so I leave this to you to decide how you wish to proceed with remaining `README.md` links. I removed `Features` from `What-Is-My-Conky?.md` because the (same) `Features` were already on `README.md` with better information / links / bold / etc.