### PR TITLE
Added misc. text formatting commands

### DIFF
--- a/doc/config_settings.xml
+++ b/doc/config_settings.xml
@@ -1080,6 +1080,15 @@
     <varlistentry>
         <term>
             <command>
+                <option>lowercase</option>
+            </command>
+        </term>
+        <listitem>Boolean value, if true, text is rendered in lower case.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
                 <option>use_spacer</option>
             </command>
         </term>

--- a/doc/variables.xml
+++ b/doc/variables.xml
@@ -3873,6 +3873,16 @@
     <varlistentry>
         <term>
             <command>
+                <option>strip</option>
+            </command>
+            <option>text</option>
+        </term>
+        <listitem>Strips all whitespace from ends of input.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
                 <option>stippled_hr</option>
             </command>
             <option>(space)</option>

--- a/doc/variables.xml
+++ b/doc/variables.xml
@@ -3873,11 +3873,11 @@
     <varlistentry>
         <term>
             <command>
-                <option>strip</option>
+                <option>rstrip</option>
             </command>
             <option>text</option>
         </term>
-        <listitem>Strips all whitespace from ends of input.
+        <listitem>Strips all trailing whitespace from input.
         <para /></listitem>
     </varlistentry>
     <varlistentry>

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -283,6 +283,9 @@ std::string current_config;
 static conky::simple_config_setting<bool> stuff_in_uppercase("uppercase", false,
                                                              true);
 
+static conky::simple_config_setting<bool> stuff_in_lowercase("lowercase", false,
+                                                             true);
+
 /* Run how many times? */
 static conky::range_config_setting<unsigned long> total_run_times(
     "total_run_times", 0, std::numeric_limits<unsigned long>::max(), 0, true);
@@ -792,6 +795,14 @@ static void generate_text() {
     tmp_p = text_buffer;
     while (*tmp_p != 0) {
       *tmp_p = toupper(static_cast<unsigned char>(*tmp_p));
+      tmp_p++;
+    }
+  } else if (stuff_in_lowercase.get(*state)) {
+    char *tmp_p;
+
+    tmp_p = text_buffer;
+    while (*tmp_p != 0) {
+      *tmp_p = tolower(static_cast<unsigned char>(*tmp_p));
       tmp_p++;
     }
   }

--- a/src/core.cc
+++ b/src/core.cc
@@ -895,6 +895,9 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ(uppercase, 0) obj->data.s = STRNDUP_ARG;
   obj->callbacks.print = &print_uppercase;
   obj->callbacks.free = &gen_free_opaque;
+  END OBJ(strip, 0) obj->data.s = STRNDUP_ARG;
+  obj->callbacks.print = &strip_trailing_whitespace;
+  obj->callbacks.free = &gen_free_opaque;
   END OBJ(catp, 0) obj->data.s = STRNDUP_ARG;
   obj->callbacks.print = &print_catp;
   obj->callbacks.free = &gen_free_opaque;

--- a/src/core.cc
+++ b/src/core.cc
@@ -895,7 +895,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ(uppercase, 0) obj->data.s = STRNDUP_ARG;
   obj->callbacks.print = &print_uppercase;
   obj->callbacks.free = &gen_free_opaque;
-  END OBJ(strip, 0) obj->data.s = STRNDUP_ARG;
+  END OBJ(rstrip, 0) obj->data.s = STRNDUP_ARG;
   obj->callbacks.print = &strip_trailing_whitespace;
   obj->callbacks.free = &gen_free_opaque;
   END OBJ(catp, 0) obj->data.s = STRNDUP_ARG;

--- a/src/misc.cc
+++ b/src/misc.cc
@@ -117,6 +117,20 @@ void print_uppercase(struct text_object *obj, char *p,
   }
 }
 
+void strip_trailing_whitespace(struct text_object *obj, char *p,
+                               unsigned int p_max_size) {
+  evaluate(obj->data.s, p, p_max_size);
+  for (unsigned int x = p_max_size - 2;; x--) {
+    if (p[x] && !isspace(p[x])) {
+      p[x + 1] = '\0';
+      break;
+    } else if (x == 0) {
+      p[x] = '\0';
+      break;
+    }
+  }
+}
+
 long long int apply_base_multiplier(const char *s, long long int num) {
   long long int base = 1024LL;
   if (*s && (0 == (strcmp(s, "si")))) { base = 1000LL; }

--- a/src/misc.cc
+++ b/src/misc.cc
@@ -99,7 +99,6 @@ void print_startcase(struct text_object *obj, char *p,
       z++;
     }
   }
-  p[p_max_size - 1] = '\0';
 }
 
 void print_lowercase(struct text_object *obj, char *p,
@@ -108,7 +107,6 @@ void print_lowercase(struct text_object *obj, char *p,
   for (unsigned int x = 0; x < p_max_size - 1 && p[x]; x++) {
     p[x] = tolower(p[x]);
   }
-  p[p_max_size - 1] = '\0';
 }
 
 void print_uppercase(struct text_object *obj, char *p,
@@ -117,7 +115,6 @@ void print_uppercase(struct text_object *obj, char *p,
   for (unsigned int x = 0; x < p_max_size - 1 && p[x]; x++) {
     p[x] = toupper(p[x]);
   }
-  p[p_max_size - 1] = '\0';
 }
 
 long long int apply_base_multiplier(const char *s, long long int num) {

--- a/src/misc.h
+++ b/src/misc.h
@@ -38,5 +38,6 @@ void print_catp(struct text_object *, char *, unsigned int);
 void print_startcase(struct text_object *, char *, unsigned int);
 void print_lowercase(struct text_object *, char *, unsigned int);
 void print_uppercase(struct text_object *, char *, unsigned int);
+void strip_trailing_whitespace(struct text_object *, char *, unsigned int);
 long long apply_base_multiplier(const char *, long long int);
 #endif /* _MISC_H */


### PR DESCRIPTION
Followup from #927 
This adds a `lowercase` boolean config option, which sets all text to lower case
If both `uppercase` and `lowercase` are enabled it defaults to `uppercase`.

This also removes the null-termination line from my previous PR, as it was an unneeded addition (strings are already null-terminated)

Lastly, this adds a `rstrip` command, which strips trailing whitespace from a string.

`${curl example.com/ip}` = `\nIP: 0.0.0.0  \n \n`
`${rstrip ${curl example.com/ip}}` = `\nIP: 0.0.0.0`
`${rstrip \n\n\n\n\n\   \n      \n   \n}` = 

Note that it does not remove whitespace from the start of the string, only the end.