### PR TITLE
Http port config

### DIFF
--- a/doc/config_settings.xml
+++ b/doc/config_settings.xml
@@ -404,6 +404,17 @@
     <varlistentry>
         <term>
             <command>
+                <option>http_port</option>
+            </command>
+        </term>
+        <listitem>Port to listen to for HTTP connections. Default value is
+        10080, but is blocked by Firefox and Chrome, so you really want to
+        change it.
+        <para /></listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>
+            <command>
                 <option>http_refresh</option>
             </command>
         </term>


### PR DESCRIPTION
This allows setting the port to listen to for HTTP, to work around #1061. Even seems to update correctly on reload.

Depends on #664 as I didn't want to rebase it again over this.