### PR TITLE
add SI unit to the limit value shown in graphs

### DIFF
--- a/src/net_stat.cc
+++ b/src/net_stat.cc
@@ -343,7 +343,7 @@ void parse_net_stat_graph_arg(struct text_object *obj, const char *arg,
 }
 
 /**
- * returns the download speed in kiB/s for the interface referenced by obj
+ * returns the download speed in B/s for the interface referenced by obj
  *
  * @param[in] obj struct containting a member data, which is a struct
  *                containing a void * to a net_stat struct
@@ -351,13 +351,13 @@ void parse_net_stat_graph_arg(struct text_object *obj, const char *arg,
 double downspeedgraphval(struct text_object *obj) {
   auto *ns = static_cast<struct net_stat *>(obj->data.opaque);
 
-  return (ns != nullptr ? (ns->recv_speed / 1024.0) : 0);
+  return (ns != nullptr ? ns->recv_speed : 0);
 }
 
 double upspeedgraphval(struct text_object *obj) {
   auto *ns = static_cast<struct net_stat *>(obj->data.opaque);
 
-  return (ns != nullptr ? (ns->trans_speed / 1024.0) : 0);
+  return (ns != nullptr ? ns->trans_speed : 0);
 }
 #endif /* BUILD_X11 */
 

--- a/src/specials.cc
+++ b/src/specials.cc
@@ -590,7 +590,10 @@ void new_graph(struct text_object *obj, char *buf, int buf_max_size,
   }
   s->tempgrad = g->tempgrad;
 #ifdef BUILD_MATH
-  if ((g->flags & SF_SHOWLOG) != 0) { s->scale = log10(s->scale + 1); }
+  if ((g->flags & SF_SHOWLOG) != 0) {
+    s->scale_log = 1;
+    s->scale = log10(s->scale + 1);
+  }
 #endif
 
   int graph_id = ((struct graph *)obj->special_data)->id;

--- a/src/specials.h
+++ b/src/specials.h
@@ -66,7 +66,8 @@ struct special_t {
   short show_scale;
   int graph_width;
   int graph_allocated;
-  int scaled;                  /* auto adjust maximum */
+  int scaled; /* auto adjust maximum */
+  int scale_log;
   unsigned long first_colour;  // for graph gradient
   unsigned long last_colour;
   short font_added;


### PR DESCRIPTION
Currently, when a graph displays the scale value it does not display the value in an easily known SI unit. When simply looking at a value, it could be bytes, kilobytes, megabytes, etc...

This patch resolves this problem. When `format_human_readable = true` and `show_graph_scale = true` are enabled, all graphs will now show the SI unit associated with the value. Even the networking graph will be displayed properly.

This is an image showing off this change (w/short-units):
![Screenshot from 2019-10-06 19-29-51](https://user-images.githubusercontent.com/73767/66281607-f53e6900-e870-11e9-9746-e99ff4caddd7.png)
