### PR TITLE
Print uid in top if user doesnt exist.

### DIFF
--- a/src/top.cc
+++ b/src/top.cc
@@ -517,7 +517,7 @@ static void print_top_user(struct text_object *obj, char *p,
   if (pw != nullptr) {
     snprintf(p, p_max_size, "%.8s", pw->pw_name);
   } else {
-    NORM_ERR("The uid doesn't exist");
+    snprintf(p, p_max_size, "%d", td->list[td->num]->uid);
   }
 }
 


### PR DESCRIPTION
The change is necessary for displaying uid instead of blank place if user doesn't exist (in top).
Changed function top.cc `print_top_user()` will add uid (decimal) value to top as opposed to adding blank and printing error to stderr.

#948 
