### PR TITLE
Fix segfault on pulseaudio tunnel sinks

### DIFF
--- a/src/pulseaudio.cc
+++ b/src/pulseaudio.cc
@@ -62,8 +62,13 @@ void pa_sink_info_callback(pa_context *c, const pa_sink_info *i, int eol,
     pdr->sink_mute = i->mute;
     pdr->sink_card = i->card;
     pdr->sink_index = i->index;
-    pdr->sink_active_port_name.assign(i->active_port->name);
-    pdr->sink_active_port_description.assign(i->active_port->description);
+    if (i->active_port != nullptr) {
+      pdr->sink_active_port_name.assign(i->active_port->name);
+      pdr->sink_active_port_description.assign(i->active_port->description);
+    } else {
+      pdr->sink_active_port_name.erase();
+      pdr->sink_active_port_description.erase();
+    }
     pdr->sink_volume = round_to_positive_int(
         100.0f * (float)pa_cvolume_avg(&(i->volume)) / (float)PA_VOLUME_NORM);
     pa_threaded_mainloop_signal(pulseaudio->mainloop, 0);


### PR DESCRIPTION
The code in `pa_sink_info_callback` handling active port information assumes there is always an active port. That's isn't the case for tunnel sinks, resulting in a segmentation fault as `i->active_port` is null.