### PR TITLE
Fix support for nested exec expressions

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -729,16 +729,12 @@ void evaluate(const char *text, char *p, int p_max_size) {
 
   /**
    * Consider expressions like: ${execp echo '${execp echo hi}'}
-   * These would require multiple passes of evaluation:
-   * The first pass would parse the first level of |execp| and would generate
-   * a callback registration using |register_exec|, but to correctly evaluate
-   * the expression, we would need to wait for the just registered callback to
-   * execute and return its result.
+   * These would require run extract_variable_text_internal() before
+   * callbacks and generate_text_internal() after callbacks.
    */
-  parse_conky_vars(&subroot, text, p, p_max_size);
+  extract_variable_text_internal(&subroot, txt);
   conky::run_all_callbacks();
-  // Run another evaluation pass.
-  parse_conky_vars(&subroot, text, p, p_max_size);
+  generate_text_internal(p, p_max_size, subroot);
   DBGP2("evaluated '%s' to '%s'", text, p);
 
   free_text_objects(&subroot);

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -732,7 +732,7 @@ void evaluate(const char *text, char *p, int p_max_size) {
    * These would require run extract_variable_text_internal() before
    * callbacks and generate_text_internal() after callbacks.
    */
-  extract_variable_text_internal(&subroot, txt);
+  extract_variable_text_internal(&subroot, text);
   conky::run_all_callbacks();
   generate_text_internal(p, p_max_size, subroot);
   DBGP2("evaluated '%s' to '%s'", text, p);


### PR DESCRIPTION
**Issue** #829 

The fix from #804 works, but it has an issue, likely a _memory_ leak.
Two calls of `generate_conky_vars` generate two more calls of `exec_cb::work`, but only one of them is destroyed.

After a few seconds, I have these calls:
```
(evaluate) text=${execp echo '${color green}59'}
(evaluate) text=
(exec_cb::work) buf=${color green}59
(exec_cb::work) buf=${color green}58
(exec_cb::work) buf=${execp echo '${color green}59'}
(exec_cb::work) buf=${color green}56
(exec_cb::work) buf=${color green}43
(exec_cb::work) buf=${color green}42
(exec_cb::work) buf=${color green}45
(exec_cb::work) buf=${color green}47
(exec_cb::work) buf=${color green}55
(exec_cb::work) buf=${color green}53
(exec_cb::work) buf=${color green}50
(exec_cb::work) buf=${color green}40
(exec_cb::work) buf=${color green}49
(exec_cb::work) buf=${color green}57
(exec_cb::work) buf=${color green}54
(exec_cb::work) buf=${color green}46
(exec_cb::work) buf=${color green}41
(exec_cb::work) buf=${color green}52
(exec_cb::work) buf=${color green}51
(exec_cb::work) buf=${color green}44
(exec_cb::work) buf=${color green}48
(exec_cb::work) buf=${color green}43
(exec_cb::work) buf=${color green}59
(exec_cb::work) buf=${color green}55
(exec_cb::work) buf=${color green}42
(exec_cb::work) buf=${color green}58
(exec_cb::work) buf=${color green}53
(exec_cb::work) buf=${color green}50
(exec_cb::work) buf=${color green}41
(exec_cb::work) buf=${color green}48
(exec_cb::work) buf=${color green}54
(exec_cb::work) buf=${color green}51
(exec_cb::work) buf=${color green}40
(exec_cb::work) buf=${color green}45
(exec_cb::work) buf=${color green}47
(exec_cb::work) buf=${color green}56
(exec_cb::work) buf=${color green}57
(exec_cb::work) buf=${execp echo '${color green}59'}
(exec_cb::work) buf=${color green}44
(exec_cb::work) buf=${color green}49
(exec_cb::work) buf=${color green}52
(exec_cb::work) buf=${color green}46
(evaluate) text=${color green}59
(exec_cb::work) buf=${color green}51
(exec_cb::work) buf=${color green}58
(exec_cb::work) buf=${color green}55
(exec_cb::work) buf=${color green}50
(exec_cb::work) buf=${color green}53
(exec_cb::work) buf=${color green}47
(exec_cb::work) buf=${color green}41
(exec_cb::work) buf=${color green}40
(exec_cb::work) buf=${color green}45
(exec_cb::work) buf=${color green}56
(exec_cb::work) buf=${color green}59
(exec_cb::work) buf=${color green}48
(exec_cb::work) buf=${execp echo '${color green}59'}
(exec_cb::work) buf=${color green}54
(exec_cb::work) buf=${color green}42
(exec_cb::work) buf=${color green}52
(exec_cb::work) buf=${color green}57
(exec_cb::work) buf=${color green}43
(exec_cb::work) buf=${color green}44
(exec_cb::work) buf=${color green}49
(exec_cb::work) buf=${color green}46
```

(tested in a simple C program with `printf("${execp echo '${color green}%d'}", (int)(time(NULL) % 101));` and conky `execp` call in config)


I found a better fix for the problem with nested `execp`. It isn't neccessary to run `generate_conky_vars` twice, but instead to run `extract_variable_text_internal` before callbacks and `generate_text_internal` after callbacks.

Calls after my fix:
```
(evaluate) text=${execp echo '${color green}92'}
(exec_cb::work) buf=${color green}92
(exec_cb::work) buf=${color green}91
(exec_cb::work) buf=${execp echo '${color green}92'}
(evaluate) text=${color green}92
(exec_cb::work) buf=${color green}92
(exec_cb::work) buf=${execp echo '${color green}92'}
(exec_cb::work) buf=${color green}91
```

I tested this fix with the code from #804 and also with `execbar`. No problems were found and there was no flickering (see #580). No increasing memory and CPU usage.

Please, someone review this fix and tell me whether I can merge it to master.

Thanks.