### PR TITLE
Octoprint

### DIFF
--- a/cmake/ConkyBuildOptions.cmake
+++ b/cmake/ConkyBuildOptions.cmake
@@ -232,13 +232,6 @@ option(BUILD_XMMS2 "Enable if you want XMMS2 (music player) support" false)
 option(BUILD_CURL "Enable if you want Curl support" false)
 
 option(BUILD_OCTOPRINT "Enable if you want Octoprint support" false)
-if (BUILD_OCTOPRINT)
-  option(OCTOPRINT_MULTIPRINTER 
-    "Enable support of multiple Octoprint servers" true)
-else (BUILD_OCTOPRINT)
-  set(OCTOPRINT_MULTIPRINTER false CACHE BOOL
-      "Enable support of multiple Octoprint servers" FORCE)
-endif(BUILD_OCTOPRINT)
 
 option(BUILD_RSS "Enable if you want RSS support" false)
 

--- a/cmake/ConkyBuildOptions.cmake
+++ b/cmake/ConkyBuildOptions.cmake
@@ -231,12 +231,21 @@ option(BUILD_XMMS2 "Enable if you want XMMS2 (music player) support" false)
 
 option(BUILD_CURL "Enable if you want Curl support" false)
 
+option(BUILD_OCTOPRINT "Enable if you want Octoprint support" false)
+if (BUILD_OCTOPRINT)
+  option(OCTOPRINT_MULTIPRINTER 
+    "Enable support of multiple Octoprint servers" true)
+else (BUILD_OCTOPRINT)
+  set(OCTOPRINT_MULTIPRINTER false CACHE BOOL
+      "Enable support of multiple Octoprint servers" FORCE)
+endif(BUILD_OCTOPRINT)
+
 option(BUILD_RSS "Enable if you want RSS support" false)
 
 option(BUILD_WEATHER_METAR "Enable METAR weather support" true)
-if(BUILD_WEATHER_METAR OR BUILD_RSS)
+if(BUILD_WEATHER_METAR OR BUILD_RSS OR BUILD_OCTOPRINT)
   set(BUILD_CURL true)
-endif(BUILD_WEATHER_METAR OR BUILD_RSS)
+endif(BUILD_WEATHER_METAR OR BUILD_RSS OR BUILD_OCTOPRINT)
 
 option(BUILD_APCUPSD "Enable APCUPSD support" true)
 

--- a/cmake/ConkyPlatformChecks.cmake
+++ b/cmake/ConkyPlatformChecks.cmake
@@ -378,7 +378,11 @@ pkg_search_module(LUA
                   lua53
                   lua5.2
                   lua-5.2
-                  lua52)
+                  lua52
+                  lua5.1
+                  lua-5.1
+                  lua51
+)
 set(conky_libs ${conky_libs} ${LUA_LIBRARIES})
 set(conky_includes ${conky_includes} ${LUA_INCLUDE_DIRS})
 link_directories(${LUA_LIBRARY_DIRS})

--- a/cmake/ConkyPlatformChecks.cmake
+++ b/cmake/ConkyPlatformChecks.cmake
@@ -436,6 +436,11 @@ if(BUILD_CURL)
   set(WANT_CURL true)
 endif(BUILD_CURL)
 
+if(BUILD_OCTOPRINT)
+  set(WANT_CURL true) #technically fulfilled by the curl threads dependency, but we do make direct library calls
+  set(WANT_JSON true)
+endif(BUILD_OCTOPRINT)
+
 if(BUILD_RSS)
   set(WANT_CURL true)
   set(WANT_LIBXML2 true)
@@ -488,6 +493,12 @@ if(WANT_CURL)
   set(conky_libs ${conky_libs} ${CURL_LIBRARIES})
   set(conky_includes ${conky_includes} ${CURL_INCLUDE_DIRS})
 endif(WANT_CURL)
+
+if(WANT_JSON)
+  pkg_check_modules(JSONCPP REQUIRED jsoncpp)
+  set(conky_libs ${conky_libs} ${JSONCPP_LIBRARIES})
+  set(conky_includes ${conky_includes} ${JSONCPP_INCLUDE_DIRS})
+endif(WANT_JSON)
 
 if(WANT_LIBXML2)
   include(FindLibXml2)

--- a/cmake/UninstallConky.cmake.in
+++ b/cmake/UninstallConky.cmake.in
@@ -1,3 +1,23 @@
+#
+# Conky, a system monitor, based on torsmo
+#
+# Please see COPYING for details
+#
+# Copyright (c) 2005-2021 Brenden Matthews, et. al. (see AUTHORS) All rights
+# reserved.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
 if(NOT EXISTS ${CMAKE_BINARY_DIR}/install_manifest.txt)
   message(FATAL_ERROR "Cannot find install manifest: ${CMAKE_BINARY_DIR}/install_manifest.txt")
 endif()

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -80,6 +80,10 @@
 
 #cmakedefine BUILD_CURL 1
 
+#cmakedefine BUILD_OCTOPRINT 1
+
+#cmakedefine OCTOPRINT_MULTIPRINTER 1
+
 #cmakedefine BUILD_WEATHER_METAR 1
 
 #cmakedefine BUILD_IMLIB2 1

--- a/doc/config_settings.xml
+++ b/doc/config_settings.xml
@@ -712,6 +712,58 @@
     <varlistentry>
         <term>
             <command>
