### PR TITLE
Remove statement causing compiler error:

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -359,10 +359,6 @@ int main(int argc, char **argv) {
     return EXIT_FAILURE;
   }
 
-#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
-  kvm_close(kd);
-#endif
-
 #ifdef LEAKFREE_NCURSES
   _nc_free_and_exit(0);  // hide false memleaks
 #endif


### PR DESCRIPTION
--- src/CMakeFiles/conky.dir/main.cc.o ---
/wrkdirs/usr/ports/sysutils/conky/work/conky-1.11.2/src/main.cc:363:13: error: use of undeclared identifier 'kd'
  kvm_close(kd);
            ^
1 error generated.
*** [src/CMakeFiles/conky.dir/main.cc.o] Error code 1