### PR TITLE
Added Intel backlight support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,7 +24,7 @@ affinity <affy at users dot sourceforge dot net>
 akash <akash at users dot sourceforge dot net>
   battery_percent and battery_bar
 
-Asbj�rn Zweidorff Kj�r <bunjiboys at users dot sourceforge dot net>
+Asbjørn Zweidorff Kjær <bunjiboys at users dot sourceforge dot net>
   support for EVE-Online skill monitoring
 
 Aseem Mohanty <amohanty at myrealbox dot com>
@@ -122,7 +122,7 @@ Gwenhael LE MOINE <cycojesus at yahoo dot fr>
 Hannu Saransaari <hipo at users dot sourceforge dot net>
   Main code
 
-Henri H�kkinen <henux at users dot sourceforge dot net>
+Henri Häkkinen <henux at users dot sourceforge dot net>
   MOC support
 
 hinokind <hinokind at users dot sourceforge dot net>
@@ -170,7 +170,7 @@ Jonas Koelker <jonaskoelker at users dot sourceforge dot net>
 Joshua Gerrish <jgerrish at users dot sourceforge dot net>
   mpd password patch
 
-J�rgen P. Tjern� <daxxar at mental dot mine dot nu>
+Jørgen P. Tjernø <daxxar at mental dot mine dot nu>
   Restores default settings before loading new config file in SIGHUP
   Some cleaning and commenting apparently :)
   SIGHUP config file reload
@@ -205,7 +205,7 @@ Lassi Selander <sleipner at users dot sourceforge dot net>
 Lauri Hakkarainen <b10nik at users dot sourceforge dot net>
   Some translating, web and other stuff
 
-Leszek Krupi�ski <leszek at wafel dot com>
+Leszek Krupiñski <leszek at wafel dot com>
   Battery number for ACPI battery
   Load average bug fix
 
@@ -317,7 +317,7 @@ Szymon Boniecki
 Thomas Cort
   CPU frequency patch for alpha
 
-Toke H�iland-J�rgensen <toke at toke dot dk>
+Toke Høiland-Jørgensen <toke at toke dot dk>
   systemd journal support
 
 Toni <bleach at users dot sourceforge dot net>
@@ -361,5 +361,5 @@ zimba-tm <zimba-tm at users dot sourceforge dot net>
 zotrix <zotrix at users dot sourceforge dot net>
   FreeBSD patch for <10 procs
 
-Daniel Be�ler <daniel@orgizm.net>
+Daniel Beßler <daniel@orgizm.net>
   argb visual patch

--- a/AUTHORS
+++ b/AUTHORS
@@ -24,7 +24,7 @@ affinity <affy at users dot sourceforge dot net>
 akash <akash at users dot sourceforge dot net>
   battery_percent and battery_bar
 
-Asbjørn Zweidorff Kjær <bunjiboys at users dot sourceforge dot net>
+Asbjï¿½rn Zweidorff Kjï¿½r <bunjiboys at users dot sourceforge dot net>
   support for EVE-Online skill monitoring
 
 Aseem Mohanty <amohanty at myrealbox dot com>
@@ -122,7 +122,7 @@ Gwenhael LE MOINE <cycojesus at yahoo dot fr>
 Hannu Saransaari <hipo at users dot sourceforge dot net>
   Main code
 
-Henri Häkkinen <henux at users dot sourceforge dot net>
+Henri Hï¿½kkinen <henux at users dot sourceforge dot net>
   MOC support
 
 hinokind <hinokind at users dot sourceforge dot net>
@@ -170,7 +170,7 @@ Jonas Koelker <jonaskoelker at users dot sourceforge dot net>
 Joshua Gerrish <jgerrish at users dot sourceforge dot net>
   mpd password patch
 
-Jørgen P. Tjernø <daxxar at mental dot mine dot nu>
+Jï¿½rgen P. Tjernï¿½ <daxxar at mental dot mine dot nu>
   Restores default settings before loading new config file in SIGHUP
   Some cleaning and commenting apparently :)
   SIGHUP config file reload
@@ -205,7 +205,7 @@ Lassi Selander <sleipner at users dot sourceforge dot net>
 Lauri Hakkarainen <b10nik at users dot sourceforge dot net>
   Some translating, web and other stuff
 
-Leszek Krupiñski <leszek at wafel dot com>
+Leszek Krupiï¿½ski <leszek at wafel dot com>
   Battery number for ACPI battery
   Load average bug fix
 
@@ -278,6 +278,9 @@ Phil <n0-1 at users dot sourceforge dot net>
 Psychon <psychon at users dot sourceforge dot net>
   a bunch of code cleanups
 