+                <option>octoprint_apikey</option>
+            </command>
+        </term>
+        <listitem>The api key for the default octoprint server. It is suggested
+        to use an application key specific to your conky instance. 
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_config</option>
+            </command>
+        </term>
+        <listitem><para>A string which can be parsed as JSON to set parameters 
+        for multiple servers. The top level value must be a JSON Object. The 
+        keys in this Object may be used by all $octoprint_* variables as the 
+        printer_id. The value associated with each printer_id key must also be 
+        a JSON Object. This inner Object requires keys "url" and "apikey". The 
+        optional key "interval" may also be provided to set the server-specific 
+        data query rate.</para>
+        <para><emphasis>WARNING: THE INTERNAL JSON READER IS UNFORGIVING.
+        </emphasis> To make your life easier, it is suggested that you validate 
+        your json before adding it to the conky config. You may also use 
+        pretty-print JSON by enclosing the multi-line JSON block in the lua
+        multi-line string indicator: [[ multi-line config ]].</para>
+        </listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_server</option>
+            </command>
+        </term>
+        <listitem>The url for the default octoprint server. Example: 
+        'http://my_octoprint_server:5000'
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_update_interval</option>
+            </command>
+        </term>
+        <listitem>The default interval at which to query any octoprint server
+        for new data. Defaults to 1 second if not specified. May be overridden
+        on a per-server basis in the octoprint_config setting.
+        <para /></listitem>
+    </varlistentry>
+
+    <varlistentry>
+        <term>
+            <command>
                 <option>out_to_console</option>
             </command>
         </term>

--- a/doc/variables.xml
+++ b/doc/variables.xml
@@ -3063,6 +3063,461 @@
     <varlistentry>
         <term>
             <command>
+                <option>octoprint_conn_baud</option>
+            </command>
+            <option>(server_id)</option>
+        </term>
+        <listitem>Baud rate of the printer connection. 
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_conn_port</option>
+            </command>
+            <option>(server_id)</option>
+        </term>
+        <listitem>Serial port of the printer connection. 
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_conn_state</option>
+            </command>
+            <option>(server_id)</option>
+        </term>
+        <listitem>State of the printer connection. 
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_job_name</option>
+            </command>
+            <option>(server_id)</option>
+        </term>
+        <listitem>Name of the current print job. 
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_job_progress</option>
+            </command>
+            <option>(server_id)</option>
+        </term>
+        <listitem>Progress of the current print job. 
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_job_progress_bar</option>
+            </command>
+            <option>(height)(,width)</option>
+            <option>(server_id)</option>
+        </term>
+        <listitem>Progress of the current print job. 
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_job_progress_pct</option>
+            </command>
+            <option>(server_id)</option>
+        </term>
+        <listitem>Percentage progress of the current print job as integer. 
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_job_state</option>
+            </command>
+            <option>(server_id)</option>
+        </term>
+        <listitem>State of the current print job. 
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_job_time</option>
+            </command>
+            <option>(server_id)</option>
+        </term>
+        <listitem>Time in seconds spent on the current print job. 
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_job_time_left</option>
+            </command>
+            <option>(server_id)</option>
+        </term>
+        <listitem>Estimated time left in seconds for the current print job. 
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_job_user</option>
+            </command>
+            <option>(server_id)</option>
+        </term>
+        <listitem>User who owns the current print job. 
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_local_filecount</option>
+            </command>
+            <option>(server_id)</option>
+        </term>
+        <listitem>Number of local printable files stored on the server. 
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_local_free</option>
+            </command>
+            <option>(server_id)</option>
+        </term>
+        <listitem>Free space for printable files on the server. 
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_local_used</option>
+            </command>
+            <option>(server_id)</option>
+        </term>
+        <listitem>Space used by printable files on the server. 
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_logs_free</option>
+            </command>
+            <option>(server_id)</option>
+        </term>
+        <listitem>Free space for log files on the server. 
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_logs_used</option>
+            </command>
+            <option>(server_id)</option>
+        </term>
+        <listitem>Space used by log files on the server. 
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_longversion</option>
+            </command>
+            <option>(server_id)</option>
+        </term>
+        <listitem>Version string of the server. 
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_printer_error</option>
+            </command>
+            <option>(server_id)</option>
+        </term>
+        <listitem>Specific error state of the printer. 
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_printer_state</option>
+            </command>
+            <option>(server_id)</option>
+        </term>
+        <listitem>Overall state of the printer. 
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used.
+        <para /></listitem>
+    </varlistentry>
+     <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_safemode</option>
+            </command>
+            <option>(server_id)</option>
+        </term>
+        <listitem>Reason why server is running in safemode. 
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_sdcard_filecount</option>
+            </command>
+            <option>(server_id)</option>
+        </term>
+        <listitem>Number files stored on the printer's sd card. 
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_sdcard_ready</option>
+            </command>
+            <option>(server_id)</option>
+        </term>
+        <listitem>Prints "true" if printer's sd card is ready, else "false".
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_temperature</option>
+            </command>
+            <option>(server_id:)component_id</option>
+        </term>
+        <listitem>Temperature of the specified component.
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used. Note the use of ":"
+        to separate the server_id from the component_id if the server_id
+        is provided. The component id must match "bed", "chamber", or
+        "toolN" where N is some integer. Tool numbers start from 0. Not all
+        printers will have all components.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_temperature_bar</option>
+            </command>
+            <option>(height)(,width)(:scale)</option>
+            <option>(server_id:)component_id</option>
+        </term>
+        <listitem><para>Temperature of the specified component.
+        Width can only be specified if height is given. Note the "," separator.
+        Scale is the max value of the bar. May be specified regardless of 
+        height and width specification, but must always include the ":" char.
+        It is suggested to make this higher than the max temperature you can 
+        ever safely reach with that particular printer component. </para>
+        <para>
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used. Note the use of ":"
+        to separate the server_id from the component_id if the server_id
+        is provided. The component id must match "bed", "chamber", or
+        "toolN" where N is some integer. Tool numbers start from 0. Not all
+        printers will have all components. </para>
+        </listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_temperature_graph</option>
+            </command>
+            <option>(server_id:)component_id (height),(width) 
+            (gradient colour 1) (gradient colour 2) (scale) (-t) (-l)</option>
+        </term>
+        <listitem><para>Temperature of the specified component.
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used. Note the use of ":"
+        to separate the server_id from the component_id if the server_id
+        is provided. The component id must match "bed", "chamber", or
+        "toolN" where N is some integer. Tool numbers start from 0. Not all
+        printers will have all components.</para>
+        <para>Gradient colors can be specified as hexadecimal
+        values with no 0x or # prefix. Use the -t switch to enable a
+        temperature gradient, so that small values are "cold" with color 1
+        and large values are "hot" with color 2. Without the -t switch,
+        the colors produce a horizontal gradient spanning the width of the
+        graph. The scale parameter defines the maximum value of the graph.
+        It is suggested to make this higher than the max temperature you can 
+        ever safely reach with that particular printer component.
+        Use the -l switch to enable a logarithmic scale, which helps to
+        see small values. The default size for graphs can be controlled
+        via the default_graph_height and default_graph_width config
+        settings.</para>
+        </listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_target_temp</option>
+            </command>
+            <option>(server_id:)component_id</option>
+        </term>
+        <listitem>Target temperature of the specified component.
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used. Note the use of ":"
+        to separate the server_id from the component_id if the server_id
+        is provided. The component id must match "bed", "chamber", or
+        "toolN" where N is some integer. Tool numbers start from 0. Not all
+        printers will have all components.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_target_temp_bar</option>
+            </command>
+            <option>(height)(,width)(:scale)</option>
+            <option>(server_id:)component_id</option>
+        </term>
+        <listitem><para>Target temperature of the specified component.
+        Width can only be specified if height is given. Note the "," separator.
+        Scale is the max value of the bar. May be specified regardless of 
+        height and width specification, but must always include the ":" char.
+        It is suggested to make this higher than the max temperature you can 
+        ever safely reach with that particular printer component. </para>
+        <para>
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used. Note the use of ":"
+        to separate the server_id from the component_id if the server_id
+        is provided. The component id must match "bed", "chamber", or
+        "toolN" where N is some integer. Tool numbers start from 0. Not all
+        printers will have all components. </para>
+        </listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_target_temp_graph</option>
+            </command>
+            <option>(server_id:)component_id (height),(width) 
+            (gradient colour 1) (gradient colour 2) (scale) (-t) (-l)</option>
+        </term>
+        <listitem><para>Target temperature of the specified component.
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used. Note the use of ":"
+        to separate the server_id from the component_id if the server_id
+        is provided. The component id must match "bed", "chamber", or
+        "toolN" where N is some integer. Tool numbers start from 0. Not all
+        printers will have all components.</para>
+        <para>Gradient colors can be specified as hexadecimal
+        values with no 0x or # prefix. Use the -t switch to enable a
+        temperature gradient, so that small values are "cold" with color 1
+        and large values are "hot" with color 2. Without the -t switch,
+        the colors produce a horizontal gradient spanning the width of the
+        graph. The scale parameter defines the maximum value of the graph.
+        It is suggested to make this higher than the max temperature you can 
+        ever safely reach with that particular printer component.
+        Use the -l switch to enable a logarithmic scale, which helps to
+        see small values. The default size for graphs can be controlled
+        via the default_graph_height and default_graph_width config
+        settings.</para>
+        </listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_user</option>
+            </command>
+            <option>(server_id)</option>
+        </term>
+        <listitem>User name associated with this query to the server. 
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
+                <option>octoprint_version</option>
+            </command>
+            <option>(server_id)</option>
+        </term>
+        <listitem>Version string of the server. 
+        If a server_id is provided, it will be used as a lookup key in the 
+        conky setting 'octoprint_config'. Otherwise the server specified in 
+        conky setting 'octoprint_server' will be used.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
                 <option>offset</option>
             </command>
             <option>(pixels)</option>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -232,6 +232,11 @@ if(BUILD_CURL)
   set(optional_sources ${optional_sources} ${ccurl_thread})
 endif(BUILD_CURL)
 
