### PR TITLE
Avoid referencing underfined symbol

### DIFF
--- a/src/display-console.cc
+++ b/src/display-console.cc
@@ -54,8 +54,11 @@ display_output_console::display_output_console(const std::string &name_)
 }
 
 bool display_output_console::detect() {
-  if ((out_to_stdout.get(*state) || out_to_stderr.get(*state)) &&
-      !out_to_ncurses.get(*state)) {
+  if ((out_to_stdout.get(*state) || out_to_stderr.get(*state))
+#ifdef BUILD_NCURSES
+      && !out_to_ncurses.get(*state)
+#endif
+  ) {
     DBGP2("Display output '%s' enabled in config.", name.c_str());
     return true;
   }


### PR DESCRIPTION
When building without ncurses out_to_ncurses is not defined. It is also not needed to check for ncurses if it is not compiled in.

The error I'm getting when building without ncurses is:

```
--- src/CMakeFiles/conky.dir/display-console.cc.o ---
/wrkdirs/usr/ports/sysutils/conky/work/conky-1.13.1/src/display-console.cc:58:8: error: use of undeclared identifier 'out_to_ncurses'
      !out_to_ncurses.get(*state)) {
       ^
1 error generated.
*** [src/CMakeFiles/conky.dir/display-console.cc.o] Error code 1
```