### PR TITLE
Add support for nested |exec| expressions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -113,6 +113,8 @@ flitsch <flitsch at users dot sourceforge dot net>
 fow <facadedewalls at yahoo dot com>
   mpd_title max length
 
+Google LLC
+
 Gwenhael LE MOINE <cycojesus at yahoo dot fr>
   Manual setting of the position
   WM_CLASS for window when drawing to own window

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -727,6 +727,17 @@ void generate_text_internal(char *p, int p_max_size, struct text_object root) {
 void evaluate(const char *text, char *p, int p_max_size) {
   struct text_object subroot {};
 
+  /**
+   * Consider expressions like: ${execp echo '${execp echo hi}'}
+   * These would require multiple passes of evaluation:
+   * The first pass would parse the first level of |execp| and would generate
+   * a callback registration using |register_exec|, but to correctly evaluate
+   * the expression, we would need to wait for the just registered callback to
+   * execute and return its result.
+   */
+  parse_conky_vars(&subroot, text, p, p_max_size);
+  conky::run_all_callbacks();
+  // Run another evaluation pass.
   parse_conky_vars(&subroot, text, p, p_max_size);
   DBGP2("evaluated '%s' to '%s'", text, p);
 

--- a/src/exec.cc
+++ b/src/exec.cc
@@ -193,14 +193,14 @@ static void remove_deleted_chars(char *string) {
  * @param[in] buf output of a command executed by an exec_cb object
  * @return number between 0.0 and 100.0
  */
-/* cache the result, so on invalid/empty values to return the cached one */
-static double cached_result = 0.0;
 static inline double get_barnum(const char *buf) {
   double barnum;
 
   if (sscanf(buf, "%lf", &barnum) != 1) {
-    /* don't reset execbars on invalid values. see issue #580 */
-    return cached_result;
+    NORM_ERR(
+        "reading exec value failed (perhaps it's not the "
+        "correct format?)");
+    return 0.0;
   }
   if (barnum > 100.0 || barnum < 0.0) {
     NORM_ERR(
@@ -209,7 +209,6 @@ static inline double get_barnum(const char *buf) {
     return 0.0;
   }
 
-  cached_result = barnum;
   return barnum;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ include_directories(${CMAKE_SOURCE_DIR}/src)
 include_directories(${CMAKE_BINARY_DIR})
 include_directories(${conky_includes})
 
-set(test_srcs "")
+set(test_srcs "test-conky.cc")
 
 if(OS_LINUX)
   set(test_srcs ${test_srcs} test-linux.cc)

--- a/tests/test-conky.cc
+++ b/tests/test-conky.cc
@@ -1,0 +1,63 @@
+/*
+ *
+ * Conky, a system monitor, based on torsmo
+ *
+ * Any original torsmo code is licensed under the BSD license
+ *
+ * All code written since the fork of torsmo is licensed under the GPL
+ *
+ * Please see COPYING for details
+ *
+ * Copyright (c) 2005-2019 Brenden Matthews, Philip Kovacs, et. al.
+ *	(see AUTHORS)
+ * All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "catch2/catch.hpp"
+#include "conky.h"
+#include "lua-config.hh"
+
+TEST_CASE("Expressions can be evaluated", "[evaluate]") {
+  state = std::make_unique<lua::state>();
+  conky::export_symbols(*state);
+
+  SECTION("Simple expressions without substitutions can be evaluated") {
+    constexpr int kMaxSize = 10;
+    const char input[kMaxSize] = "text";
+    char result[kMaxSize]{'\0'};
+
+    evaluate(input, result, kMaxSize);
+    REQUIRE(strncmp(input, result, kMaxSize) == 0);
+  }
+
+  SECTION("execs can be evaluated") {
+    constexpr int kMaxSize = 50;
+    const char input[kMaxSize] = "${exec echo text}";
+    char result[kMaxSize]{'\0'};
+
+    evaluate(input, result, kMaxSize);
+    REQUIRE(strncmp("text", result, kMaxSize) == 0);
+  }
+
+  SECTION("execp echo without other substitutions can be evaluated") {
+    constexpr int kMaxSize = 50;
+    const char input[kMaxSize] = "${execp echo text}";
+    char result[kMaxSize]{'\0'};
+
+    evaluate(input, result, kMaxSize);
+    REQUIRE(strncmp("text", result, kMaxSize) == 0);
+  }
+}


### PR DESCRIPTION
**Issue**: #802 

**Changes**
- Nested exec expressions like ${execp echo '${execp echo hi}'} are not
  evaluated correctly because parsing expressions like these generates and
  registers new callbacks but we never wait for these callbacks to
  complete before returning the result of the evaluation.
  Fix this by re-evaluating expressions after running all pending callbacks.
- Revert a644600bc5ae8bf0971cdaf992b7c1d6c7c92553
  This commit is actually a bug that causes |execbar|s to re-use values from
  each other, which causes weird jumps and falls. Please check issue #802 
  and issue #580 for details.

**Tests**
In addition to adding unit tests (verified to fail without my patch), the following config was manually tested:
```
conky.config = {
    out_to_x=false,
    out_to_console=true,
    own_window=true,
    update_interval=0.2,
}
conky.text = [[
    ${execp python -c 'from random import randint;print("BAR: ${exec echo %s}" % randint(10,99))'}
    ${execp echo '${execp echo '"'"'${execp echo hi}'"'"'}'}
]]
```

Result before patch (and after reverting a644600bc5ae8bf0971cdaf992b7c1d6c7c92553 because
it detracts us from the main problem):
```
    BAR: 
    
    BAR: 
    
    BAR: 
    hi
    BAR: 
    hi
    BAR: 
    hi
    BAR: 
    hi
    BAR: 45
    hi
    BAR: 
    hi
    BAR: 
    hi
    BAR: 
    hi
    BAR: 
    hi
    BAR: 
    hi
```

Result after patch:
```
    BAR: 69
    hi
    BAR: 88
    hi
    BAR: 55
    hi
    BAR: 25
    hi
    BAR: 33
    hi
    BAR: 21
    hi
```
