### PR TITLE
conky: Allow hwmon command to accept hwmon device name

### DIFF
--- a/doc/variables.xml
+++ b/doc/variables.xml
@@ -1496,8 +1496,11 @@
             </command>
             <option>(dev) type n (factor offset)</option>
         </term>
-        <listitem>Hwmon sensor from sysfs (Linux 2.6). Parameter dev may be
-        omitted if you have only one hwmon device. Parameter type is either
+        <listitem>Hwmon sensor from sysfs (Linux 2.6). Parameter dev can be:
+        1) Number. e.g '1' means hwmon1. 2) Module name. e.g. 'k10temp' means
+        the first hwmon device whose module name is 'k10temp. 3) Omitted. Then
+        the first hwmon device (hwmon0) will be used.
+        Parameter type is either
         'in' or 'vol' meaning voltage; 'fan' meaning fan; 'temp' meaning
         temperature. Parameter n is number of the sensor. See
         <filename>/sys/class/hwmon/</filename>&#160;on your local computer.


### PR DESCRIPTION
[PROBLEM]
Some hwmon device number may change due to module load sequence.
E.g:
One boot would cause the following layout:
hwmon0->acpitz
hwmon1->pch_skylake
hwmon2->thinkpad
hwmon3->coretemp
hwmon4->iwlwifi

While another boot could lead to:
hwmon0->acpitz
hwmon1->pch_skylake
hwmon2->coretemp
hwmon3->thinkpad
hwmon4->iwlwifi

[ENHANCEMENT]
This patch will enhance the hwmon command to accept hwmon device name as
first parameter instead of number.

Now "hwmon 3 temp 1" can be converted to "hwmon coretemp temp 1", which
is more readable and user won't ever need to bother the hwmon sequence
number change.