### PR TITLE
Fix 860

### DIFF
--- a/src/common.cc
+++ b/src/common.cc
@@ -293,14 +293,6 @@ void update_stuff() {
 
   /* if you registered a callback with conky::register_cb, this will run it */
   conky::run_all_callbacks();
-
-#if !defined(__linux__)
-  /* XXX: move the following into the update_meminfo() functions? */
-  if (no_buffers.get(*state)) {
-    info.mem -= info.bufmem;
-    info.memeasyfree += info.bufmem;
-  }
-#endif
 }
 
 /* Ohkie to return negative values for temperatures */

--- a/src/common.cc
+++ b/src/common.cc
@@ -294,11 +294,13 @@ void update_stuff() {
   /* if you registered a callback with conky::register_cb, this will run it */
   conky::run_all_callbacks();
 
+#if !defined(__linux__)
   /* XXX: move the following into the update_meminfo() functions? */
   if (no_buffers.get(*state)) {
     info.mem -= info.bufmem;
     info.memeasyfree += info.bufmem;
   }
+#endif
 }
 
 /* Ohkie to return negative values for temperatures */

--- a/src/linux.cc
+++ b/src/linux.cc
@@ -227,7 +227,10 @@ int update_meminfo(void) {
      full or non-present, OOM happens. Therefore this is the value users want to
      monitor, regarding their RAM.
   */
-
+  if (no_buffers.get(*state)) {
+    info.mem -= info.bufmem;
+    info.memeasyfree += info.bufmem;
+  }
   fclose(meminfo_fp);
   return 0;
 }


### PR DESCRIPTION
**Changes:** completely moved code block:
```c
if (no_buffers.get(*state)) {
  info.mem -= info.bufmem;
  info.memeasyfree += info.bufmem;
}
```
from `common.cc` to `linux.cc`
No other source file use the `bufmem` variable from the `info` struct: they all seem to have their own distinct ways of handling memory quantities, so this block only _specifically applies_ to the `linux.cc` version of the code.
The problem is that by having this in `common.cc`, the memory quantities are incorrect when using `${exep}` and `${execpi}` with linux.
**Testing/Validation:** Unfortunately I don't have the resources to build for any other system, but by looking through each code file I can say with certainty that `info.bufmem` only appears in `linux.cc`. Outside of that, I have the Arch package version to test against which is ver. `conky 1.11.4`.
I made a few simple configs and scripts to use for testing
conky.conf
```lua
conky.config = {
    no_buffers = true,
    out_to_x = false,
    out_to_console = true,
    update_interval = 1.0,
    total_run_times = 1,
    short_units = true,
}
conky.text = [[
${execp ./test.sh }
Total memory:   ${memmax}
memperc:        %${memperc}
mem:            ${mem}
memfree:        ${memfree}
memdirty:       ${memdirty}
memeasyfree:    ${memeasyfree}
]]
```
and test.sh
```sh
#!/bin/zsh
print 'Test'
```
Here's a screenshot of the output of both versions using the config/script:
![conky vs ./conky](https://user-images.githubusercontent.com/50938330/62643121-42579a80-b915-11e9-8620-ab100b394eb2.png)
The first instance is the Arch package build and the second is the compiled version from my branch.
There's a noticeable difference between the two versions for `${memperc}`, `${mem}`, and `${memeasyfree}`. However, htop only reports me using 1.70G:
![htop](https://user-images.githubusercontent.com/50938330/62643166-569b9780-b915-11e9-9aa5-d8bc6a7cee04.png)