### PR TITLE
Added lower_case and upper_case commands

### DIFF
--- a/doc/variables.xml
+++ b/doc/variables.xml
@@ -3847,7 +3847,27 @@
             </command>
             <option>text</option>
         </term>
-        <listitem>All words capitalized regardless.
+        <listitem>Capitalises the start of each word.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>lower_case</option>
+            </command>
+            <option>text</option>
+        </term>
+        <listitem>Converts all letters into lowercase.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>upper_case</option>
+            </command>
+            <option>text</option>
+        </term>
+        <listitem>Converts all letters into uppercase.
         <para /></listitem>
     </varlistentry>
     <varlistentry>

--- a/doc/variables.xml
+++ b/doc/variables.xml
@@ -3843,7 +3843,7 @@
     <varlistentry>
         <term>
             <command>
-                <option>start_case</option>
+                <option>startcase</option>
             </command>
             <option>text</option>
         </term>
@@ -3853,7 +3853,7 @@
     <varlistentry>
         <term>
             <command>
-                <option>lower_case</option>
+                <option>lowercase</option>
             </command>
             <option>text</option>
         </term>
@@ -3863,7 +3863,7 @@
     <varlistentry>
         <term>
             <command>
-                <option>upper_case</option>
+                <option>uppercase</option>
             </command>
             <option>text</option>
         </term>

--- a/src/core.cc
+++ b/src/core.cc
@@ -886,6 +886,12 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ(start_case, 0) obj->data.s = STRNDUP_ARG;
   obj->callbacks.print = &print_cap;
   obj->callbacks.free = &gen_free_opaque;
+  END OBJ(lower_case, 0) obj->data.s = STRNDUP_ARG;
+  obj->callbacks.print = &print_lower;
+  obj->callbacks.free = &gen_free_opaque;
+  END OBJ(upper_case, 0) obj->data.s = STRNDUP_ARG;
+  obj->callbacks.print = &print_upper;
+  obj->callbacks.free = &gen_free_opaque;
   END OBJ(catp, 0) obj->data.s = STRNDUP_ARG;
   obj->callbacks.print = &print_catp;
   obj->callbacks.free = &gen_free_opaque;

--- a/src/core.cc
+++ b/src/core.cc
@@ -882,15 +882,18 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
 #ifdef __x86_64__
   END OBJ(freq2, 0) obj->callbacks.print = &print_freq2;
 #endif /* __x86_64__ */
-
+  END OBJ(startcase, 0) obj->data.s = STRNDUP_ARG;
+  obj->callbacks.print = &print_startcase;
+  obj->callbacks.free = &gen_free_opaque;
+  // Deprecated, for compatibility purposes only
   END OBJ(start_case, 0) obj->data.s = STRNDUP_ARG;
-  obj->callbacks.print = &print_cap;
+  obj->callbacks.print = &print_startcase;
   obj->callbacks.free = &gen_free_opaque;
-  END OBJ(lower_case, 0) obj->data.s = STRNDUP_ARG;
-  obj->callbacks.print = &print_lower;
+  END OBJ(lowercase, 0) obj->data.s = STRNDUP_ARG;
+  obj->callbacks.print = &print_lowercase;
   obj->callbacks.free = &gen_free_opaque;
-  END OBJ(upper_case, 0) obj->data.s = STRNDUP_ARG;
-  obj->callbacks.print = &print_upper;
+  END OBJ(uppercase, 0) obj->data.s = STRNDUP_ARG;
+  obj->callbacks.print = &print_uppercase;
   obj->callbacks.free = &gen_free_opaque;
   END OBJ(catp, 0) obj->data.s = STRNDUP_ARG;
   obj->callbacks.print = &print_catp;

