### PR TITLE
Ensure that all ncurses libraries are linked to, including libtinfo i…

### DIFF
--- a/cmake/ConkyPlatformChecks.cmake
+++ b/cmake/ConkyPlatformChecks.cmake
@@ -216,6 +216,7 @@ if(BUILD_HTTP)
 endif(BUILD_HTTP)
 
 if(BUILD_NCURSES)
+  set(CURSES_NEED_NCURSES TRUE)
   include(FindCurses)
   if(NOT CURSES_FOUND)
     message(FATAL_ERROR "Unable to find ncurses library")


### PR DESCRIPTION
…f it's a separate library

Without following change conky fails to link on Gentoo Linux if it's built with following options:
-DBUILD_NCURSES=yes -DMAINTAINER_MODE=OFF
It fails to link with following error:
/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: src/CMakeFiles/conky.dir/conky.cc.o: undefined reference to symbol 'stdscr'
/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: /lib64/libtinfo.so.6: error adding symbols: DSO missing from command line

On Gentoo by default ncurses is split into libncurses and libtinfo, and libtinfo is missing from linking command, which leads to this error. This change forces cmake to search for libtinfo if it's a separate library, and link to it.