### PR TITLE
Disable including dev/wi/if_wavelan_ieee.h as it has ben removed from FreeBSD source code in head

### DIFF
--- a/src/freebsd.cc
+++ b/src/freebsd.cc
@@ -49,7 +49,9 @@
 #include <unistd.h>
 
 #include <dev/acpica/acpiio.h>
+#if 0
 #include <dev/wi/if_wavelan_ieee.h>
+#endif
 
 #include <mutex>
 


### PR DESCRIPTION
It looks like the code actually using this include is already included in an #if 0 block and disabled, so I'm disabling this include unconditionally.