### PR TITLE
llua: expose cpu_count

### DIFF
--- a/src/llua.cc
+++ b/src/llua.cc
@@ -533,7 +533,7 @@ void llua_setup_info(struct information *i, double u_interval) {
   lua_newtable(lua_L);
 
   llua_set_number("update_interval", u_interval);
-  (void)i;
+  llua_set_number("cpu_count", i->cpu_count);
 
   lua_setglobal(lua_L, "conky_info");
 }


### PR DESCRIPTION
This avoids having to hardcode the CPU count, and crashing with scripts
with too many cpus prepared (typically rings).

Had this around for a while now, it's very annoying having to fix scripts just because the cpu count is hardcoded in them…