### PR TITLE
Correct dependencies on generated header files

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -30,8 +30,7 @@ if(BUILD_BUILTIN_CONFIG)
                              ${CMAKE_CURRENT_SOURCE_DIR}/${builtin_config}
                              defconfig.h defconfig
                      DEPENDS ${builtin_config})
-  add_custom_target(defconfig ALL DEPENDS defconfig.h)
-  set_source_files_properties(defconfig.h PROPERTIES GENERATED TRUE)
+  set(generated_hdr_files ${generated_hdr_files} defconfig.h)
 endif(BUILD_BUILTIN_CONFIG)
 
 if(BUILD_OLD_CONFIG)
@@ -40,6 +39,7 @@ if(BUILD_OLD_CONFIG)
                              ${CMAKE_SOURCE_DIR}/extras/convert.lua
                              convertconf.h convertconf
                      DEPENDS ${CMAKE_SOURCE_DIR}/extras/convert.lua)
-  add_custom_target(convertconf ALL DEPENDS convertconf.h)
-  set_source_files_properties(convertconf.h PROPERTIES GENERATED TRUE)
+  set(generated_hdr_files ${generated_hdr_files} convertconf.h)
 endif(BUILD_OLD_CONFIG)
+
+add_custom_target(generated_hdr_files DEPENDS ${generated_hdr_files})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -295,8 +295,10 @@ endif(BUILD_HSV_GRADIENT)
 if(BUILD_TESTS)
   # Create a library strictly for testing
   add_library(conky_core ${conky_sources} ${optional_sources})
+  add_dependencies(conky_core generated_hdr_files)
   target_link_libraries(conky_core ${conky_libs})
   add_executable(conky main.cc)
+  add_dependencies(conky generated_hdr_files)
   target_link_libraries(conky conky_core ${conky_libs})
   install(TARGETS conky_core
           RUNTIME DESTINATION bin
@@ -304,6 +306,7 @@ if(BUILD_TESTS)
           ARCHIVE DESTINATION ${LIB_INSTALL_DIR})
 else()
   add_executable(conky main.cc ${conky_sources} ${optional_sources})
+  add_dependencies(conky generated_hdr_files)
   target_link_libraries(conky ${conky_libs})
 endif()
 


### PR DESCRIPTION
This change corrects dependencies on generated defconfig.h and/or
convertconf.h header files because they must be generated before
compilation of conky.cc and main.cc if BUILD_BUILTIN_CONFIG and/or
BUILD_OLD_CONFIG are set.

Fixes: https://github.com/brndnmtthws/conky/issues/1118