### PR TITLE
Add basic pulseaudio source (microphone etc.) support

### DIFF
--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -951,6 +951,15 @@ values:
     desc: |-
       If Pulseaudio's default sink is muted, display everything
       between $if_pa_sink_muted and the corresponding $else or $endif.
+  - name: if_pa_source_running
+    desc: |-
+      If Pulseaudio's default source is running (e.g. a program is accessing
+      your microphone), display everything between $if_pa_source_running and
+      the corresponding $else or $endif.
+  - name: if_pa_source_muted
+    desc: |-
+      If Pulseaudio's default source (e.g. your microphone) is muted, display
+      everything between $if_pa_source_muted and the corresponding $else or $endif.
   - name: if_running
     desc:
       "If PROCESS is running, display everything between\n$if_running and the corresponding\

--- a/src/core.cc
+++ b/src/core.cc
@@ -660,12 +660,8 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
                                                                      EQUAL) {
     obj->data.i = PB_BATT_STATUS;
   }
-  else if (strcmp(arg, "percent") == EQUAL) {
-    obj->data.i = PB_BATT_PERCENT;
-  }
-  else if (strcmp(arg, "time") == EQUAL) {
-    obj->data.i = PB_BATT_TIME;
-  }
+  else if (strcmp(arg, "percent") == EQUAL) { obj->data.i = PB_BATT_PERCENT; }
+  else if (strcmp(arg, "time") == EQUAL) { obj->data.i = PB_BATT_TIME; }
   else {
     NORM_ERR("pb_battery: illegal argument '%s', defaulting to status", arg);
     obj->data.i = PB_BATT_STATUS;
@@ -2013,7 +2009,8 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ(pa_card_name, 0) obj->callbacks.print = &print_puau_card_name;
   obj->callbacks.free = &free_pulseaudio;
   init_pulseaudio(obj);
-  END OBJ_IF(if_pa_source_running, 0) obj->callbacks.iftest = &puau_source_running;
+  END OBJ_IF(if_pa_source_running, 0) obj->callbacks.iftest =
+      &puau_source_running;
   obj->callbacks.free = &free_pulseaudio;
   init_pulseaudio(obj);
   END OBJ_IF(if_pa_source_muted, 0) obj->callbacks.iftest = &puau_source_muted;

--- a/src/core.cc
+++ b/src/core.cc
@@ -2013,6 +2013,12 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ(pa_card_name, 0) obj->callbacks.print = &print_puau_card_name;
   obj->callbacks.free = &free_pulseaudio;
   init_pulseaudio(obj);
+  END OBJ_IF(if_pa_source_running, 0) obj->callbacks.iftest = &puau_source_running;
+  obj->callbacks.free = &free_pulseaudio;
+  init_pulseaudio(obj);
+  END OBJ_IF(if_pa_source_muted, 0) obj->callbacks.iftest = &puau_source_muted;
+  obj->callbacks.free = &free_pulseaudio;
+  init_pulseaudio(obj);
 #endif /* BUILD_PULSEAUDIO */
 #ifdef BUILD_INTEL_BACKLIGHT
   END OBJ(intel_backlight, 0) obj->callbacks.print = &print_intel_backlight;

--- a/src/pulseaudio.cc
+++ b/src/pulseaudio.cc
@@ -49,6 +49,9 @@ const struct pulseaudio_default_results pulseaudio_result0 = {std::string(),
                                                               0,
                                                               0,
                                                               std::string(),
+                                                              PA_SOURCE_SUSPENDED,
+                                                              0,
+                                                              std::string(),
                                                               std::string(),
                                                               0};
 pulseaudio_c *pulseaudio = nullptr;
@@ -77,12 +80,27 @@ void pa_sink_info_callback(pa_context *c, const pa_sink_info *i, int eol,
   ++eol;
 }
 
+
+void pa_source_info_callback(pa_context *c, const pa_source_info *i, int eol,
+                           void *data) {
+  if (i != nullptr && data) {
+    struct pulseaudio_default_results *pdr =
+        (struct pulseaudio_default_results *)data;
+    pdr->source_state = i->state;
+    pdr->source_mute = i->mute;
+    pa_threaded_mainloop_signal(pulseaudio->mainloop, 0);
+  }
+  (void)c;
+  ++eol;
+}
+
 void pa_server_info_callback(pa_context *c, const pa_server_info *i,
                              void *userdata) {
   if (i != nullptr) {
     struct pulseaudio_default_results *pdr =
         (struct pulseaudio_default_results *)userdata;
     pdr->sink_name.assign(i->default_sink_name);
+    pdr->source_name.assign(i->default_source_name);
     pa_threaded_mainloop_signal(pulseaudio->mainloop, 0);
   }
   (void)c;
@@ -163,6 +181,14 @@ void subscribe_cb(pa_context *c, pa_subscription_event_type_t t, uint32_t index,
       PULSEAUDIO_OP(pa_context_get_sink_info_by_name(
                         c, res->sink_name.c_str(), pa_sink_info_callback, res),
                     "pa_context_get_sink_info_by_name failed");
+    } break;
+
+    case PA_SUBSCRIPTION_EVENT_SOURCE: {
+      if (res->source_name.empty()) return;
+      pa_operation *op;
+      PULSEAUDIO_OP(pa_context_get_source_info_by_name(
+                        c, res->source_name.c_str(), pa_source_info_callback, res),
+                    "pa_context_get_source_info_by_name failed");
     } break;
 
     case PA_SUBSCRIPTION_EVENT_CARD:
@@ -252,6 +278,16 @@ void init_pulseaudio(struct text_object *obj) {
     return;
   }
 
+  if (pulseaudio->result.source_name.empty()) return;
+
+  PULSEAUDIO_WAIT(pa_context_get_source_info_by_name(
+      pulseaudio->context, pulseaudio->result.source_name.c_str(),
+      pa_source_info_callback, &pulseaudio->result));
+
+  if (pulseaudio->result.source_name.empty()) {
+    NORM_ERR("Incorrect pulseaudio source information.");
+    return;
+  }
   if (pulseaudio->result.sink_card != (uint32_t)-1)
     PULSEAUDIO_WAIT(pa_context_get_card_info_by_index(
         pulseaudio->context, pulseaudio->result.sink_card,
@@ -264,6 +300,7 @@ void init_pulseaudio(struct text_object *obj) {
   if (!(op = pa_context_subscribe(
             pulseaudio->context,
             (pa_subscription_mask_t)(PA_SUBSCRIPTION_MASK_SINK |
+                                     PA_SUBSCRIPTION_MASK_SOURCE |
                                      PA_SUBSCRIPTION_MASK_SERVER |
                                      PA_SUBSCRIPTION_MASK_CARD),
             nullptr, NULL))) {
@@ -311,6 +348,14 @@ uint8_t puau_vol(struct text_object *obj) {
 
 int puau_muted(struct text_object *obj) {
   return get_pulseaudio(obj).sink_mute;
+}
+
+int puau_source_running(struct text_object *obj) {
+  return get_pulseaudio(obj).source_state == PA_SOURCE_RUNNING;
+}
+
+int puau_source_muted(struct text_object *obj) {
+  return get_pulseaudio(obj).source_mute;
 }
 
 void print_puau_sink_description(struct text_object *obj, char *p,

--- a/src/pulseaudio.cc
+++ b/src/pulseaudio.cc
@@ -40,20 +40,21 @@
 
 struct pulseaudio_default_results get_result_copy();
 
-const struct pulseaudio_default_results pulseaudio_result0 = {std::string(),
-                                                              std::string(),
-                                                              std::string(),
-                                                              std::string(),
-                                                              0,
-                                                              0,
-                                                              0,
-                                                              0,
-                                                              std::string(),
-                                                              PA_SOURCE_SUSPENDED,
-                                                              0,
-                                                              std::string(),
-                                                              std::string(),
-                                                              0};
+const struct pulseaudio_default_results pulseaudio_result0 = {
+    std::string(),
+    std::string(),
+    std::string(),
+    std::string(),
+    0,
+    0,
+    0,
+    0,
+    std::string(),
+    PA_SOURCE_SUSPENDED,
+    0,
+    std::string(),
+    std::string(),
+    0};
 pulseaudio_c *pulseaudio = nullptr;
 
 void pa_sink_info_callback(pa_context *c, const pa_sink_info *i, int eol,
@@ -80,9 +81,8 @@ void pa_sink_info_callback(pa_context *c, const pa_sink_info *i, int eol,
   ++eol;
 }
 
-
 void pa_source_info_callback(pa_context *c, const pa_source_info *i, int eol,
-                           void *data) {
+                             void *data) {
   if (i != nullptr && data) {
     struct pulseaudio_default_results *pdr =
         (struct pulseaudio_default_results *)data;
@@ -186,9 +186,10 @@ void subscribe_cb(pa_context *c, pa_subscription_event_type_t t, uint32_t index,
     case PA_SUBSCRIPTION_EVENT_SOURCE: {
       if (res->source_name.empty()) return;
       pa_operation *op;
-      PULSEAUDIO_OP(pa_context_get_source_info_by_name(
-                        c, res->source_name.c_str(), pa_source_info_callback, res),
-                    "pa_context_get_source_info_by_name failed");
+      PULSEAUDIO_OP(
+          pa_context_get_source_info_by_name(c, res->source_name.c_str(),
+                                             pa_source_info_callback, res),
+          "pa_context_get_source_info_by_name failed");
     } break;
 
     case PA_SUBSCRIPTION_EVENT_CARD:

--- a/src/pulseaudio.h
+++ b/src/pulseaudio.h
@@ -31,6 +31,7 @@
 #define _PULSEAUDIO_H
 
 #include <pulse/pulseaudio.h>
+#include <string>
 #include "text_object.h"
 
 void init_pulseaudio(struct text_object *obj);
@@ -48,6 +49,8 @@ void print_puau_card_active_profile(struct text_object *obj, char *p,
                                     unsigned int p_max_size);
 double puau_volumebarval(struct text_object *obj);
 int puau_muted(struct text_object *obj);
+int puau_source_running(struct text_object *obj);
+int puau_source_muted(struct text_object *obj);
 
 struct pulseaudio_default_results {
   // default sink
@@ -59,6 +62,11 @@ struct pulseaudio_default_results {
   int sink_mute;
   uint32_t sink_index;
   unsigned int sink_volume;  // percentage
+
+  // default source
+  std::string source_name;
+  pa_source_state source_state;
+  int source_mute;
 
   // default card
   std::string card_active_profile_description;
@@ -87,7 +95,8 @@ class pulseaudio_c {
         cstate(PULSE_CONTEXT_INITIALIZING),
         ninits(0),
         result({std::string(), std::string(), std::string(), std::string(), 0,
-                0, 0, 0, std::string(), std::string(), 0}){};
+                0, 0, 0, std::string(), PA_SOURCE_SUSPENDED, 0, std::string(),
+                std::string(), 0}){};
 };
 
 #endif /* _PULSEAUDIO_H */

--- a/src/top.cc
+++ b/src/top.cc
@@ -99,9 +99,7 @@ static void unhash_all_processes() {
   }
 }
 
-struct process *get_first_process() {
-  return first_process;
-}
+struct process *get_first_process() { return first_process; }
 
 void free_all_processes() {
   struct process *next = nullptr, *pr = first_process;


### PR DESCRIPTION
This PR adds basic pulseaudio source support. The conky objects `if_pa_source_running` and `if_pa_source_muted` were added to query the status of the default pulse audio source.

I implemented this feature to display if an application is accessing my microphone and if it is currently muted or not:
running | muted | not running
----------|-----------|----------------
![running](https://user-images.githubusercontent.com/31921487/145483984-83b29719-cd6e-48ff-ad92-6afec7afc13e.png) | ![muted](https://user-images.githubusercontent.com/31921487/145484415-d0c82211-9c80-4575-bce8-3bfc3146e1e4.png) | ![idle](https://user-images.githubusercontent.com/31921487/145484268-5311c0cc-7985-4e84-8bd0-0767ec8693dd.png)


The added features can be tested using
```
conky -t 'microphone\
$if_pa_source_running\
$if_pa_source_muted muted\
$else running\
$endif\
$else not running$endif'
```
which will display the current source state accordingly.

Other features of conky remain unchanged, though some other code was reformatted when using `make clang-format`.