### PR TITLE
Scale UI elements according to Xft.dpi

### DIFF
--- a/src/conky.h
+++ b/src/conky.h
@@ -301,17 +301,8 @@ void set_updatereset(int);
 int get_updatereset(void);
 int get_total_updates(void);
 
-#ifdef BUILD_X11
-#ifdef BUILD_XFT
 static int xft_dpi;
 int xft_dpi_scale(int value);
-#define DPI_SCALE(a) xft_dpi_scale(a)
-#else
-#define DPI_SCALE(a) a
-#endif /* BUILD_XFT */
-#else
-#define DPI_SCALE(a) a
-#endif /* BUILD_X11 */
 
 int get_saved_coordinates_x(int);
 int get_saved_coordinates_y(int);

--- a/src/conky.h
+++ b/src/conky.h
@@ -301,6 +301,18 @@ void set_updatereset(int);
 int get_updatereset(void);
 int get_total_updates(void);
 
+#ifdef BUILD_X11
+#ifdef BUILD_XFT
+static int xft_dpi;
+int xft_dpi_scale(int value);
+#define DPI_SCALE(a) xft_dpi_scale(a)
+#else
+#define DPI_SCALE(a) a
+#endif /* BUILD_XFT */
+#else
+#define DPI_SCALE(a) a
+#endif /* BUILD_X11 */
+
 int get_saved_coordinates_x(int);
 int get_saved_coordinates_y(int);
 

