### PR TITLE
Fix diskio graph scale being 3 orders of magnitude too small

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1571,6 +1571,9 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
             }
 #ifdef BUILD_MATH
             if (show_graph_scale.get(*state) && (current->show_scale == 1)) {
+              if (current->scale_colour != 0) {
+                set_foreground_color(current->scale_colour);
+              }
               int tmp_x = cur_x;
               int tmp_y = cur_y;
               cur_x += font_ascent() / 2;

--- a/src/diskio.cc
+++ b/src/diskio.cc
@@ -153,7 +153,7 @@ static void print_diskio_dir(struct text_object *obj, int dir, char *p,
 
   /* TODO: move this correction from kB to kB/s elsewhere
    * (or get rid of it??) */
-  human_readable((val / active_update_interval()) * 1024LL, p, p_max_size);
+  human_readable(val / active_update_interval(), p, p_max_size);
 }
 
 void print_diskio(struct text_object *obj, char *p, unsigned int p_max_size) {
@@ -219,9 +219,9 @@ void update_diskio_values(struct diskio_stat *ds, unsigned int reads,
   /* compute averages */
   int samples = diskio_avg_samples.get(*state);
   for (i = 0; i < samples; i++) {
-    sum += ds->sample[i];
-    sum_r += ds->sample_read[i];
-    sum_w += ds->sample_write[i];
+    sum += ds->sample[i] * 1024LL;
+    sum_r += ds->sample_read[i] * 1024LL;
+    sum_w += ds->sample_write[i] * 1024LL;
   }
   ds->current = sum / static_cast<double>(samples);
   ds->current_read = sum_r / static_cast<double>(samples);

--- a/src/specials.cc
+++ b/src/specials.cc
@@ -97,7 +97,7 @@ struct graph {
   int id;
   char flags;
   int width, height;
-  unsigned int first_colour, last_colour;
+  unsigned int first_colour, last_colour, scale_colour;
   double scale;
   char tempgrad;
 };
@@ -402,6 +402,7 @@ char *scan_graph(struct text_object *obj, const char *args, double defscale) {
   g->height = default_graph_height.get(*state);
   g->first_colour = 0;
   g->last_colour = 0;
+  g->scale_colour = 0;
   g->scale = defscale;
   g->tempgrad = FALSE;
   if (args != nullptr) {
@@ -464,6 +465,7 @@ char *scan_graph(struct text_object *obj, const char *args, double defscale) {
     store_option_value<double *> (&g->scale, "%lf", no_quote_args, "--scale");
     store_option_value<unsigned int *> (&g->first_colour, "%x", no_quote_args, "--first_colour");
     store_option_value<unsigned int *> (&g->last_colour, "%x", no_quote_args, "--last_colour");
+    store_option_value<unsigned int *> (&g->scale_colour, "%x", no_quote_args, "--scale_colour");
 
     return ptr;
   }
@@ -712,6 +714,7 @@ void new_graph(struct text_object *obj, char *buf, int buf_max_size,
   s->height = xft_dpi_scale(g->height);
   s->first_colour = adjust_colours(g->first_colour);
   s->last_colour = adjust_colours(g->last_colour);
+  s->scale_colour = adjust_colours(g->scale_colour);
   if (g->scale != 0) {
     s->scaled = 0;
     s->scale = g->scale;

--- a/src/specials.h
+++ b/src/specials.h
@@ -84,6 +84,10 @@ extern int special_count;
  * text_object.h */
 struct text_object;
 
+char *store_positional_args(struct graph *, char *, char *, double);
+void get_option_value(char **, size_t, char *, const char *);
+template<typename T>
+void store_option_value(T, const char *, char *, const char *);
 /* scanning special arguments */
 const char *scan_bar(struct text_object *, const char *, double);
 const char *scan_gauge(struct text_object *, const char *, double);

--- a/src/specials.h
+++ b/src/specials.h
@@ -71,6 +71,7 @@ struct special_t {
   int scale_log;
   unsigned long first_colour;  // for graph gradient
   unsigned long last_colour;
+  unsigned long scale_colour;  // colour of the value showing the scale
   short font_added;
   char tempgrad;
   struct special_t *next;


### PR DESCRIPTION
The scale shown in diskiograph with `show_graph_scale = true` was 3 orders of magnitude too small (it shows "B" instead of "KiB" etc)

Before:
![diskio_error](https://user-images.githubusercontent.com/67431858/135904874-429ef25e-b919-4d9c-aaee-5779871e134b.png)

After:
![diskio_correct](https://user-images.githubusercontent.com/67431858/135904911-3b9395fa-3ae1-4398-b451-49ca11c58cf4.png)
