### PR TITLE
Fix if_mounted & if_running variables for FreeBSD

### DIFF
--- a/src/core.cc
+++ b/src/core.cc
@@ -1077,7 +1077,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
       obj->data.s = STRNDUP_ARG;
   obj->callbacks.iftest = &if_existing_iftest;
   obj->callbacks.free = &gen_free_opaque;
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
   END OBJ_IF_ARG(if_mounted, 0, "if_mounted needs an argument") obj->data.s =
       STRNDUP_ARG;
   obj->callbacks.iftest = &check_mount;


### PR DESCRIPTION
if_mounted and if_running were dysfunctional in FreeBSD. This rather trivial modification enables them again. Tested on my 12-STABLE machine.