+Rogier Reerink <me at rogier dot io>
+  Intel backlight support
+
 roiban adi <adiroiban at users dot sourceforge dot net>
   hex colour patch
 
@@ -314,7 +317,7 @@ Szymon Boniecki
 Thomas Cort
   CPU frequency patch for alpha
 
-Toke Høiland-Jørgensen <toke at toke dot dk>
+Toke Hï¿½iland-Jï¿½rgensen <toke at toke dot dk>
   systemd journal support
 
 Toni <bleach at users dot sourceforge dot net>
@@ -358,5 +361,5 @@ zimba-tm <zimba-tm at users dot sourceforge dot net>
 zotrix <zotrix at users dot sourceforge dot net>
   FreeBSD patch for <10 procs
 
-Daniel Beßler <daniel@orgizm.net>
+Daniel Beï¿½ler <daniel@orgizm.net>
   argb visual patch

--- a/cmake/ConkyBuildOptions.cmake
+++ b/cmake/ConkyBuildOptions.cmake
@@ -259,6 +259,9 @@ option(BUILD_JOURNAL "Enable support for reading from the systemd journal"
 option(BUILD_PULSEAUDIO
        "Enable support for Pulseaudio's default sink and source" false)
 
+option(BUILD_INTEL_BACKLIGHT
+       "Enable support for Intel backlight" false)
+
 option(BUILD_HSV_GRADIENT "Enable gradient in HSV colour space" true)
 
 message(STATUS "CMAKE_C_FLAGS: " ${CMAKE_C_FLAGS})

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -107,6 +107,8 @@
 
 #cmakedefine BUILD_PULSEAUDIO 1
 
+#cmakedefine BUILD_INTEL_BACKLIGHT 0
+
 #cmakedefine BUILD_IPV6 1
 
 #cmakedefine BUILD_HTTP 1

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -282,6 +282,11 @@ if(BUILD_PULSEAUDIO)
   set(optional_sources ${optional_sources} ${pulseaudio})
 endif(BUILD_PULSEAUDIO)
 
+if(BUILD_INTEL_BACKLIGHT)
+  set(intel_backlight intel_backlight.cc intel_backlight.h)
+  set(optional_sources ${optional_sources} ${intel_backlight})
+endif(BUILD_INTEL_BACKLIGHT)
+
 if(BUILD_HSV_GRADIENT)
   set(hsv_gradient hsv_gradient.cc hsv_gradient.h)
   set(optional_sources ${optional_sources} ${hsv_gradient})

--- a/src/core.cc
+++ b/src/core.cc
@@ -107,6 +107,9 @@
 #ifdef BUILD_PULSEAUDIO
 #include "pulseaudio.h"
 #endif /* BUILD_PULSEAUDIO */
+#ifdef BUILD_INTEL_BACKLIGHT
+#include "intel_backlight.h"
+#endif /* BUILD_INTEL_BACKLIGHT */
 
 /* check for OS and include appropriate headers */
 #if defined(__linux__)
@@ -1971,6 +1974,11 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   obj->callbacks.free = &free_pulseaudio;
   init_pulseaudio(obj);
 #endif /* BUILD_PULSEAUDIO */
+#ifdef BUILD_INTEL_BACKLIGHT
+  END OBJ(intel_backlight, 0) obj->callbacks.print = &print_intel_backlight;
+  obj->callbacks.free = &free_intel_backlight;
+  init_intel_backlight(obj);
+#endif /* BUILD_INTEL_BACKLIGHT */
   END {
     auto *buf = static_cast<char *>(malloc(text_buffer_size.get(*state)));
 

--- a/src/intel_backlight.cc
+++ b/src/intel_backlight.cc
@@ -1,0 +1,107 @@
+/*
+ *
+ * Conky, a system monitor, based on torsmo.
+ *
+ * Any original torsmo code is licensed under the BSD license.
+ * All code written since the fork of torsmo is licensed under the GPL.
+ * Please see COPYING for details.
+ *
+ * Copyright (c) 2021 Rogier Reerink
+ *  (See AUTHORS)
+ * All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "intel_backlight.h"
+#include "logging.h"
+
+#define FS_BRIGHTNESS_MAX "/sys/class/backlight/intel_backlight/max_brightness"
+#define FS_BRIGHTNESS_CURRENT "/sys/class/backlight/intel_backlight/brightness"
+
+struct backlight {
+  FILE *fp_max;
+  unsigned max;
+  FILE *fp_current;
+  unsigned current;
+};
+
+void open_backlight(struct backlight *bl) {
+  bl->fp_max = fopen(FS_BRIGHTNESS_MAX, "r");
+  if (bl->fp_max == NULL) {
+    NORM_ERR("Failed to open file: '" FS_BRIGHTNESS_MAX "'.");
+  }
+  bl->fp_current = fopen(FS_BRIGHTNESS_CURRENT, "r");
+  if (bl->fp_current == NULL) {
+    NORM_ERR("Failed to open file: '" FS_BRIGHTNESS_CURRENT "'.");
+  }
+}
+
+void read_backlight(struct backlight *bl) {
+  FILE *fp_max, *fp_current;
+  fp_max = bl->fp_max;
+  if (fp_max != NULL) {
+    rewind(fp_max);
+    fflush(fp_max);
+    if (fscanf(fp_max, "%u", &(bl->max)) < 0) {
+      NORM_ERR("Failed to read maximum brightness.");
+    }
+  } else {
+    bl->max = 0;
+  }
+  fp_current = bl->fp_current;
+  if (fp_current != NULL) {
+    rewind(fp_current);
+    fflush(fp_current);
+    if (fscanf(fp_current, "%u", &(bl->current)) < 0) {
+      NORM_ERR("Failed to read current brightness.");
+    }
+  } else {
+    bl->current = 0;
+  }
+}
+
+unsigned get_backlight_percent(struct backlight *bl) {
+  read_backlight(bl);
+  if (bl->max == 0) {
+    return 0;
+  } else {
+    return bl->current * 100.0 / bl->max + 0.5;
+  }
+}
+
+void close_backlight(struct backlight *bl) {
+  if (bl->fp_max != NULL) { fclose(bl->fp_max); }
+  if (bl->fp_current != NULL) { fclose(bl->fp_current); }
+}
+
+void init_intel_backlight(struct text_object *obj) {
+  struct backlight *bl = (struct backlight *)malloc(sizeof(struct backlight));
+  open_backlight(bl);
+  obj->data.opaque = bl;
+}
+
+void free_intel_backlight(struct text_object *obj) {
+  struct backlight *bl = (struct backlight *)obj->data.opaque;
+  close_backlight(bl);
+  free(bl);
+}
+
+void print_intel_backlight(struct text_object *obj, char *p,
+                           unsigned int p_max_size) {
+  struct backlight *bl = (struct backlight *)obj->data.opaque;
+  unsigned percent = get_backlight_percent(bl);
+  snprintf(p, p_max_size, "%d", percent);
+}

--- a/src/intel_backlight.h
+++ b/src/intel_backlight.h
@@ -1,0 +1,39 @@
+/*
+ *
+ * Conky, a system monitor, based on torsmo.
+ *
+ * Any original torsmo code is licensed under the BSD license.
+ * All code written since the fork of torsmo is licensed under the GPL.
+ * Please see COPYING for details.
+ *
+ * Copyright (c) 2021 Rogier Reerink
+ *  (See AUTHORS)
+ * All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef _INTEL_BACKLIGHT_H
+#define _INTEL_BACKLIGHT_H
+
+#include "conky.h"
+#include "text_object.h"
+
+void init_intel_backlight(struct text_object *obj);
+void free_intel_backlight(struct text_object *obj);
+void print_intel_backlight(struct text_object *obj, char *p,
+                           unsigned int p_max_size);
+
+#endif /* _INTEL_BACKLIGHT_H */


### PR DESCRIPTION
I added support for displaying Intel backlight information from sysfs. Such a function does not yet seem to exist in Conky and although it shouldn't be too difficult to write a Lua script for it, I think a native implementation is just a bit nicer. Unfortunately, it only works with Intel backlight because I don't know how other backlight drivers use sysfs.

As far as I can see this PR shouldn't affect other behaviour in Conky.

Steps that were taken to find errors:
1. I compiled and tested the code with and without valid sysfs paths to confirm that a failed `fopen` would be handled correctly.
2. I ran Intel backlight from 0 to _full_ to check that no zero-division was done and that the whole range was covered well.
3. I configured conky.conf with 0 to multiple instances of `intel_backlight` to check that either nothing would happen (in case of 0) or that each instance would open, read and close the backlight files well (using additional log messages, which I removed after confirmation.)

![Peek 2021-04-20 23-16](https://user-images.githubusercontent.com/15676084/115474151-2016c500-a23d-11eb-8ce8-c7052d229f74.gif)

This is my first commit here, so I hope that it's all in good shape. Please, let me know when I've missed something!
