### PR TITLE
Test `make install` target, and release build.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -357,6 +357,7 @@ centos7 clang-5:
       - stuck_or_timeout_failure
       - unknown_failure
       - api_failure
+  allow_failure: true
   tags:
     - freebsd12
   before_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -467,6 +467,19 @@ freebsd12 clang-7:
     - if [ "$COMPILER" == "clang-7" ] ; then make -j4 test-conky-coverage-txt ; fi
     - if [ "$COMPILER" == "clang-7" ] ; then make -j4 test-conky-coverage-html ; fi
     - if [ "$COMPILER" == "clang-7" ] ; then lcov-summary test-conky-coverage-html.info.cleaned ; fi
+    - make -j4
+    - if [[ "$DISTRO" == "freebsd12" ]] ; then sudo make install ; else make install ; fi
+    - conky -v
+    - >
+      cmake
+      -DCMAKE_C_COMPILER_LAUNCHER=sccache
+      -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      -DRELEASE=ON
+      ..
+    - make -j4
+    - if [[ "$DISTRO" == "freebsd12" ]] ; then sudo make install ; else make install ; fi
+    - conky -v
   coverage: '/Total Coverage:\s+(\d+\.\d+)%/'
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-coverage-report"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -471,6 +471,7 @@ freebsd12 clang-7:
     - make -j4
     - if [[ "$DISTRO" == "freebsd12" ]] ; then sudo make install ; else make install ; fi
     - conky -v
+    - find . -iname '*.gcda' -delete
     - >
       cmake
       -DCMAKE_C_COMPILER_LAUNCHER=sccache

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -30,7 +30,7 @@ pushd "$BUILD_DIR"
 
 # configure build files with cmake
 # we need to explicitly set the install prefix, as CMake's default is /usr/local for some reason...
-cmake -DRELEASE=ON -DCMAKE_INSTALL_PREFIX=/usr "$REPO_ROOT"
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DRELEASE=ON -DCMAKE_INSTALL_PREFIX=/usr "$REPO_ROOT"
 
 # build project and install files into AppDir
 make -j4


### PR DESCRIPTION
This should help catch issues related to #812.

I also am going to allow the FreeBSD builds to fail for now, because they are too flakey. The current issue seems to be with `sccache` blowing up on the linker step.