### PR TITLE
Fix incorrect network speed (resolves #863)

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -766,6 +766,12 @@ static void generate_text() {
    * some info.mem entries */
   update_stuff();
 
+  /* Update `last_update_time` before `generate_text_internal()`, as the latter
+   * calls `evaluate()` -> `update_net_stats()`, which needs `last_update_time`
+   * to be set correctly. If this is not done, than the network speed being
+   * shown will be much lower than the actual speed.*/
+  last_update_time = current_update_time;
+
   /* populate the text buffer; generate_text_internal() iterates through
    * global_root_object (an instance of the text_object struct) and calls
    * any callbacks that were set on startup by construct_text_object(). */
@@ -822,7 +828,6 @@ static void generate_text() {
   if (next_update_time < time || next_update_time > time + ui) {
     next_update_time = time - fmod(time, ui) + ui;
   }
-  last_update_time = current_update_time;
   total_updates++;
 }
 


### PR DESCRIPTION
Resolves https://github.com/brndnmtthws/conky/issues/863.

I found that the call sequence happens like:

- `current_update_time = get_time();`
- `generate_text_internal(p, max_user_text.get(*state), global_root_object);` -> `evaluate()` -> `update_net_stats()`
- `last_update_time = current_update_time;`

So `last_update_time` is updated too late for `update_net_stats()` to receive the correct value. Setting it before `generate_text_internal()` fixes things.

An example config file:

```lua
conky.text = [[
${execpi 3600 whoami}
lo ip          ${alignr}${addr lo}
Net Down       ${downspeed lo} \
Net Up         ${upspeed lo}
Total Down     ${totaldown lo} \
Total Up       ${totalup lo}
${downspeedgraph lo 60,230 6250000}${alignr}\
${upspeedgraph lo 60,230 2500000}
]]
```

To test this, run the following in one window:

    $ iperf --server

Following in another window:

    $ iperf --client localhost --bandwidth 1M

Conky should correctly display `Net Down` & `Net Up` as `128 KiB`.

