### PR TITLE
Correct width of formated data rates.

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -591,10 +591,10 @@ void human_readable(long long num, char *buf, int size) {
     return;
   }
   if (short_units.get(*state)) {
-    width = 5;
+    width = 6;
     format = "%.*f %.1s";
   } else {
-    width = 7;
+    width = 8;
     format = "%.*f %-.3s";
   }
 


### PR DESCRIPTION
The current width of data rates is incorrect causing data rate fields to change in size.  I have increase the width of data rates by one to correct this and therefore cause the data rate fields to stay the same width in known cases.