### PR TITLE
idtype enum breaks Solaris conky

### DIFF
--- a/src/proc.cc
+++ b/src/proc.cc
@@ -603,10 +603,10 @@ void print_pid_time(struct text_object *obj, char *p, unsigned int p_max_size) {
   }
 }
 
-enum idtype { egid, euid, fsgid, fsuid, gid, sgid, suid, uid };
+enum xid_type { egid, euid, fsgid, fsuid, gid, sgid, suid, uid };
 
 void print_pid_Xid(struct text_object *obj, char *p, int p_max_size,
-                   idtype type) {
+                   xid_type type) {
   char *begin, *end, *buf = nullptr;
   int bytes_read;
   std::ostringstream pathstream;


### PR DESCRIPTION
**Descriptions**
* Besides the `idtype_t`, Solaris defines also the `idtype` enum in `sys/procset.h` thus defining the same enum (with different meaning) in `src/proc.cc` breaks conky build on Solaris:
```
[ 66%] Building CXX object src/CMakeFiles/conky.dir/proc.cc.o
/usr/local/src/conky-master/src/proc.cc:606:6: error: multiple definition of ‘enum idtype’
 enum idtype { egid, euid, fsgid, fsuid, gid, sgid, suid, uid };
      ^~~~~~
In file included from /usr/include/sys/wait.h:22:0,
                 from /usr/include/stdlib.h:16,
                 from /usr/gcc/7/include/c++/7.3.0/cstdlib:75,
                 from /usr/gcc/7/include/c++/7.3.0/ext/string_conversions.h:41,
                 from /usr/gcc/7/include/c++/7.3.0/bits/basic_string.h:6349,
                 from /usr/gcc/7/include/c++/7.3.0/string:52,
                 from /usr/gcc/7/include/c++/7.3.0/stdexcept:39,
                 from /usr/gcc/7/include/c++/7.3.0/array:39,
                 from /usr/gcc/7/include/c++/7.3.0/tuple:39,
                 from /usr/gcc/7/include/c++/7.3.0/bits/unique_ptr.h:37,
                 from /usr/gcc/7/include/c++/7.3.0/memory:80,
                 from /usr/local/src/conky-master/src/proc.cc:34:
/usr/include/sys/procset.h:35:2: note: previous definition here
  idtype  /* pollutes XPG4.2 namespace */
  ^~~~~~
/usr/local/src/conky-master/src/proc.cc: In function ‘void print_pid_Xid(text_object*, char*, int, idtype)’:
/usr/local/src/conky-master/src/proc.cc:622:12: error: ‘egid’ was not declared in this scope
       case egid:
            ^~~~
[...]
```

* Since the `idtype` is used just at a couple of places in `proc.cc`, I propose renaming it to something else, e.g. `xid_type`.
* Alternatively, we can try to prevent `sys/procset.h` from introducing the typeid by tweaking some defines (like _XPG4_2) but this seems to be a high-risk-low-reward approach in this context.

**Licenses**
* no change

Thanks!