### PR TITLE
Add a separate option for building html documentation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,11 +88,11 @@ set(MAN_FILES doc/conky.1)
 
 install(FILES ${DOC_FILES} DESTINATION ${DOC_PATH})
 
-if(MAINTAINER_MODE)
+if(BUILD_DOCS)
   install(FILES ${HTML_FILES} DESTINATION ${HTML_PATH})
 
   install(FILES ${MAN_FILES} DESTINATION ${MAN_PATH})
-endif(MAINTAINER_MODE)
+endif(BUILD_DOCS)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   install(FILES conky.desktop DESTINATION share/applications)

--- a/cmake/ConkyBuildOptions.cmake
+++ b/cmake/ConkyBuildOptions.cmake
@@ -91,7 +91,9 @@ option(CHECK_CODE_QUALITY "Check code formatting/quality with clang" false)
 option(RELEASE "Build release package" false)
 mark_as_advanced(RELEASE)
 
-option(MAINTAINER_MODE "Enable maintainer mode (builds docs)" false)
+option(MAINTAINER_MODE "Enable maintainer mode" false)
+
+option(BUILD_DOCS "Build documentation" false)
 
 option(BUILD_I18N "Enable if you want internationalization support" true)
 if(BUILD_I18N)

--- a/cmake/ConkyPlatformChecks.cmake
+++ b/cmake/ConkyPlatformChecks.cmake
@@ -497,7 +497,7 @@ if(WANT_LIBXML2)
 endif(WANT_LIBXML2)
 
 # Look for doc generation programs
-if(MAINTAINER_MODE)
+if(BUILD_DOCS)
   # Used for doc generation
   find_program(APP_DB2X_XSLTPROC db2x_xsltproc)
   if(NOT APP_DB2X_XSLTPROC)
@@ -529,7 +529,7 @@ if(MAINTAINER_MODE)
                    APP_MAN
                    APP_SED
                    APP_LESS)
-endif(MAINTAINER_MODE)
+endif(BUILD_DOCS)
 
 if(CMAKE_BUILD_TYPE MATCHES "Debug")
   set(DEBUG true)

--- a/cmake/Docbook.cmake
+++ b/cmake/Docbook.cmake
@@ -33,7 +33,7 @@
 
 # man_MANS = conky.1
 
-if(MAINTAINER_MODE)
+if(BUILD_DOCS)
 
   function(wrap_xsltproc)
     if(NOT ARGV)
@@ -96,4 +96,4 @@ if(MAINTAINER_MODE)
 
   endfunction(wrap_man)
 
-endif(MAINTAINER_MODE)
+endif(BUILD_DOCS)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -20,7 +20,7 @@
 
 include(Docbook)
 
-if(MAINTAINER_MODE)
+if(BUILD_DOCS)
   wrap_xsltproc(lua config_settings variables)
   wrap_man(docs)
-endif(MAINTAINER_MODE)
+endif(BUILD_DOCS)


### PR DESCRIPTION
**Descriptions**
* This pull request separates building the documentation from MAINTAINER_MODE with a new option called BUILD_DOCS
* IMO it deserves and extra option as it is not related to the other functionality of MAINTAINER_MODE which sets the build type and enables tests which nowadays also enables the building of the conky_core debug library.
* This way if one only wants documentation he doesn't get a lot of other stuff he probably doesn't need.
* Building with and without the new options seems to work fine.

**Notes**
* I have not yet added this option to the `static void print_version(void)` function. If you think it is necessary I can add it .
* Maybe the travis and gitlab-ci configuration also needs to be adapted to reflect this changes.