### PR TITLE
Adding graph option to invert y-axis

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -26,7 +26,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-
+#include <iostream> // REMOVE THIS
 #include "conky.h"
 #include <algorithm>
 #include <cerrno>
@@ -1505,13 +1505,21 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
                   }
                 }
                 /* this is mugfugly, but it works */
-                XDrawLine(display, window.drawable, window.gc,
-                          text_offset_x + cur_x + i + 1, text_offset_y + by + h,
-                          text_offset_x + cur_x + i + 1,
-                          text_offset_y + round_to_positive_int(
+                
+                int x1 = text_offset_x + cur_x + i + 1;
+                int y1 = text_offset_y + by + (current->invy?0:h);
+                int x2 = x1;
+                int y2 = text_offset_y + round_to_positive_int(
                                               static_cast<double>(by) + h -
                                               current->graph[j] * (h - 1) /
-                                                  current->scale));
+                                                  current->scale);
+                if(current->invy){
+                  y2 = text_offset_y + round_to_positive_int(
+                                              static_cast<double>(by) + 
+                                              current->graph[j] * (h - 1) /
+                                                  current->scale);
+                }
+                XDrawLine(display, window.drawable, window.gc, x1, y1, x2, y2);
                 ++j;
               }
             }

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -26,7 +26,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include <iostream> // REMOVE THIS
 #include "conky.h"
 #include <algorithm>
 #include <cerrno>

--- a/src/specials.cc
+++ b/src/specials.cc
@@ -100,6 +100,7 @@ struct graph {
   unsigned int first_colour, last_colour;
   double scale;
   char tempgrad;
+  char invy;
 };
 
 struct stippled_hr {
@@ -215,6 +216,7 @@ char *scan_graph(struct text_object *obj, const char *args, double defscale) {
   g->last_colour = 0;
   g->scale = defscale;
   g->tempgrad = FALSE;
+  g->invy = FALSE;
   if (args != nullptr) {
     /* extract double-quoted command in case of execgraph */
     if (*args == '"') {
@@ -252,6 +254,12 @@ char *scan_graph(struct text_object *obj, const char *args, double defscale) {
       g->flags |= SF_SHOWLOG;
     }
 
+     /* set invert-y-axis-flag, if '-y' specified
+     * It doesn#t matter where the argument is exactly. */
+    if ((strstr(argstr, " " INVY) != nullptr) ||
+        strncmp(argstr, INVY, strlen(INVY)) == 0) {
+      g->invy = TRUE;
+    }
     /* all the following functions try to interpret the beginning of a
      * a string with different formaters. If successfully the return from
      * this whole function */
@@ -589,6 +597,7 @@ void new_graph(struct text_object *obj, char *buf, int buf_max_size,
     s->show_scale = 1;
   }
   s->tempgrad = g->tempgrad;
+  s->invy = g->invy;
 #ifdef BUILD_MATH
   if ((g->flags & SF_SHOWLOG) != 0) {
     s->scale_log = 1;

--- a/src/specials.h
+++ b/src/specials.h
@@ -36,6 +36,7 @@
 // don't use spaces in LOGGRAPH or NORMGRAPH if you change them
 #define LOGGRAPH "-l"
 #define TEMPGRAD "-t"
+#define INVY "-y"
 
 enum special_types {
   NONSPECIAL = 0,
@@ -73,6 +74,7 @@ struct special_t {
   unsigned long last_colour;
   short font_added;
   char tempgrad;
+  char invy;
   struct special_t *next;
 };
 


### PR DESCRIPTION
This PR adds a new flag to the graph to invert the y-axis, i.e., the bars will go form top-to-bottom.
This feature will enable for instance the creation of read/write or up/download "stacked graphs", with upload being in the normal direction and the download in the inverted direction (see image).

The "inverted" option can be enabled by passing `-y` to the graph arguments, similar to `-t` and `-l`

Example configuration:
```
... 
${upspeedgraph wl0 40,300 FFFFFFF 77B753  -t}
${downspeedgraph wl0 40,300 FFFFFFF 77B753  -l -y}
...
```
![conky_inverted_graph](https://user-images.githubusercontent.com/1397824/146239613-24d2300a-f6c1-455b-a3ad-e24355d485be.png)

