### PR TITLE
Added option 'forced_redraw' to resolve flickering issues on workspace change

### DIFF
--- a/doc/config_settings.xml
+++ b/doc/config_settings.xml
@@ -33,6 +33,15 @@
     <varlistentry>
         <term>
             <command>
+                <option>forced_redraw</option>
+            </command>
+        </term>
+        <listitem>Boolean value, if true, Conky will redraw everything when you switch the workspace. This may cause delays/flickering on some WMs.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
                 <option>border_inner_margin</option>
             </command>
         </term>

--- a/extras/convert.lua
+++ b/extras/convert.lua
@@ -40,7 +40,7 @@ local bool_setting = {
     own_window = true, own_window_argb_visual = true, own_window_transparent = true,
     short_units = true, show_graph_range = true, show_graph_scale = true,
     times_in_seconds = true, top_cpu_separate = true, uppercase = true, use_xft = true,
-    draw_blended = true
+    draw_blended = true, forced_redraw = true
 };
 
 local num_setting = {

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -2046,11 +2046,11 @@ void main_loop() {
 #endif
               if (ev.xproperty.atom == ATOM(_XROOTPMAP_ID) ||
                   ev.xproperty.atom == ATOM(_XROOTMAP_ID)) {
-               if (forced_redraw.get(*state)) {
+                if (forced_redraw.get(*state)) {
                   draw_stuff();
                   next_update_time = get_time();
                   need_to_update = 1;
-                 }
+                }
               }
 #ifdef USE_ARGB
             }

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -2046,9 +2046,11 @@ void main_loop() {
 #endif
               if (ev.xproperty.atom == ATOM(_XROOTPMAP_ID) ||
                   ev.xproperty.atom == ATOM(_XROOTMAP_ID)) {
-                draw_stuff();
-                next_update_time = get_time();
-                need_to_update = 1;
+               if (forced_redraw.get(*state)) {
+                  draw_stuff();
+                  next_update_time = get_time();
+                  need_to_update = 1;
+                 }
               }
 #ifdef USE_ARGB
             }

--- a/src/x11.cc
+++ b/src/x11.cc
@@ -337,6 +337,8 @@ conky::range_config_setting<int> border_width("border_width", 0,
 conky::simple_config_setting<bool> use_xft("use_xft", false, false);
 #endif
 
+conky::simple_config_setting<bool> forced_redraw("forced_redraw", false, false);
+
 #ifdef OWN_WINDOW
 conky::simple_config_setting<bool> set_transparent("own_window_transparent",
                                                    false, false);

--- a/src/x11.h
+++ b/src/x11.h
@@ -232,6 +232,8 @@ extern conky::range_config_setting<int> border_inner_margin;
 extern conky::range_config_setting<int> border_outer_margin;
 extern conky::range_config_setting<int> border_width;
 
+extern conky::simple_config_setting<bool> forced_redraw;
+
 #ifdef BUILD_XFT
 extern conky::simple_config_setting<bool> use_xft;
 #endif


### PR DESCRIPTION
When you change the workspace, conky redraws everything that causes it to delay/flicker. This PR fixes this.
This issue is present on xfwm4, compton and perhaps many WMs.

https://youtu.be/KMC1RzKh0pA