### PR TITLE
Remove duplicate command option

### DIFF
--- a/doc/command_options.xml
+++ b/doc/command_options.xml
@@ -175,16 +175,6 @@
     <varlistentry>
         <term>
             <command>
-                <option>-x</option>
-            </command>
-            <option>X_COORDINATE</option>
-        </term>
-        <listitem>X position.
-        <para></para></listitem>
-    </varlistentry>
-    <varlistentry>
-        <term>
-            <command>
                 <option>-X | --display=</option>
             </command>
             <option>DISPLAY</option>


### PR DESCRIPTION
X_COORDINATE is listed twice. This pull request removes the duplicate.