### PR TITLE
make cmake builds reproducible

### DIFF
--- a/cmake/Conky.cmake
+++ b/cmake/Conky.cmake
@@ -157,13 +157,11 @@ endif(NOT RELEASE)
 
 mark_as_advanced(APP_AWK APP_WC APP_DATE APP_UNAME)
 
-# BUILD_DATE=$(LANG=en_US LC_ALL=en_US LOCALE=en_US date) BUILD_ARCH="$(uname
-# -sr) ($(uname -m))"
-execute_process(COMMAND ${APP_DATE}
-                RESULT_VARIABLE RETVAL
-                OUTPUT_VARIABLE BUILD_DATE
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
-execute_process(COMMAND ${APP_UNAME} -srm
+# BUILD_DATE=$(LANG=en_US LC_ALL=en_US LOCALE=en_US date --utc
+# --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%Y-%m-%d)
+# BUILD_ARCH="$(uname -sm)"
+STRING(TIMESTAMP BUILD_DATE "%Y-%m-%d" UTC)
+execute_process(COMMAND ${APP_UNAME} -sm
                 RESULT_VARIABLE RETVAL
                 OUTPUT_VARIABLE BUILD_ARCH
                 OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
While working on the [reproducible build](https://reproducible-builds.org/) project, I noticed that conky could not be build reproduced.

This patch makes the output consistent across builds by using [SOURCE_DATE_EPOCH](https://reproducible-builds.org/docs/source-date-epoch/) and `uname -sm` (by omitting the `-r` the kernel version is gone).