### PR TITLE
docs.xml: document SIGUSR2

### DIFF
--- a/doc/docs.xml
+++ b/doc/docs.xml
@@ -130,6 +130,7 @@
         <filename>~/.config/conky/conky.conf</filename>: "killall -SIGUSR1
         conky". Saves you the trouble of having to kill and then
         restart.</para>
+        <para>An easy way to force Conky to update: "killall -SIGUSR2 conky".</para>
     </refsect1>
     <refsect1>
     <title>Options</title>


### PR DESCRIPTION
This was completely undocumented so I had to find this feature via testing first. It is necessary for the clocks (in example a status bar and conky) on a pinephone to be in sync after waking up.

This change does not affect the behaviour of conky, just add information about SIGUSR2.
I have tested it by running conky through the terminal, when receiving SIGUSR2 conky notifies the user of this change through stdout.

http://0x0.st/-4ft.png

No new files have been added.