+if(BUILD_OCTOPRINT)
+  set(octoprint octoprint.cc octoprint.h)
+  set(optional_sources ${optional_sources} ${octoprint})
+endif(BUILD_OCTOPRINT)
+
 if(BUILD_RSS)
   set(rss rss.cc rss.h prss.cc prss.h)
   set(optional_sources ${optional_sources} ${rss})

--- a/src/core.cc
+++ b/src/core.cc
@@ -2034,11 +2034,21 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   octoprint_parse_arg(obj, arg);
   obj->callbacks.barval = &octoprint_temperature;
   obj->callbacks.free = &gen_free_opaque;
+  END OBJ(octoprint_target_temp_bar, 0)
+  arg = scan_bar(obj, arg, 0);
+  octoprint_parse_arg(obj, arg);
+  obj->callbacks.barval = &octoprint_target_temp;
+  obj->callbacks.free = &gen_free_opaque;
 #ifdef BUILD_X11
   END OBJ(octoprint_temperature_graph, 0)
   arg = scan_graph(obj, arg, 0);
   octoprint_parse_arg(obj, arg);
   obj->callbacks.graphval = &octoprint_temperature;
+  obj->callbacks.free = &gen_free_opaque;
+  END OBJ(octoprint_target_temp_graph, 0)
+  arg = scan_graph(obj, arg, 0);
+  octoprint_parse_arg(obj, arg);
+  obj->callbacks.graphval = &octoprint_target_temp;
   obj->callbacks.free = &gen_free_opaque;
 #endif /* BUILD_X11 */
 #endif /* BUILD_OCTOPRINT */

--- a/src/core.cc
+++ b/src/core.cc
@@ -1986,10 +1986,60 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   init_intel_backlight(obj);
 #endif /* BUILD_INTEL_BACKLIGHT */
 #ifdef BUILD_OCTOPRINT