--- a/src/misc.cc
+++ b/src/misc.cc
@@ -87,26 +87,19 @@ void print_catp(struct text_object *obj, char *p, unsigned int p_max_size) {
 
 void print_startcase(struct text_object *obj, char *p,
                      unsigned int p_max_size) {
-  unsigned int x = 0;
-  int z = 0;
-  char buf[DEFAULT_TEXT_BUFFER_SIZE];
-  char *src = obj->data.s;
-  char *dest = buf;
-
   evaluate(obj->data.s, p, p_max_size);
-  if (0 != strcmp(p, "")) { src = p; }
-
-  for (; *src && p_max_size - 1 > x; src++, x++) {
-    if (0 == z) {
-      *dest++ = (toupper(static_cast<unsigned char>(*src)));
+  for (unsigned int x = 0, z = 0; x < p_max_size - 1 && p[x]; x++) {
+    if (isspace(p[x])) {
+      z = 0;
+    } else if (z == 0) {
+      p[x] = toupper(p[x]);
       z++;
-      continue;
+    } else {
+      p[x] = tolower(p[x]);
+      z++;
     }
-    *dest++ = *src;
-    if (' ' == *src) z = 0;
   }
-  *dest = '\0';
-  snprintf(p, p_max_size, "%s", buf);
+  p[p_max_size - 1] = '\0';
 }
 
 void print_lowercase(struct text_object *obj, char *p,

--- a/src/misc.cc
+++ b/src/misc.cc
@@ -108,6 +108,22 @@ void print_cap(struct text_object *obj, char *p, unsigned int p_max_size) {
   snprintf(p, p_max_size, "%s", buf);
 }
 
+void print_lower(struct text_object *obj, char *p, unsigned int p_max_size) {
+  evaluate(obj->data.s, p, p_max_size);
+  for (unsigned int x = 0; x < p_max_size-1 && p[x]; x++) {
+    p[x] = tolower(p[x]);
+  }
+  p[p_max_size-1] = '\0';
+}
+
+void print_upper(struct text_object *obj, char *p, unsigned int p_max_size) {
+  evaluate(obj->data.s, p, p_max_size);
+  for (unsigned int x = 0; x < p_max_size-1 && p[x]; x++) {
+    p[x] = toupper(p[x]);
+  }
+  p[p_max_size-1] = '\0';
+}
+
 long long int apply_base_multiplier(const char *s, long long int num) {
   long long int base = 1024LL;
   if (*s && (0 == (strcmp(s, "si")))) { base = 1000LL; }

--- a/src/misc.cc
+++ b/src/misc.cc
@@ -110,18 +110,18 @@ void print_cap(struct text_object *obj, char *p, unsigned int p_max_size) {
 
 void print_lower(struct text_object *obj, char *p, unsigned int p_max_size) {
   evaluate(obj->data.s, p, p_max_size);
-  for (unsigned int x = 0; x < p_max_size-1 && p[x]; x++) {
+  for (unsigned int x = 0; x < p_max_size - 1 && p[x]; x++) {
     p[x] = tolower(p[x]);
   }
-  p[p_max_size-1] = '\0';
+  p[p_max_size - 1] = '\0';
 }
 
 void print_upper(struct text_object *obj, char *p, unsigned int p_max_size) {
   evaluate(obj->data.s, p, p_max_size);
-  for (unsigned int x = 0; x < p_max_size-1 && p[x]; x++) {
+  for (unsigned int x = 0; x < p_max_size - 1 && p[x]; x++) {
     p[x] = toupper(p[x]);
   }
-  p[p_max_size-1] = '\0';
+  p[p_max_size - 1] = '\0';
 }
 
 long long int apply_base_multiplier(const char *s, long long int num) {

--- a/src/misc.cc
+++ b/src/misc.cc
@@ -85,7 +85,7 @@ void print_catp(struct text_object *obj, char *p, unsigned int p_max_size) {
   delete[] buf;
 }
 
-void print_cap(struct text_object *obj, char *p, unsigned int p_max_size) {
+void print_startcase(struct text_object *obj, char *p, unsigned int p_max_size) {
   unsigned int x = 0;
   int z = 0;
   char buf[DEFAULT_TEXT_BUFFER_SIZE];
@@ -108,7 +108,7 @@ void print_cap(struct text_object *obj, char *p, unsigned int p_max_size) {
   snprintf(p, p_max_size, "%s", buf);
 }
 
-void print_lower(struct text_object *obj, char *p, unsigned int p_max_size) {
+void print_lowercase(struct text_object *obj, char *p, unsigned int p_max_size) {
   evaluate(obj->data.s, p, p_max_size);
   for (unsigned int x = 0; x < p_max_size - 1 && p[x]; x++) {
     p[x] = tolower(p[x]);
@@ -116,7 +116,7 @@ void print_lower(struct text_object *obj, char *p, unsigned int p_max_size) {
   p[p_max_size - 1] = '\0';
 }
 
-void print_upper(struct text_object *obj, char *p, unsigned int p_max_size) {
+void print_uppercase(struct text_object *obj, char *p, unsigned int p_max_size) {
   evaluate(obj->data.s, p, p_max_size);
   for (unsigned int x = 0; x < p_max_size - 1 && p[x]; x++) {
     p[x] = toupper(p[x]);

--- a/src/misc.cc
+++ b/src/misc.cc
@@ -85,7 +85,8 @@ void print_catp(struct text_object *obj, char *p, unsigned int p_max_size) {
   delete[] buf;
 }
 
-void print_startcase(struct text_object *obj, char *p, unsigned int p_max_size) {
+void print_startcase(struct text_object *obj, char *p,
+                     unsigned int p_max_size) {
   unsigned int x = 0;
   int z = 0;
   char buf[DEFAULT_TEXT_BUFFER_SIZE];
@@ -108,7 +109,8 @@ void print_startcase(struct text_object *obj, char *p, unsigned int p_max_size) 
   snprintf(p, p_max_size, "%s", buf);
 }
 
-void print_lowercase(struct text_object *obj, char *p, unsigned int p_max_size) {
+void print_lowercase(struct text_object *obj, char *p,
+                     unsigned int p_max_size) {
   evaluate(obj->data.s, p, p_max_size);
   for (unsigned int x = 0; x < p_max_size - 1 && p[x]; x++) {
     p[x] = tolower(p[x]);
@@ -116,7 +118,8 @@ void print_lowercase(struct text_object *obj, char *p, unsigned int p_max_size) 
   p[p_max_size - 1] = '\0';
 }
 
-void print_uppercase(struct text_object *obj, char *p, unsigned int p_max_size) {
+void print_uppercase(struct text_object *obj, char *p,
+                     unsigned int p_max_size) {
   evaluate(obj->data.s, p, p_max_size);
   for (unsigned int x = 0; x < p_max_size - 1 && p[x]; x++) {
     p[x] = toupper(p[x]);

--- a/src/misc.h
+++ b/src/misc.h
@@ -35,8 +35,8 @@
 
 void print_cat(struct text_object *, char *, unsigned int);
 void print_catp(struct text_object *, char *, unsigned int);
-void print_cap(struct text_object *, char *, unsigned int);
-void print_lower(struct text_object *, char *, unsigned int);
-void print_upper(struct text_object *, char *, unsigned int);
+void print_startcase(struct text_object *, char *, unsigned int);
+void print_lowercase(struct text_object *, char *, unsigned int);
+void print_uppercase(struct text_object *, char *, unsigned int);
 long long apply_base_multiplier(const char *, long long int);
 #endif /* _MISC_H */

--- a/src/misc.h
+++ b/src/misc.h
@@ -36,5 +36,7 @@
 void print_cat(struct text_object *, char *, unsigned int);
 void print_catp(struct text_object *, char *, unsigned int);
 void print_cap(struct text_object *, char *, unsigned int);
+void print_lower(struct text_object *, char *, unsigned int);
+void print_upper(struct text_object *, char *, unsigned int);
 long long apply_base_multiplier(const char *, long long int);
 #endif /* _MISC_H */


### PR DESCRIPTION
Each command takes in input and converts it into upper/lower case, to compliment `start_case`.

Examples:
- `${lower_case ABC d e fG}` = "abc d e fg"
- `${nodename}` = "Alex's PC"
- `${lower_case ${nodename}}` = "alex's pc"
- `${upper_case ${nodename}}` = "ALEX'S PC"
- `${upper_case}` = ""

I added these so there is a way to change the case of text individually per-text.

I based them off of `start_case` but simplified them a lot more to make it easier to read and maintain.
I have corrected all formatting mistakes with `make clang-format`.