### PR TITLE
fix typo in in lua_parse description

### DIFF
--- a/doc/variables.xml
+++ b/doc/variables.xml
@@ -2133,7 +2133,7 @@
         <listitem>Executes a Lua function with given parameters, then prints
         the returned string. See also 'lua_load' on how to load scripts. Conky
         puts 'conky_' in front of function_name to prevent accidental calls to
-        the wrong function unless you put you place 'conky_' in front of it
+        the wrong function unless you place 'conky_' in front of it
         yourself.
         <para /></listitem>
     </varlistentry>
@@ -2149,7 +2149,7 @@
         bar. Expects result value to be an integer between 0 and 100. See also
         'lua_load' on how to load scripts. Conky puts 'conky_' in front of
         function_name to prevent accidental calls to the wrong function unless
-        you put you place 'conky_' in front of it yourself.
+        you place 'conky_' in front of it yourself.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2164,7 +2164,7 @@
         gauge. Expects result value to be an integer between 0 and 100. See
         also 'lua_load' on how to load scripts. Conky puts 'conky_' in front
         of function_name to prevent accidental calls to the wrong function
-        unless you put you place 'conky_' in front of it yourself.
+        unless you place 'conky_' in front of it yourself.
         <para /></listitem>
     </varlistentry>
     <varlistentry>
@@ -2196,7 +2196,7 @@
         then parses and prints the result value as per the syntax for the
         conky.text section. See also 'lua_load' on how to load scripts. Conky
         puts 'conky_' in front of function_name to prevent accidental calls to
-        the wrong function unless you put you place 'conky_' in front of it
+        the wrong function unless you place 'conky_' in front of it
         yourself.
         <para /></listitem>
     </varlistentry>


### PR DESCRIPTION
**Descriptions**
* `s/you put (you place 'conky_' in front of it)/\1/`
* just string in all four occurrences changed, no code changes