-  END OBJ(octoprint_printer_state, 0)
-  octoprint_parse_arg(obj, arg);
-  obj->callbacks.print = &print_octoprint_printer_state;
+#define OCTOPRINT_OBJ(name) \
+  END OBJ(octoprint_##name, 0) \
+  octoprint_parse_arg(obj, arg); \
+  obj->callbacks.print = &print_octoprint_##name; \
   obj->callbacks.free = &octoprint_free_obj_info;
+  
+  OCTOPRINT_OBJ(user)
+  OCTOPRINT_OBJ(version)
+  OCTOPRINT_OBJ(longversion)
+  OCTOPRINT_OBJ(safemode)
+  OCTOPRINT_OBJ(conn_baud)
+  OCTOPRINT_OBJ(conn_port)
+  OCTOPRINT_OBJ(conn_state)
+  OCTOPRINT_OBJ(local_used)
+  OCTOPRINT_OBJ(local_free)
+  OCTOPRINT_OBJ(local_total)
+  OCTOPRINT_OBJ(local_filecount)
+  OCTOPRINT_OBJ(sdcard_filecount)
+  OCTOPRINT_OBJ(job_name)
+  OCTOPRINT_OBJ(job_time)
+  OCTOPRINT_OBJ(job_time_left)
+  OCTOPRINT_OBJ(job_state)
+  OCTOPRINT_OBJ(job_user)
+  OCTOPRINT_OBJ(logs_used)
+  OCTOPRINT_OBJ(logs_free)
+  OCTOPRINT_OBJ(logs_total)
+  OCTOPRINT_OBJ(printer_state)
+  OCTOPRINT_OBJ(printer_error)
+  OCTOPRINT_OBJ(temperature)
+  OCTOPRINT_OBJ(target_temp)
+  OCTOPRINT_OBJ(sdcard_ready)
+#undef OCTOPRINT_OBJ
+  
+  END OBJ(octoprint_job_progress_pct, 0)
+  octoprint_parse_arg(obj, arg);
+  obj->callbacks.percentage = &octoprint_job_progress_pct;
+  obj->callbacks.free = &octoprint_free_obj_info;
+  END OBJ(octoprint_job_progress_bar, 0)
+  arg = scan_bar(obj, arg, 100);
+  octoprint_parse_arg(obj, arg);
+  obj->callbacks.barval = &octoprint_job_progress_barval;
+  obj->callbacks.free = &gen_free_opaque;
+
+  END OBJ(octoprint_temperature_bar, 0)
+  arg = scan_bar(obj, arg, 100);
+  octoprint_parse_arg(obj, arg); //TODO: fixed scale view
+  obj->callbacks.barval = &octoprint_temperature;
+  obj->callbacks.free = &gen_free_opaque;
+  END OBJ(octoprint_temperature_graph, 0)
+  arg = scan_graph(obj, arg, 0);
+  octoprint_parse_arg(obj, arg);
+  obj->callbacks.graphval = &octoprint_temperature;
+  obj->callbacks.free = &gen_free_opaque;
+
 #endif /* BUILD_OCTOPRINT */
 
   END {

--- a/src/core.cc
+++ b/src/core.cc
@@ -110,6 +110,9 @@
 #ifdef BUILD_INTEL_BACKLIGHT
 #include "intel_backlight.h"
 #endif /* BUILD_INTEL_BACKLIGHT */
+#ifdef BUILD_OCTOPRINT
+#include "octoprint.h"
+#endif /* BUILD_OCTOPRINT */
 
 /* check for OS and include appropriate headers */
 #if defined(__linux__)
@@ -1982,6 +1985,13 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   obj->callbacks.free = &free_intel_backlight;
   init_intel_backlight(obj);
 #endif /* BUILD_INTEL_BACKLIGHT */
+#ifdef BUILD_OCTOPRINT
+  END OBJ(octoprint_printer_state, 0)
+  octoprint_parse_arg(obj, arg);
+  obj->callbacks.print = &print_octoprint_printer_state;
+  obj->callbacks.free = &octoprint_free_obj_info;
+#endif /* BUILD_OCTOPRINT */
+
   END {
     auto *buf = static_cast<char *>(malloc(text_buffer_size.get(*state)));
 

--- a/src/core.cc
+++ b/src/core.cc
@@ -2029,10 +2029,9 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   octoprint_parse_arg(obj, arg);
   obj->callbacks.barval = &octoprint_job_progress_barval;
   obj->callbacks.free = &gen_free_opaque;
-
   END OBJ(octoprint_temperature_bar, 0)
-  arg = scan_bar(obj, arg, 100);
-  octoprint_parse_arg(obj, arg); //TODO: fixed scale view
+  arg = scan_bar(obj, arg, 0);
+  octoprint_parse_arg(obj, arg);
   obj->callbacks.barval = &octoprint_temperature;
   obj->callbacks.free = &gen_free_opaque;
 #ifdef BUILD_X11

--- a/src/core.cc
+++ b/src/core.cc
@@ -2005,6 +2005,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   OCTOPRINT_OBJ(local_filecount)
   OCTOPRINT_OBJ(sdcard_filecount)
   OCTOPRINT_OBJ(job_name)
+  OCTOPRINT_OBJ(job_progress)
   OCTOPRINT_OBJ(job_time)
   OCTOPRINT_OBJ(job_time_left)
   OCTOPRINT_OBJ(job_state)
@@ -2034,12 +2035,13 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   octoprint_parse_arg(obj, arg); //TODO: fixed scale view
   obj->callbacks.barval = &octoprint_temperature;
   obj->callbacks.free = &gen_free_opaque;
+#ifdef BUILD_X11
   END OBJ(octoprint_temperature_graph, 0)
   arg = scan_graph(obj, arg, 0);
   octoprint_parse_arg(obj, arg);
   obj->callbacks.graphval = &octoprint_temperature;
   obj->callbacks.free = &gen_free_opaque;
-
+#endif /* BUILD_X11 */
 #endif /* BUILD_OCTOPRINT */
 
   END {

--- a/src/main.cc
+++ b/src/main.cc
@@ -142,6 +142,9 @@ static void print_version() {
 #ifdef BUILD_PULSEAUDIO
             << _("  * PulseAudio\n")
 #endif /* BUIL_PULSEAUDIO */
+#ifdef BUILD_OCTOPRINT
+            << _("  * Octoprint\n")
+#endif /* BUILD_OCTOPRINT */
 #ifdef DEBUG
             << _("  * Debugging extensions\n")
 #endif

--- a/src/main.cc
+++ b/src/main.cc
@@ -143,7 +143,7 @@ static void print_version() {
             << _("  * PulseAudio\n")
 #endif /* BUIL_PULSEAUDIO */
 #ifdef BUILD_OCTOPRINT
-            << _("  * Octoprint\n")
+            << _("  * OctoPrint\n")
 #endif /* BUILD_OCTOPRINT */
 #ifdef DEBUG
             << _("  * Debugging extensions\n")

--- a/src/octoprint.cc
+++ b/src/octoprint.cc
@@ -163,9 +163,9 @@ Json::Value octoprint_get_last_xfer(const std::string &printer_id, const std::st
       NORM_ERR("octoprint: url for printer '%s' not specified",printer_id.c_str());
       return Json::Value(Json::nullValue);
     }
-    token = printer_conf["token"].asString();
+    token = printer_conf["apikey"].asString();
     if (token.empty()) {
-      NORM_ERR("octoprint: token for printer '%s' not specified",printer_id.c_str());
+      NORM_ERR("octoprint: apikey for printer '%s' not specified",printer_id.c_str());
       return Json::Value(Json::nullValue);
     }
     if (printer_conf.isMember("interval"))
@@ -263,6 +263,7 @@ void print_octoprint_conn_state(struct text_object *obj, char *p, unsigned int p
 // /api/files/<location>/<file>
 void print_octoprint_local_used(struct text_object *obj, char *p, unsigned int p_max_size) {
   std::queue<std::string> q({"files"});
+  //TODO: make recursive
   auto result = extract_common(obj, "/api/files/local", q);
 
   std::size_t bytes{0};

--- a/src/octoprint.cc
+++ b/src/octoprint.cc
@@ -320,12 +320,22 @@ double octoprint_job_progress_barval(struct text_object *obj) {
 
 void print_octoprint_job_time(struct text_object *obj, char *p, unsigned int p_max_size) {
   std::queue<std::string> q({"progress", "printTime"});
-  print_common(extract_common(obj, "/api/job", q), p, p_max_size);
+  auto seconds = extract_common(obj, "/api/job", q);
+  if (seconds.isNull()) {
+    snprintf(p, p_max_size, "???");
+  } else {
+    format_seconds(p, p_max_size, seconds.asLargestInt());
+  }
 }
 
 void print_octoprint_job_time_left(struct text_object *obj, char *p, unsigned int p_max_size) {
   std::queue<std::string> q({"progress", "printTimeLeft"});
-  print_common(extract_common(obj, "/api/job", q), p, p_max_size);
+  auto seconds = extract_common(obj, "/api/job", q);
+  if (seconds.isNull()) {
+    snprintf(p, p_max_size, "???");
+  } else {
+    format_seconds(p, p_max_size, seconds.asLargestInt());
+  }
 }
 
 void print_octoprint_job_state(struct text_object *obj, char *p, unsigned int p_max_size) {

--- a/src/octoprint.cc
+++ b/src/octoprint.cc
@@ -393,7 +393,7 @@ void print_octoprint_temperature(struct text_object *obj, char *p, unsigned int 
   if (temperature.isNull()){
     snprintf(p, p_max_size, "???");
   } else {
-    snprintf(p, p_max_size, "%3.1f", temperature.asDouble());
+    snprintf(p, p_max_size, "%5.1f", temperature.asDouble());
   }
 }
 
@@ -402,10 +402,9 @@ void print_octoprint_target_temp(struct text_object *obj, char *p, unsigned int 
   if (temperature.isNull()){
     snprintf(p, p_max_size, "???");
   } else {
-    snprintf(p, p_max_size, "%3.1f", temperature.asDouble());
+    snprintf(p, p_max_size, "%5.1f", temperature.asDouble());
   }
 }
-
 
 double octoprint_temperature(struct text_object *obj) {
   return get_temperature(obj,"actual").asDouble();

--- a/src/octoprint.cc
+++ b/src/octoprint.cc
@@ -191,6 +191,10 @@ Json::Value extract_common(struct text_object *obj, const std::string& endpoint,
   }
 
   const auto state_json = octoprint_get_last_xfer(od->printer_id ? od->printer_id : "", endpoint);
+  if (state_json.isNull()) {
+    NORM_ERR("no data available for printer '%s' endpoint '%s'", (od->printer_id ? od->printer_id : "<default>"), endpoint.c_str());
+    return state_json;
+  }
   return recursive_get(state_json, query_path);
 }
 
@@ -416,7 +420,7 @@ void print_octoprint_sdcard_ready(struct text_object *obj, char *p, unsigned int
   print_common(extract_common(obj, "/api/printer", q), p, p_max_size);
 }
 
-
+//tries to match the specific component patterns
 int check_for_component(const char* arg) {
   int char_count{0};
   if (sscanf(arg, "tool%*d%n ", &char_count) != EOF && char_count) {
@@ -426,6 +430,7 @@ int check_for_component(const char* arg) {
   return char_count;
 }
 
+//tries to parse a string which may contain printer and/or component specifier
 void octoprint_parse_arg(struct text_object *obj, const char *arg) {
   struct octoprint_data *od;
   od = static_cast<struct octoprint_data *>(malloc(sizeof(struct octoprint_data)));

--- a/src/octoprint.cc
+++ b/src/octoprint.cc
@@ -1,0 +1,215 @@
+/*
+ *
+ * Conky, a system monitor, based on torsmo
+ *
+ * Please see COPYING for details
+ *
+ * Copyright (c) 2005-2021 Brenden Matthews, Philip Kovacs, et. al.
+ *	(see AUTHORS)
+ * All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "octoprint.h"
+#include "ccurl_thread.h"
+#include "setting.hh"
+#include "luamm.hh"
+
+#include <curl/curl.h>
+
+
+#include <cmath>
+
+//single printer configs
+conky::simple_config_setting<std::string> octoprint_server("octoprint_server", "",
+                                                       false);
+conky::simple_config_setting<std::string> octoprint_apikey("octoprint_apikey", "",
+                                                       false);
+conky::simple_config_setting<double> octoprint_update_interval("octoprint_update_interval", 1,
+                                                       false);
+
+// so we can use a lua string to back a JSON value
+template <>
+struct conky::lua_traits<Json::Value, false, false, false> {
+  static const lua::Type type = lua::TSTRING;
+  typedef Json::Value Type;
+
+  static inline std::pair<Type, bool> convert(lua::state &l, int index,
+                                              const std::string &) {
+    auto str = l.tostring(index);
+    Json::Value root;
+    Json::Reader reader;
+    bool parsingSuccessful = reader.parse( str, root );
+    if ( !parsingSuccessful ) {
+      return {Json::Value(Json::nullValue), false};
+    }
+    return {root, true};
+  }
+};
+
+conky::simple_config_setting<Json::Value> octoprint_config("octoprint_config", Json::Value(Json::nullValue), false);
+
+
+class octoprint_cb : public curl_callback<Json::Value> {
+  typedef curl_callback<Json::Value> Base;
+
+protected:
+  virtual void process_data() {
+    try {
+      Json::Value tmp;
+      Json::Reader reader;
+      bool parsingSuccessful = reader.parse( data, tmp );
+      if ( !parsingSuccessful ) {
+        NORM_ERR("Error parsing the curl result into json");
+      }
+      std::unique_lock<std::mutex> lock(Base::result_mutex);
+      Base::result = tmp;
+    } catch (std::runtime_error &e) { NORM_ERR("%s", e.what()); }
+  }
+public:
+  octoprint_cb(uint32_t period, const std::string &url, const std::string& token) :
+    Base(period, Base::Tuple(url)) {
+      NORM_ERR("creating curl cb with token %s",token.c_str());
+      curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_BEARER);
+      curl_easy_setopt(curl, CURLOPT_XOAUTH2_BEARER, token.c_str());
+      curl_easy_setopt(curl, CURLOPT_VERBOSE, 1);
+      Base::result = Json::Value(Json::nullValue);
+    }
+};
+
+struct octoprint_data {
+  char *printer_id;
+  int tool_index;
+};
+
+void print_octoprint_printer_state(struct text_object *obj, char *p, unsigned int p_max_size) {
+  struct octoprint_data *od = static_cast<struct octoprint_data *>(obj->data.opaque);
+  if (!od) {
+    NORM_ERR("error processing Octoprint data");
+    return;
+  }
+
+  auto state_json = octoprint_get_last_xfer(od->printer_id, "/api/printer");
+
+  if (state_json.isNull()) {
+    strncpy(p,"data not found", p_max_size);
+    return;
+  }
+
+  strncpy(p, state_json["state"]["text"].asCString(), p_max_size);
+}
+
+
+Json::Value octoprint_get_last_xfer(const std::string &printer_id, const std::string &endpoint) {
+  std::string url;
+  std::string token;
+  double interval;
+  if (printer_id.empty()) {
+    url = octoprint_server.get(*state);
+    if (url.empty()) {
+      NORM_ERR("octoprint: no default printer url specified");
+      return Json::Value(Json::nullValue);
+    }
+    
+    token = octoprint_apikey.get(*state);
+    if (token.empty()) {
+      NORM_ERR("octoprint: no default api key specified");
+      return Json::Value(Json::nullValue);
+    }
+    interval = octoprint_update_interval.get(*state);  
+  } else {
+    const auto conf_blob = octoprint_config.get(*state);
+      Json::StreamWriterBuilder wbuilder;
+      wbuilder["indentation"] = "";
+      auto conf_str = Json::writeString(wbuilder,conf_blob);
+    NORM_ERR("octoprint_config: %s",conf_str.c_str());
+    if (!conf_blob.isMember(std::string{printer_id})) {
+      NORM_ERR("octoprint: could not find printer_id: %s", printer_id.c_str());
+      return Json::Value(Json::nullValue);
+    }
+    const auto& printer_conf = conf_blob[printer_id];
+    url = printer_conf["url"].asString();
+    if (url.empty()) {
+      NORM_ERR("octoprint: url for printer '%s' not specified",printer_id.c_str());
+      return Json::Value(Json::nullValue);
+    }
+    token = printer_conf["token"].asString();
+    if (token.empty()) {
+      NORM_ERR("octoprint: token for printer '%s' not specified",printer_id.c_str());
+      return Json::Value(Json::nullValue);
+    }
+    interval = printer_conf["interval"].asDouble();
+  }
+  url += endpoint;
+  return octoprint_get_last_xfer(url, token, interval);
+} 
+
+/* prints result data to text buffer, used by $curl */
+Json::Value octoprint_get_last_xfer(const std::string &url, const std::string &token, double interval) {
+  //first extract the update rate for the printer id
+  uint32_t period = std::max(lround(interval / active_update_interval()), 1l);
+  auto cb = conky::register_cb<octoprint_cb>(period, url, token);
+
+  return cb->get_result_copy();
+}
+
+
+
+void octoprint_parse_arg(struct text_object *obj, const char *arg) {
+  NORM_ERR("octoprint_parse_arg got arg '%s'",arg);
+  struct octoprint_data *od;
+  // null values are perfectly acceptable here
+  od = static_cast<struct octoprint_data *>(malloc(sizeof(struct octoprint_data)));
+  memset(od, 0, sizeof(struct octoprint_data));
+  od->printer_id = strdup("");
+  obj->data.opaque = od;
+  if (arg == nullptr || strlen(arg) < 1) {
+    return;
+  }
+
+  //we have some args.
+  // %s -> octoprint_config key
+  // %d -> tool index
+  // %s %d -> octoprint_config key and tool index
+  // there is a pathological case where a user could supply a single set of
+  //    number-compatible chars, expecting it to be treated as a config key 
+  //    and not a tool index. 
+
+  int tool_index;
+  int match = sscanf(arg, "%d", &tool_index);
+  if (match == 1) {
+    NORM_ERR("parsed numeric from arg '%d'",tool_index);
+    od->tool_index = tool_index;
+    return;
+  } 
+
+  int char_count{0};
+  match = sscanf(arg, "%*s%n %d", &char_count, &tool_index);
+  if (char_count > 0) {
+    od->printer_id = strndup(arg,char_count);
+    NORM_ERR("parsed string from arg '%s'",od->printer_id);
+  }
+  if (match > 0) {
+    NORM_ERR("parsed numeric from arg '%d'",tool_index);
+    od->tool_index = tool_index;
+  }
+  
+}
+
+void octoprint_free_obj_info(struct text_object *obj) {
+  struct octoprint_data *od = static_cast<struct octoprint_data *>(obj->data.opaque);
+  free_and_zero(od->printer_id);
+  free_and_zero(obj->data.opaque);
+}

--- a/src/octoprint.h
+++ b/src/octoprint.h
@@ -72,26 +72,9 @@ void print_octoprint_target_temp(struct text_object *, char *, unsigned int);
 double octoprint_temperature(struct text_object *);
 double octoprint_target_temp(struct text_object *);
 
-
-
-void print_octoprint_tool_temperature(struct text_object *, char *, unsigned int);
-double octoprint_tool_temperature(struct text_object *);
-void print_octoprint_tool_target_temp(struct text_object *, char *, unsigned int);
-void print_octoprint_bed_temperature(struct text_object *, char *, unsigned int);
-void print_octoprint_bed_target_temp(struct text_object *, char *, unsigned int);
-void print_octoprint_chamber_temperature(struct text_object *, char *, unsigned int);
-void print_octoprint_chamber_target_temp(struct text_object *, char *, unsigned int);
 void print_octoprint_sdcard_ready(struct text_object *, char *, unsigned int);
 
-
-// Json::Value octoprint_get_last_xfer(const std::string &printer_id, const std::string &endpoint);
-
-// Json::Value octoprint_get_last_xfer(const std::string &url, const std::string &token, double interval);
-
-
 void octoprint_parse_arg(struct text_object *, const char *);
-
-
 void octoprint_free_obj_info(struct text_object *);
 
 #endif

--- a/src/octoprint.h
+++ b/src/octoprint.h
@@ -51,6 +51,7 @@ void print_octoprint_local_filecount(struct text_object *, char *, unsigned int)
 void print_octoprint_sdcard_filecount(struct text_object *, char *, unsigned int);
 // /api/job
 void print_octoprint_job_name(struct text_object *, char *, unsigned int);
+void print_octoprint_job_progress(struct text_object *, char *, unsigned int);
 uint8_t octoprint_job_progress_pct(struct text_object *);
 double octoprint_job_progress_barval(struct text_object *);
 

--- a/src/octoprint.h
+++ b/src/octoprint.h
@@ -26,7 +26,7 @@
 #define OCTOPRINT_H_
 
 #include "conky.h"
-#include "json/json.h"
+// #include "json/json.h"
 
 //general variable format: ${octoprint_user printer_id <optional index>}
 
@@ -51,10 +51,13 @@ void print_octoprint_local_filecount(struct text_object *, char *, unsigned int)
 void print_octoprint_sdcard_filecount(struct text_object *, char *, unsigned int);
 // /api/job
 void print_octoprint_job_name(struct text_object *, char *, unsigned int);
-void print_octoprint_job_progress_pct(struct text_object *, char *, unsigned int);
+uint8_t octoprint_job_progress_pct(struct text_object *);
+double octoprint_job_progress_barval(struct text_object *);
+
 void print_octoprint_job_time(struct text_object *, char *, unsigned int);
 void print_octoprint_job_time_left(struct text_object *, char *, unsigned int);
 void print_octoprint_job_state(struct text_object *, char *, unsigned int);
+void print_octoprint_job_user(struct text_object *, char *, unsigned int);
 // /plugin/logging/logs
 void print_octoprint_logs_used(struct text_object *, char *, unsigned int);
 void print_octoprint_logs_free(struct text_object *, char *, unsigned int);
@@ -62,7 +65,16 @@ void print_octoprint_logs_total(struct text_object *, char *, unsigned int);
 // /api/printer  -- use single endpoint for efficiency
 void print_octoprint_printer_state(struct text_object *, char *, unsigned int);
 void print_octoprint_printer_error(struct text_object *, char *, unsigned int);
+
+void print_octoprint_temperature(struct text_object *, char *, unsigned int);
+void print_octoprint_target_temp(struct text_object *, char *, unsigned int);
+double octoprint_temperature(struct text_object *);
+double octoprint_target_temp(struct text_object *);
+
+
+
 void print_octoprint_tool_temperature(struct text_object *, char *, unsigned int);
+double octoprint_tool_temperature(struct text_object *);
 void print_octoprint_tool_target_temp(struct text_object *, char *, unsigned int);
 void print_octoprint_bed_temperature(struct text_object *, char *, unsigned int);
 void print_octoprint_bed_target_temp(struct text_object *, char *, unsigned int);
@@ -71,9 +83,9 @@ void print_octoprint_chamber_target_temp(struct text_object *, char *, unsigned 
 void print_octoprint_sdcard_ready(struct text_object *, char *, unsigned int);
 
 
-Json::Value octoprint_get_last_xfer(const std::string &printer_id, const std::string &endpoint);
+// Json::Value octoprint_get_last_xfer(const std::string &printer_id, const std::string &endpoint);
 
-Json::Value octoprint_get_last_xfer(const std::string &url, const std::string &token, double interval);
+// Json::Value octoprint_get_last_xfer(const std::string &url, const std::string &token, double interval);
 
 
 void octoprint_parse_arg(struct text_object *, const char *);

--- a/src/octoprint.h
+++ b/src/octoprint.h
@@ -1,0 +1,84 @@
+/*
+ *
+ * Conky, a system monitor, based on torsmo
+ *
+ * Please see COPYING for details
+ *
+ * Copyright (c) 2005-2021 Brenden Matthews, Philip Kovacs, et. al.
+ *	(see AUTHORS)
+ * All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef OCTOPRINT_H_
+#define OCTOPRINT_H_
+
+#include "conky.h"
+#include "json/json.h"
+
+//general variable format: ${octoprint_user printer_id <optional index>}
+
+// /api/currentuser
+void print_octoprint_user(struct text_object *, char *, unsigned int);
+// /api/version
+void print_octoprint_version(struct text_object *, char *, unsigned int);
+void print_octoprint_longversion(struct text_object *, char *, unsigned int);
+// /api/server
+void print_octoprint_safemode(struct text_object *, char *, unsigned int);
+// /api/connection
+void print_octoprint_conn_baud(struct text_object *, char *, unsigned int);
+void print_octoprint_conn_port(struct text_object *, char *, unsigned int);
+void print_octoprint_conn_state(struct text_object *, char *, unsigned int);
+// /api/files
+// /api/files/<location>
+// /api/files/<location>/<file>
+void print_octoprint_local_used(struct text_object *, char *, unsigned int);
+void print_octoprint_local_free(struct text_object *, char *, unsigned int);
+void print_octoprint_local_total(struct text_object *, char *, unsigned int);
+void print_octoprint_local_filecount(struct text_object *, char *, unsigned int);
+void print_octoprint_sdcard_filecount(struct text_object *, char *, unsigned int);
+// /api/job
+void print_octoprint_job_name(struct text_object *, char *, unsigned int);
+void print_octoprint_job_progress_pct(struct text_object *, char *, unsigned int);
+void print_octoprint_job_time(struct text_object *, char *, unsigned int);
+void print_octoprint_job_time_left(struct text_object *, char *, unsigned int);
+void print_octoprint_job_state(struct text_object *, char *, unsigned int);
+// /plugin/logging/logs
+void print_octoprint_logs_used(struct text_object *, char *, unsigned int);
+void print_octoprint_logs_free(struct text_object *, char *, unsigned int);
+void print_octoprint_logs_total(struct text_object *, char *, unsigned int);
+// /api/printer  -- use single endpoint for efficiency
+void print_octoprint_printer_state(struct text_object *, char *, unsigned int);
+void print_octoprint_printer_error(struct text_object *, char *, unsigned int);
+void print_octoprint_tool_temperature(struct text_object *, char *, unsigned int);
+void print_octoprint_tool_target_temp(struct text_object *, char *, unsigned int);
+void print_octoprint_bed_temperature(struct text_object *, char *, unsigned int);
+void print_octoprint_bed_target_temp(struct text_object *, char *, unsigned int);
+void print_octoprint_chamber_temperature(struct text_object *, char *, unsigned int);
+void print_octoprint_chamber_target_temp(struct text_object *, char *, unsigned int);
+void print_octoprint_sdcard_ready(struct text_object *, char *, unsigned int);
+
+
+Json::Value octoprint_get_last_xfer(const std::string &printer_id, const std::string &endpoint);
+
+Json::Value octoprint_get_last_xfer(const std::string &url, const std::string &token, double interval);
+
+
+void octoprint_parse_arg(struct text_object *, const char *);
+
+
+void octoprint_free_obj_info(struct text_object *);
+
+#endif

--- a/src/specials.cc
+++ b/src/specials.cc
@@ -171,6 +171,10 @@ const char *scan_bar(struct text_object *obj, const char *args, double def_scale
     } else if (sscanf(args, ":%lf %n", &b->scale, &n) == 1) {
       b->width = default_bar_width.get(*state);
       b->height = default_bar_height.get(*state);
+    } else {
+      b->width = default_bar_width.get(*state);
+      b->height = default_bar_height.get(*state);
+      b->scale = def_scale;
     }
     args += n;
   } else {


### PR DESCRIPTION
**Descriptions**
Added a new interface to work with the REST API provided by [OctoPrint](https://octoprint.org/). This permits conky to display
information about an OctoPrint server, an attached 3D printer, and any print job that may be running.

**Licenses**
No changes

**Notes**
Separate from the the OctoPrint interface itself, there are two system improvements that may be useful elsewhere. The first is a change to the `scan_bar` method in `specials.cc`. This adds an option to directly extract a scale value from the arg line in a standardized way. A default scale and auto-scaling can still be done in the code as before, in case no scale value is given in the arg (backwards compatible). The second is a new `conky::lua_traints<>` specialization for JSON values. The data on the lua stack is a string, but the object presented to the application on the c++ side is a Json::Value. This allows generic data structures to be embedded in the conky.config data. The conversion from string to Json::Value is incredibly unforgiving, but it seems very useful.

