### PR TITLE
Fix for #877

### DIFF
--- a/src/top.cc
+++ b/src/top.cc
@@ -390,10 +390,6 @@ static void process_find_top(struct process **cpu, struct process **mem,
 }
 
 int update_top() {
-  // XXX: this was a separate callback. and it should be again, as soon as it's
-  // possible
-  update_meminfo();
-
   process_find_top(info.cpu, info.memu, info.time
 #ifdef BUILD_IOSTATS
                    ,


### PR DESCRIPTION
### Description
Race condition happens due to separate calls to `update_meminfo()` with multi-threading enabled, `no_buffers = yes` set in configuration, and using `${top}` objects. Applies only to Linux builds.

A call to `run_all_callbacks()` runs `exec_cb::work()`, which spawns a thread for `update_meminfo()` and one for `update_top()`. Since `update_top()` calls `update_meminfo()`, this means there are two separate threads running `update_meminfo()` in a slightly staggered timing, causing the `info.mem -= info.bufmem` to be applied twice with the same values.

#### How the changes will affect existing behaviour
This should prevent wrong values being reported due to double-booking `info.mem` updates. 
Since `run_all_callbacks()` is responsible for regular updates, separate calls to functions registered as a callback should be avoided. Judging by the comment that I removed, this call seems to be lingering from a time before callbacks were implemented.

#### Describe how you tested and validated your changes.
[Outsourcing](https://github.com/brndnmtthws/conky/issues/877#issuecomment-522187310)

Any sort of configuration that utilizes any `${top}` objects and has `no_buffers = yes` is what causes it. Take: 
```
conky.config = {
    no_buffers = true,
    out_to_x = false,
    out_to_console = true,
    update_interval = 3.0,
    short_units = true,
}
conky.text = [[ RAM ${mem} ${top_mem mem_res 1} ]]
```
Which with `conky 1.11.5` produces:
![2019-08-18-104822_398x206_scrot](https://user-images.githubusercontent.com/50938330/63226267-f96dd480-c1a5-11e9-9566-334281f1852e.png)
Compared to this commit version which with the same configuration produces:
![2019-08-18-104951_398x146_scrot](https://user-images.githubusercontent.com/50938330/63226301-3cc84300-c1a6-11e9-8d34-3a2d837e6d3a.png)