--- a/src/imlib2.cc
+++ b/src/imlib2.cc
@@ -133,11 +133,19 @@ void cimlib_add_image(const char *args) {
   if (tmp != nullptr) {
     tmp += 3;
     sscanf(tmp, "%i,%i", &cur->x, &cur->y);
+#ifdef BUILD_XFT
+    cur->x = DPI_SCALE(cur->x);
+    cur->y = DPI_SCALE(cur->y);
+#endif /* BUILD_XFT */
   }
   tmp = strstr(args, "-s ");
   if (tmp != nullptr) {
     tmp += 3;
     if (sscanf(tmp, "%ix%i", &cur->w, &cur->h) != 0) { cur->wh_set = 1; }
+#ifdef BUILD_XFT
+    cur->w = DPI_SCALE(cur->w);
+    cur->h = DPI_SCALE(cur->h);
+#endif /* BUILD_XFT */
   }
 
   tmp = strstr(args, "-n");
@@ -200,8 +208,8 @@ static void cimlib_draw_image(struct image_list_s *cur, int *clip_x,
   w = imlib_image_get_width();
   h = imlib_image_get_height();
   if (cur->wh_set == 0) {
-    cur->w = w;
-    cur->h = h;
+    cur->w = DPI_SCALE(w);
+    cur->h = DPI_SCALE(h);
   }
   imlib_context_set_image(buffer);
   imlib_blend_image_onto_image(image, 1, 0, 0, w, h, cur->x, cur->y, cur->w,

--- a/src/imlib2.cc
+++ b/src/imlib2.cc
@@ -134,8 +134,8 @@ void cimlib_add_image(const char *args) {
     tmp += 3;
     sscanf(tmp, "%i,%i", &cur->x, &cur->y);
 #ifdef BUILD_XFT
-    cur->x = DPI_SCALE(cur->x);
-    cur->y = DPI_SCALE(cur->y);
+    cur->x = xft_dpi_scale(cur->x);
+    cur->y = xft_dpi_scale(cur->y);
 #endif /* BUILD_XFT */
   }
   tmp = strstr(args, "-s ");
@@ -143,8 +143,8 @@ void cimlib_add_image(const char *args) {
     tmp += 3;
     if (sscanf(tmp, "%ix%i", &cur->w, &cur->h) != 0) { cur->wh_set = 1; }
 #ifdef BUILD_XFT
-    cur->w = DPI_SCALE(cur->w);
-    cur->h = DPI_SCALE(cur->h);
+    cur->w = xft_dpi_scale(cur->w);
+    cur->h = xft_dpi_scale(cur->h);
 #endif /* BUILD_XFT */
   }
 
@@ -208,8 +208,8 @@ static void cimlib_draw_image(struct image_list_s *cur, int *clip_x,
   w = imlib_image_get_width();
   h = imlib_image_get_height();
   if (cur->wh_set == 0) {
-    cur->w = DPI_SCALE(w);
-    cur->h = DPI_SCALE(h);
+    cur->w = xft_dpi_scale(w);
+    cur->h = xft_dpi_scale(h);
   }
   imlib_context_set_image(buffer);
   imlib_blend_image_onto_image(image, 1, 0, 0, w, h, cur->x, cur->y, cur->w,

--- a/src/specials.cc
+++ b/src/specials.cc
@@ -396,8 +396,8 @@ void new_gauge_in_x11(struct text_object *obj, char *buf, double usage) {
   s = new_special(buf, GAUGE);
 
   s->arg = usage;
-  s->width = g->width;
-  s->height = g->height;
+  s->width = DPI_SCALE(g->width);
+  s->height = DPI_SCALE(g->height);
   s->scale = g->scale;
 }
 #endif /* BUILD_X11 */
@@ -551,7 +551,7 @@ void new_graph(struct text_object *obj, char *buf, int buf_max_size,
   s = new_special(buf, GRAPH);
 
   /* set graph (special) width to width in obj */
-  s->width = g->width;
+  s->width = DPI_SCALE(g->width);
   if (s->width != 0) { s->graph_width = s->width; }
 
   if (s->graph_width != s->graph_allocated) {
@@ -576,7 +576,7 @@ void new_graph(struct text_object *obj, char *buf, int buf_max_size,
     s->graph_allocated = s->graph_width;
     graphs[g->id] = graph;
   }
-  s->height = g->height;
+  s->height = DPI_SCALE(g->height);
   s->first_colour = adjust_colours(g->first_colour);
   s->last_colour = adjust_colours(g->last_colour);
   if (g->scale != 0) {
@@ -611,7 +611,7 @@ void new_hr(struct text_object *obj, char *p, unsigned int p_max_size) {
 
   if (p_max_size == 0) { return; }
 
-  new_special(p, HORIZONTAL_LINE)->height = obj->data.l;
+  new_special(p, HORIZONTAL_LINE)->height = DPI_SCALE(obj->data.l);
 }
 
 void scan_stippled_hr(struct text_object *obj, const char *arg) {
@@ -643,8 +643,8 @@ void new_stippled_hr(struct text_object *obj, char *p,
 
   s = new_special(p, STIPPLED_HR);
 
-  s->height = sh->height;
-  s->arg = sh->arg;
+  s->height = DPI_SCALE(sh->height);
+  s->arg = DPI_SCALE(sh->arg);
 }
 #endif /* BUILD_X11 */
 
@@ -705,8 +705,8 @@ static void new_bar_in_x11(struct text_object *obj, char *buf, double usage) {
   s = new_special(buf, BAR);
 
   s->arg = usage;
-  s->width = b->width;
-  s->height = b->height;
+  s->width = DPI_SCALE(b->width);
+  s->height = DPI_SCALE(b->height);
   s->scale = b->scale;
 }
 #endif /* BUILD_X11 */
@@ -741,12 +741,12 @@ void new_outline(struct text_object *obj, char *p, unsigned int p_max_size) {
 
 void new_offset(struct text_object *obj, char *p, unsigned int p_max_size) {
   if (p_max_size == 0) { return; }
-  new_special(p, OFFSET)->arg = obj->data.l;
+  new_special(p, OFFSET)->arg = DPI_SCALE(obj->data.l);
 }
 
 void new_voffset(struct text_object *obj, char *p, unsigned int p_max_size) {
   if (p_max_size == 0) { return; }
-  new_special(p, VOFFSET)->arg = obj->data.l;
+  new_special(p, VOFFSET)->arg = DPI_SCALE(obj->data.l);
 }
 
 void new_save_coordinates(struct text_object *obj, char *p,
@@ -757,18 +757,18 @@ void new_save_coordinates(struct text_object *obj, char *p,
 
 void new_alignr(struct text_object *obj, char *p, unsigned int p_max_size) {
   if (p_max_size == 0) { return; }
-  new_special(p, ALIGNR)->arg = obj->data.l;
+  new_special(p, ALIGNR)->arg = DPI_SCALE(obj->data.l);
 }
 
 // A positive offset pushes the text further left
 void new_alignc(struct text_object *obj, char *p, unsigned int p_max_size) {
   if (p_max_size == 0) { return; }
-  new_special(p, ALIGNC)->arg = obj->data.l;
+  new_special(p, ALIGNC)->arg = DPI_SCALE(obj->data.l);
 }
 
 void new_goto(struct text_object *obj, char *p, unsigned int p_max_size) {
   if (p_max_size == 0) { return; }
-  new_special(p, GOTO)->arg = obj->data.l;
+  new_special(p, GOTO)->arg = DPI_SCALE(obj->data.l);
 }
 
 void scan_tab(struct text_object *obj, const char *arg) {
@@ -796,8 +796,8 @@ void new_tab(struct text_object *obj, char *p, unsigned int p_max_size) {
   if ((t == nullptr) || (p_max_size == 0)) { return; }
 
   s = new_special(p, TAB);
-  s->width = t->width;
-  s->arg = t->arg;
+  s->width = DPI_SCALE(t->width);
+  s->arg = DPI_SCALE(t->arg);
 }
 
 void clear_stored_graphs() {

--- a/src/specials.cc
+++ b/src/specials.cc
@@ -396,8 +396,8 @@ void new_gauge_in_x11(struct text_object *obj, char *buf, double usage) {
   s = new_special(buf, GAUGE);
 
   s->arg = usage;
-  s->width = DPI_SCALE(g->width);
-  s->height = DPI_SCALE(g->height);
+  s->width = xft_dpi_scale(g->width);
+  s->height = xft_dpi_scale(g->height);
   s->scale = g->scale;
 }
 #endif /* BUILD_X11 */
@@ -551,7 +551,7 @@ void new_graph(struct text_object *obj, char *buf, int buf_max_size,
   s = new_special(buf, GRAPH);
 
   /* set graph (special) width to width in obj */
-  s->width = DPI_SCALE(g->width);
+  s->width = xft_dpi_scale(g->width);
   if (s->width != 0) { s->graph_width = s->width; }
 
   if (s->graph_width != s->graph_allocated) {
@@ -576,7 +576,7 @@ void new_graph(struct text_object *obj, char *buf, int buf_max_size,
     s->graph_allocated = s->graph_width;
     graphs[g->id] = graph;
   }
-  s->height = DPI_SCALE(g->height);
+  s->height = xft_dpi_scale(g->height);
   s->first_colour = adjust_colours(g->first_colour);
   s->last_colour = adjust_colours(g->last_colour);
   if (g->scale != 0) {
@@ -611,7 +611,7 @@ void new_hr(struct text_object *obj, char *p, unsigned int p_max_size) {
 
   if (p_max_size == 0) { return; }
 
-  new_special(p, HORIZONTAL_LINE)->height = DPI_SCALE(obj->data.l);
+  new_special(p, HORIZONTAL_LINE)->height = xft_dpi_scale(obj->data.l);
 }
 
 void scan_stippled_hr(struct text_object *obj, const char *arg) {
@@ -643,8 +643,8 @@ void new_stippled_hr(struct text_object *obj, char *p,
 
   s = new_special(p, STIPPLED_HR);
 
-  s->height = DPI_SCALE(sh->height);
-  s->arg = DPI_SCALE(sh->arg);
+  s->height = xft_dpi_scale(sh->height);
+  s->arg = xft_dpi_scale(sh->arg);
 }
 #endif /* BUILD_X11 */
 
@@ -705,8 +705,8 @@ static void new_bar_in_x11(struct text_object *obj, char *buf, double usage) {
   s = new_special(buf, BAR);
 
   s->arg = usage;
-  s->width = DPI_SCALE(b->width);
-  s->height = DPI_SCALE(b->height);
+  s->width = xft_dpi_scale(b->width);
+  s->height = xft_dpi_scale(b->height);
   s->scale = b->scale;
 }
 #endif /* BUILD_X11 */
@@ -741,12 +741,12 @@ void new_outline(struct text_object *obj, char *p, unsigned int p_max_size) {
 
 void new_offset(struct text_object *obj, char *p, unsigned int p_max_size) {
   if (p_max_size == 0) { return; }
-  new_special(p, OFFSET)->arg = DPI_SCALE(obj->data.l);
+  new_special(p, OFFSET)->arg = xft_dpi_scale(obj->data.l);
 }
 
 void new_voffset(struct text_object *obj, char *p, unsigned int p_max_size) {
   if (p_max_size == 0) { return; }
-  new_special(p, VOFFSET)->arg = DPI_SCALE(obj->data.l);
+  new_special(p, VOFFSET)->arg = xft_dpi_scale(obj->data.l);
 }
 
 void new_save_coordinates(struct text_object *obj, char *p,
@@ -757,18 +757,18 @@ void new_save_coordinates(struct text_object *obj, char *p,
 
 void new_alignr(struct text_object *obj, char *p, unsigned int p_max_size) {
   if (p_max_size == 0) { return; }
-  new_special(p, ALIGNR)->arg = DPI_SCALE(obj->data.l);
+  new_special(p, ALIGNR)->arg = xft_dpi_scale(obj->data.l);
 }
 
 // A positive offset pushes the text further left
 void new_alignc(struct text_object *obj, char *p, unsigned int p_max_size) {
   if (p_max_size == 0) { return; }
-  new_special(p, ALIGNC)->arg = DPI_SCALE(obj->data.l);
+  new_special(p, ALIGNC)->arg = xft_dpi_scale(obj->data.l);
 }
 
 void new_goto(struct text_object *obj, char *p, unsigned int p_max_size) {
   if (p_max_size == 0) { return; }
-  new_special(p, GOTO)->arg = DPI_SCALE(obj->data.l);
+  new_special(p, GOTO)->arg = xft_dpi_scale(obj->data.l);
 }
 
 void scan_tab(struct text_object *obj, const char *arg) {
@@ -796,8 +796,8 @@ void new_tab(struct text_object *obj, char *p, unsigned int p_max_size) {
   if ((t == nullptr) || (p_max_size == 0)) { return; }
 
   s = new_special(p, TAB);
-  s->width = DPI_SCALE(t->width);
-  s->arg = DPI_SCALE(t->arg);
+  s->width = xft_dpi_scale(t->width);
+  s->arg = xft_dpi_scale(t->arg);
 }
 
 void clear_stored_graphs() {


### PR DESCRIPTION
As in the title, this PR changes the size of all UI elements (graphs, sizes, offsets...) depending on the Xft.dpi X resource. Xft.dpi is the recommended way to scale application graphics on HiDPI displays, but it currently breaks conky: only xft text is scaled correctly, everything else is not. This results in many inconsistencies when Xft.dpi is set to anything other than the default value (96).See also issue #944 and my screenshots below. 

With this PR, any size in pixels is scaled by the appropriate amount before being used for rendering. A DPI value of 96 means no scaling, 192 is 2x scaling, and so on. Scaling by non-integer amounts is rounded to the closest pixel size, e.g. 2 px scaled by 160% is 3.2 px, so it is rounded to 3 px.

If use_xft is false, then text is not scaled, so I also kept the UI elements unscaled. Alternatively, it should be possible to calculate an equivalent scaled size for the non-xft font, and thus scale both text and UI elements even when use_xft = false. Please let me know if the non-xft case should be handled in this way. Also, if any other change is considered necessary, just tell me.

Screenshots follow, to demonstrate the problem and how it is solved. They all use the same configuration file, so that the differences among them are only due to the Xft.dpi setting and to the way it is handled.

<details>
<summary>Standard dpi (96):</summary>

![unscaled](https://user-images.githubusercontent.com/20945263/114006806-0d75b680-9861-11eb-8021-188c0c472952.png)
</details>
<details>
<summary>Increased dpi (160), without this PR:</summary>

![scaled_wrong](https://user-images.githubusercontent.com/20945263/114006836-14042e00-9861-11eb-8fd5-553759a46bbb.png)
</details>
<details>
<summary>Increased dpi (160), with this PR:</summary>

![scaled_ok](https://user-images.githubusercontent.com/20945263/114006857-1797b500-9861-11eb-8fd1-15d776b2a1f4.png)
</details>