### PR TITLE
Fixes #1068 : Added custom uninstall target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,3 +104,14 @@ if(CHECK_CODE_QUALITY)
   find_package(ClangTidy)
   find_package(ClangFormat)
 endif(CHECK_CODE_QUALITY)
+
+# uninstall target
+if(NOT TARGET uninstall)
+  configure_file(
+      "${CMAKE_MODULE_PATH}/UninstallConky.cmake.in"
+    "${CMAKE_BINARY_DIR}/cmake_uninstall.cmake"
+    IMMEDIATE @ONLY)
+
+  add_custom_target(uninstall
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_BINARY_DIR}/cmake_uninstall.cmake)
+endif()

--- a/cmake/UninstallConky.cmake.in
+++ b/cmake/UninstallConky.cmake.in
@@ -1,3 +1,23 @@
+#
+# Conky, a system monitor, based on torsmo
+#
+# Please see COPYING for details
+#
+# Copyright (c) 2005-2021 Brenden Matthews, et. al. (see AUTHORS) All rights
+# reserved.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
 if(NOT EXISTS ${CMAKE_BINARY_DIR}/install_manifest.txt)
   message(FATAL_ERROR "Cannot find install manifest: ${CMAKE_BINARY_DIR}/install_manifest.txt")
 endif()

--- a/cmake/UninstallConky.cmake.in
+++ b/cmake/UninstallConky.cmake.in
@@ -1,0 +1,21 @@
+if(NOT EXISTS ${CMAKE_BINARY_DIR}/install_manifest.txt)
+  message(FATAL_ERROR "Cannot find install manifest: ${CMAKE_BINARY_DIR}/install_manifest.txt")
+endif()
+
+file(READ "${CMAKE_BINARY_DIR}/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      ${CMAKE_COMMAND} ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif()
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif()
+endforeach()


### PR DESCRIPTION
* Added an uninstall target as directed by the [CMake FAQ](https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#can-i-do-make-uninstall-with-cmake) by copying UninstallConky.cmake.in as cmake_uninstall.cmake and running cmake_uninstall.cmake as a script when target is invoked.
* Change validation - 
![image](https://user-images.githubusercontent.com/10692792/118417997-83fea300-b6ae-11eb-9586-6bb98d61be52.png)
 