### PR TITLE
Fixed nil value call error while converting old sytax config

### DIFF
--- a/extras/convert.lua
+++ b/extras/convert.lua
@@ -156,5 +156,5 @@ if conky == nil then
     output:write(converted);
     output:close();
 else
-    return assert(loadstring(converted, 'converted config'));
+    return assert(load(converted, 'converted config'));
 end;


### PR DESCRIPTION
**Description**
The latest conky git build using Lua v5.4.0 fails to convert the old syntax config on startup with the following error:

`conky: Syntax error (/home/user/.config/conky/conky.conf:1: syntax error near 'yes') while reading config file. 
conky: Assuming it's in old syntax and attempting conversion.
conky: [string "..."]:159: attempt to call a nil value (global 'loadstring')
`

The only change made in this pull request was to switch from the deprecated and removed `loadstring` function to the identical `load` function. After building with those changes, the config is successfully converted once again.

