### PR TITLE
Add a `legacyfree` variable for `free` compat.

### DIFF
--- a/doc/variables.xml
+++ b/doc/variables.xml
@@ -2314,6 +2314,15 @@
     <varlistentry>
         <term>
             <command>
+                <option>legacymem</option>
+            </command>
+        </term>
+        <listitem>Amount of memory used, calculated the same way as in the `free` program.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
                 <option>memgauge</option>
             </command>
             <option>(height),(width)</option>

--- a/src/common.cc
+++ b/src/common.cc
@@ -395,6 +395,7 @@ double cpu_barval(struct text_object *obj) {
 PRINT_HR_GENERATOR(mem)
 PRINT_HR_GENERATOR(memwithbuffers)
 PRINT_HR_GENERATOR(memeasyfree)
+PRINT_HR_GENERATOR(legacymem)
 PRINT_HR_GENERATOR(memfree)
 PRINT_HR_GENERATOR(memmax)
 PRINT_HR_GENERATOR(memdirty)

--- a/src/common.h
+++ b/src/common.h
@@ -105,6 +105,7 @@ double cpu_barval(struct text_object *);
 void print_mem(struct text_object *, char *, unsigned int);
 void print_memwithbuffers(struct text_object *, char *, unsigned int);
 void print_memeasyfree(struct text_object *, char *, unsigned int);
+void print_legacymem(struct text_object *, char *, unsigned int);
 void print_memfree(struct text_object *, char *, unsigned int);
 void print_memmax(struct text_object *, char *, unsigned int);
 void print_memdirty(struct text_object *, char *, unsigned int);

--- a/src/conky.h
+++ b/src/conky.h
@@ -166,7 +166,7 @@ struct information {
 
   /* memory information in kilobytes */
   unsigned long long mem, memwithbuffers, memeasyfree, memfree, memmax,
-      memdirty;
+      memdirty, legacymem;
   unsigned long long swap, swapfree, swapmax;
   unsigned long long bufmem, buffers, cached;
 

--- a/src/core.cc
+++ b/src/core.cc
@@ -1169,6 +1169,9 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ(mem, &update_meminfo) obj->data.s = STRNDUP_ARG;
   obj->callbacks.print = &print_mem;
   obj->callbacks.free = &gen_free_opaque;
+  END OBJ(legacymem, &update_meminfo) obj->data.s = STRNDUP_ARG;
+  obj->callbacks.print = &print_legacymem;
+  obj->callbacks.free = &gen_free_opaque;
   END OBJ(memwithbuffers, &update_meminfo) obj->data.s = STRNDUP_ARG;
   obj->callbacks.print = &print_memwithbuffers;
   obj->callbacks.free = &gen_free_opaque;

--- a/src/dragonfly.cc
+++ b/src/dragonfly.cc
@@ -153,6 +153,7 @@ int update_meminfo(void) {
   info.memmax = total_pages * (pagesize >> 10);
   info.mem = (total_pages - free_pages - inactive_pages) * (pagesize >> 10);
   info.memeasyfree = info.memfree = info.memmax - info.mem;
+  info.legacymem = info.mem;
 
   if ((swapmode(&swap_avail, &swap_free)) >= 0) {
     info.swapmax = swap_avail;

--- a/src/freebsd.cc
+++ b/src/freebsd.cc
@@ -170,6 +170,7 @@ int update_meminfo(void) {
   info.mem = (total_pages - free_pages - inactive_pages) * (pagesize >> 10);
   info.memwithbuffers = info.mem;
   info.memeasyfree = info.memfree = info.memmax - info.mem;
+  info.legacymem = info.mem;
 
   if ((swapmode(&swap_avail, &swap_free)) >= 0) {
     info.swapmax = swap_avail;

--- a/src/haiku.cc
+++ b/src/haiku.cc
@@ -62,6 +62,7 @@ int update_meminfo() {
   // TODO: we have some more info...
   info.memwithbuffers = info.mem;
   info.memeasyfree = info.memfree = info.memmax - info.mem;
+  info.legacymem = info.mem;
 
   info.swapmax = si.max_swap_pages * (B_PAGE_SIZE >> 10);
   info.swapfree = si.free_swap_pages * (B_PAGE_SIZE >> 10);

--- a/src/linux.cc
+++ b/src/linux.cc
@@ -191,7 +191,7 @@ int update_meminfo(void) {
 
   info.memmax = info.memdirty = info.swap = info.swapfree = info.swapmax =
       info.memwithbuffers = info.buffers = info.cached = info.memfree =
-          info.memeasyfree = 0;
+          info.memeasyfree = info.legacymem = 0;
 
   if (!(meminfo_fp = open_file("/proc/meminfo", &reported))) { return 0; }
 
@@ -258,6 +258,8 @@ int update_meminfo(void) {
   info.mem = curmem;
   info.bufmem = curbufmem;
   info.memeasyfree = cureasyfree;
+  info.legacymem =
+      info.memmax - (info.memfree + info.buffers + info.cached + sreclaimable);
 
   fclose(meminfo_fp);
   return 0;

--- a/src/netbsd.cc
+++ b/src/netbsd.cc
@@ -127,6 +127,7 @@ void update_meminfo() {
   info.mem = ((total_pages - free_pages - inactive_pages) * pagesize) >> 10;
   info.memwithbuffers = info.mem;
   info.memeasyfree = info.memfree = info.memmax - info.mem;
+  info.legacymem = info.mem;
 
   if (swapmode(&swap_avail, &swap_free) >= 0) {
     info.swapmax = swap_avail;

--- a/src/openbsd.cc
+++ b/src/openbsd.cc
@@ -174,6 +174,7 @@ void update_meminfo() {
   info.memmax = pagetok(vmtotal.t_rm) + pagetok(vmtotal.t_free);
   info.mem = info.memwithbuffers = pagetok(vmtotal.t_rm);
   info.memeasyfree = info.memfree = info.memmax - info.mem;
+  info.legacymem = info.mem;
 
   if ((swapmode(&swap_used, &swap_avail)) >= 0) {
     info.swapmax = swap_avail;


### PR DESCRIPTION
It seems there is some confusion between the way Conky reports free
memory, versus other programs. I'm adding a new variable, `legacyfree`,
to provide the same value that is reported on older programs that don't
report memory the way recommended by newer kernels.

For more details, see:
 * https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773
 * https://github.com/brndnmtthws/conky/pull/859
 * https://github.com/brndnmtthws/conky/pull/1028
 * https://github.com/brndnmtthws/conky/issues/1090

This resolves #1090.