### PR TITLE
make `gw_iface` work with net stat

### DIFF
--- a/src/net_stat.cc
+++ b/src/net_stat.cc
@@ -134,6 +134,9 @@ void parse_net_stat_arg(struct text_object *obj, const char *arg,
   if (arg == nullptr) { arg = DEFAULTNETDEV; }
 
   if (0 == (strcmp("$gw_iface", arg)) || 0 == (strcmp("${gw_iface}", arg))) {
+#if defined(__linux__)
+    update_gateway_info();
+#endif
     arg = e_iface;
   }
 

--- a/src/net_stat.cc
+++ b/src/net_stat.cc
@@ -335,6 +335,14 @@ void parse_net_stat_graph_arg(struct text_object *obj, const char *arg,
 
   // default to DEFAULTNETDEV
   if (buf != nullptr) {
+#if defined(__linux__)
+    if (0 == (strcmp("$gw_iface", buf)) || 0 == (strcmp("${gw_iface}", buf))) {
+      update_gateway_info();
+      obj->data.opaque = get_net_stat(e_iface, obj, free_at_crash);
+      free(buf);
+      return;
+    }
+#endif
     obj->data.opaque = get_net_stat(buf, obj, free_at_crash);
     free(buf);
     return;


### PR DESCRIPTION
**Descriptions**

Currently `gw_iface` doesn't work with the network speed (unless it's in a Lua function like `${lua rjust ${downspeed ${gw_iface}} 8}`), and doesn't wok not the network graph.

```
conky.text = [[
${gw_iface}\
${downspeed ${gw_iface}}\
${upspeed ${gw_iface}}
${downspeedgraph ${gw_iface} 60,230 7500000}${alignr}\
${upspeedgraph ${gw_iface} 60,230 3000000}
]]
```

This change lets it work with both:

The `downspeed` portion of the code appears to check for this, but it's buggy as it doesn't run `update_gateway_info()`.

![Screenshot_2021-05-17_20-08-10](https://user-images.githubusercontent.com/2058940/118471948-aa265080-b74b-11eb-8080-143251dea8ac.png)

I'm not sure why this broke, as I remember it did work once. This could be related to [Partially revert change from c352069b31b2dbb4d. · brndnmtthws/conky@da2ddb0](https://github.com/brndnmtthws/conky/commit/da2ddb00ed05a772003f4d4ae5fc1156099dc66f), I'm not sure.
