### PR TITLE
Fix conky window crawling

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1802,7 +1802,6 @@ static void draw_stuff() {
     selected_font = 0;
     if (draw_shades.get(*state) && !draw_outline.get(*state)) {
       text_offset_x = text_offset_y = 1;
-      text_start_y++;
       set_foreground_color(default_shade_color.get(*state));
       draw_mode = BG;
       draw_text();


### PR DESCRIPTION
The conky window is crawling when some other is moving around it.

To reproduce this bug run conky with the following config:

   double_buffer yes

   TEXT
   TEST

And slowly move other window near conky window.

The bug was introduced in e2bd14e7b7dcde5c60044b6f806f9f708d575a61.

Original patch by: George V. Kouryachy (Fr. Br. George) <george@altlinux.org>
