### PR TITLE
properly format PIDs longer than 5 digits

### DIFF
--- a/data/conky.conf
+++ b/data/conky.conf
@@ -77,7 +77,7 @@ ${color grey}File systems:
 ${color grey}Networking:
 Up:$color ${upspeed} ${color grey} - Down:$color ${downspeed}
 $hr
-${color grey}Name              PID   CPU%   MEM%
+${color grey}Name              PID     CPU%   MEM%
 ${color lightgrey} ${top name 1} ${top pid 1} ${top cpu 1} ${top mem 1}
 ${color lightgrey} ${top name 2} ${top pid 2} ${top cpu 2} ${top mem 2}
 ${color lightgrey} ${top name 3} ${top pid 3} ${top cpu 3} ${top mem 3}

--- a/src/top.cc
+++ b/src/top.cc
@@ -538,7 +538,7 @@ static void print_top_user(struct text_object *obj, char *p,
   }
 
 PRINT_TOP_GENERATOR(cpu, (unsigned int)7, "%6.2f", amount)
-PRINT_TOP_GENERATOR(pid, (unsigned int)6, "%5i", pid)
+PRINT_TOP_GENERATOR(pid, (unsigned int)8, "%7i", pid)
 PRINT_TOP_GENERATOR(uid, (unsigned int)6, "%5i", uid)
 PRINT_TOP_HR_GENERATOR(mem_res, rss, 1)
 PRINT_TOP_HR_GENERATOR(mem_vsize, vsize, 1)


### PR DESCRIPTION
64-bit Linux allows PIDs up to 4194304 (7 digits), but current code will truncate any PID longer than 5 digits
