### PR TITLE
Fix bug of graphs resetting when using conditional special types

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -100,6 +100,7 @@
 #include "mail.h"
 #include "nc.h"
 #include "net_stat.h"
+#include "specials.h"
 #include "temphelper.h"
 #include "template.h"
 #include "timeinfo.h"
@@ -2381,6 +2382,8 @@ void free_specials(special_t *&current) {
     delete current;
     current = nullptr;
   }
+
+  clear_stored_graphs();
 }
 
 void clean_up_without_threads(void *memtofree1, void *memtofree2) {

--- a/src/specials.cc
+++ b/src/specials.cc
@@ -38,8 +38,8 @@
 #include <sys/param.h>
 #endif /* HAVE_SYS_PARAM_H */
 #include <algorithm>
-#include <sstream>
 #include <map>
+#include <sstream>
 #include "colours.h"
 #include "common.h"
 #include "conky.h"
@@ -49,7 +49,7 @@ struct special_t *specials = nullptr;
 int special_count;
 int graph_count = 0;
 
-std::map<int, double*> graphs;
+std::map<int, double *> graphs;
 
 namespace {
 conky::range_config_setting<int> default_bar_width(
@@ -507,19 +507,18 @@ graph_buf_end:
   *p = '\0';
 }
 
-double* copy_graph(double* original_graph, int graph_width) {
-  double* new_graph = new double[graph_width];
+double *copy_graph(double *original_graph, int graph_width) {
+  double *new_graph = new double[graph_width];
 
   memcpy(new_graph, original_graph, graph_width * sizeof(double));
 
   return new_graph;
 }
 
-double* retrieve_graph(int graph_id, int graph_width) {
+double *retrieve_graph(int graph_id, int graph_width) {
   if (graphs.find(graph_id) == graphs.end()) {
     return new double[graph_width];
-  }
-  else {
+  } else {
     return copy_graph(graphs[graph_id], graph_width);
   }
 }
@@ -527,8 +526,7 @@ double* retrieve_graph(int graph_id, int graph_width) {
 void store_graph(int graph_id, struct special_t *s) {
   if (s->graph == nullptr) {
     graphs[graph_id] = nullptr;
-  }
-  else {
+  } else {
     graphs[graph_id] = copy_graph(s->graph, s->graph_width);
   }
 }
@@ -592,7 +590,7 @@ void new_graph(struct text_object *obj, char *buf, int buf_max_size,
   if ((g->flags & SF_SHOWLOG) != 0) { s->scale = log10(s->scale + 1); }
 #endif
 
-  int graph_id = ((struct graph*)obj->special_data)->id;
+  int graph_id = ((struct graph *)obj->special_data)->id;
   s->graph = retrieve_graph(graph_id, s->graph_width);
 
   graph_append(s, val, g->flags);
@@ -788,4 +786,9 @@ void new_tab(struct text_object *obj, char *p, unsigned int p_max_size) {
   s = new_special(p, TAB);
   s->width = t->width;
   s->arg = t->arg;
+}
+
+void clear_stored_graphs() {
+  graph_count = 0;
+  graphs.clear();
 }

--- a/src/specials.h
+++ b/src/specials.h
@@ -109,6 +109,8 @@ void new_alignc(struct text_object *, char *, unsigned int);
 void new_goto(struct text_object *, char *, unsigned int);
 void new_tab(struct text_object *, char *, unsigned int);
 
+void clear_stored_graphs();
+
 struct special_t *new_special(char *buf, enum special_types t);
 
 #endif /* _SPECIALS_H */


### PR DESCRIPTION
This fixes Issue #441 Graph reset when using conditional color

Graphs would appear to change their previous data when any of the displayed special types (e.g. $color, $hr, $offset) was added or removed from the display (e.g. from a conditional statement). This is because Graphs were just looking at memory locations for previous graph data, but those locations could change if any special types were added or removed. Now the previous graph data will get stored explicitly. 

I don't think that anything other than graphs need to store data, but similar changes might need to get made to those too. 