### PR TITLE
Put libraries into the proper directories and install portmon library.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -297,10 +297,16 @@ else()
   target_link_libraries(conky ${conky_libs})
 endif()
 
-# Install libtcp-portmon too?
 install(TARGETS conky
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION ${LIB_INSTALL_DIR}/conky
         ARCHIVE DESTINATION ${LIB_INSTALL_DIR}/conky)
+
+if(BUILD_PORT_MONITORS)
+  install(TARGETS tcp-portmon
+          RUNTIME DESTINATION bin
+          LIBRARY DESTINATION ${LIB_INSTALL_DIR}/conky
+          ARCHIVE DESTINATION ${LIB_INSTALL_DIR}/conky)
+endif(BUILD_PORT_MONITORS)
 
 print_target_properties(conky)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -290,8 +290,8 @@ if(BUILD_TESTS)
   target_link_libraries(conky conky_core ${conky_libs})
   install(TARGETS conky_core
           RUNTIME DESTINATION bin
-          LIBRARY DESTINATION lib
-          ARCHIVE DESTINATION lib)
+          LIBRARY DESTINATION ${LIB_INSTALL_DIR}/conky
+          ARCHIVE DESTINATION ${LIB_INSTALL_DIR}/conky)
 else()
   add_executable(conky main.cc ${conky_sources} ${optional_sources})
   target_link_libraries(conky ${conky_libs})
@@ -300,7 +300,7 @@ endif()
 # Install libtcp-portmon too?
 install(TARGETS conky
         RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib)
+        LIBRARY DESTINATION ${LIB_INSTALL_DIR}/conky
+        ARCHIVE DESTINATION ${LIB_INSTALL_DIR}/conky)
 
 print_target_properties(conky)


### PR DESCRIPTION
**Descriptions**

**first changeset**
* Unlike the other libraries conky_core is installed to hardcoded /usr/lib instead of /usr/lib/conky
* This also ignores 64 bit systems, using LIB_INSTALL_DIR takes care of this

**second changeset**

* when building shared libraries with SET (BUILD_SHARED_LIBS ON CACHE BOOLEAN "") which is now the default for Gentoo Linux conky fails to start with:

> conky: error while loading shared libraries: libtcp-portmon.so: cannot open shared object file: No such file or directory
* adding tcp-portmon as install target fixes this issue