### PR TITLE
Install libconky_core, too, if wanted.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -288,6 +288,10 @@ if(BUILD_TESTS)
   target_link_libraries(conky_core ${conky_libs})
   add_executable(conky main.cc)
   target_link_libraries(conky conky_core ${conky_libs})
+  install(TARGETS conky_core
+          RUNTIME DESTINATION bin
+          LIBRARY DESTINATION lib
+          ARCHIVE DESTINATION lib)
 else()
   add_executable(conky main.cc ${conky_sources} ${optional_sources})
   target_link_libraries(conky ${conky_libs})


### PR DESCRIPTION
If someone decides to install the testing build, it doesn't include
libconky_core.

This fixes #756.