### PR TITLE
Replace atoi and atol with strtol (most files).

### DIFF
--- a/src/cmus.cc
+++ b/src/cmus.cc
@@ -100,10 +100,11 @@ void cmus_cb::work() {
       } else if (strncmp(line, "position ", 9) == 0) {
         cmus.curtime = line + 9;
         cmus.timeleft =
-            atoi(cmus.totaltime.c_str()) - atoi(cmus.curtime.c_str());
+            strtol(cmus.totaltime.c_str(), nullptr, 10) -
+                strtol(cmus.curtime.c_str(), nullptr, 10);
         if (cmus.curtime.size() > 0) {
-          cmus.progress = static_cast<float>(atoi(cmus.curtime.c_str())) /
-                          atoi(cmus.totaltime.c_str());
+          cmus.progress = static_cast<float>(strtol(cmus.curtime.c_str(), nullptr, 10)) /
+                          strtol(cmus.totaltime.c_str(), nullptr, 10);
         } else {
           cmus.progress = 0;
         }
@@ -188,7 +189,7 @@ void print_cmus_totaltime(struct text_object *obj, char *p,
       lround(music_player_interval.get(*state) / active_update_interval()), 1l);
   const cmus_result &cmus =
       conky::register_cb<cmus_cb>(period)->get_result_copy();
-  format_seconds_short(p, p_max_size, atol(cmus.totaltime.c_str()));
+  format_seconds_short(p, p_max_size, strtol(cmus.totaltime.c_str(), nullptr, 10));
 }
 
 void print_cmus_timeleft(struct text_object *obj, char *p,
@@ -198,7 +199,6 @@ void print_cmus_timeleft(struct text_object *obj, char *p,
       lround(music_player_interval.get(*state) / active_update_interval()), 1l);
   const cmus_result &cmus =
       conky::register_cb<cmus_cb>(period)->get_result_copy();
-  // format_seconds_short(p, p_max_size, atol(cmus.timeleft.c_str()));
   format_seconds_short(p, p_max_size, static_cast<long>(cmus.timeleft));
 }
 
@@ -209,7 +209,7 @@ void print_cmus_curtime(struct text_object *obj, char *p,
       lround(music_player_interval.get(*state) / active_update_interval()), 1l);
   const cmus_result &cmus =
       conky::register_cb<cmus_cb>(period)->get_result_copy();
-  format_seconds_short(p, p_max_size, atol(cmus.curtime.c_str()));
+  format_seconds_short(p, p_max_size, strtol(cmus.curtime.c_str(), nullptr, 10));
 }
 
 #undef CMUS_PRINT_GENERATOR

--- a/src/common.cc
+++ b/src/common.cc
@@ -316,7 +316,7 @@ void scan_loadavg_arg(struct text_object *obj, const char *arg) {
   obj->data.i = 0;
   if ((arg != nullptr) && (arg[1] == 0) &&
       (isdigit(static_cast<unsigned char>(arg[0])) != 0)) {
-    obj->data.i = atoi(arg);
+    obj->data.i = strtol(arg, nullptr, 10);
     if (obj->data.i > 3 || obj->data.i < 1) {
       NORM_ERR("loadavg arg needs to be in range (1,3)");
       obj->data.i = 0;

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -2183,7 +2183,7 @@ void initialisation(int argc, char **argv) {
 #endif /* BUILD_X11 */
       case 'p':
         if (first_pass != 0) {
-          startup_pause = atoi(optarg);
+          startup_pause = strtol(optarg, nullptr, 10);
           sleep(startup_pause);
         }
         break;

--- a/src/core.cc
+++ b/src/core.cc
@@ -432,25 +432,25 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   obj->callbacks.free = &gen_free_opaque;
 #endif /* !__OpenBSD__ */
   END OBJ(freq, nullptr) get_cpu_count();
-  if ((arg == nullptr) || (isdigit(static_cast<unsigned char>(arg[0])) == 0) ||
-      strlen(arg) >= 3 || atoi(&arg[0]) == 0 ||
-      static_cast<unsigned int>(atoi(&arg[0])) > info.cpu_count) {
+  if ((arg == nullptr) || strlen(arg) >= 3 ||
+      strtol(&arg[0], nullptr, 10) == 0 ||
+      static_cast<unsigned int>(strtol(&arg[0], nullptr, 10)) > info.cpu_count) {
     obj->data.i = 1;
     /* NORM_ERR("freq: Invalid CPU number or you don't have that many CPUs! "
       "Displaying the clock for CPU 1."); */
   } else {
-    obj->data.i = atoi(&arg[0]);
+    obj->data.i = strtol(&arg[0], nullptr, 10);
   }
   obj->callbacks.print = &print_freq;
   END OBJ(freq_g, nullptr) get_cpu_count();
-  if ((arg == nullptr) || (isdigit(static_cast<unsigned char>(arg[0])) == 0) ||
-      strlen(arg) >= 3 || atoi(&arg[0]) == 0 ||
-      static_cast<unsigned int>(atoi(&arg[0])) > info.cpu_count) {
+  if ((arg == nullptr) || strlen(arg) >= 3 ||
+      strtol(&arg[0], nullptr, 10) == 0 ||
+      static_cast<unsigned int>(strtol(&arg[0], nullptr, 10)) > info.cpu_count) {
     obj->data.i = 1;
     /* NORM_ERR("freq_g: Invalid CPU number or you don't have that many "
       "CPUs! Displaying the clock for CPU 1."); */
   } else {
-    obj->data.i = atoi(&arg[0]);
+    obj->data.i = strtol(&arg[0], nullptr, 10);
   }
   obj->callbacks.print = &print_freq_g;
 #if defined(__linux__)
@@ -483,23 +483,23 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   obj->callbacks.free = &free_tcp_ping;
 #if defined(__linux__)
   END OBJ(voltage_mv, 0) get_cpu_count();
-  if (!arg || !isdigit((unsigned char)arg[0]) || strlen(arg) >= 3 ||
-      atoi(&arg[0]) == 0 || (unsigned int)atoi(&arg[0]) > info.cpu_count) {
+  if (!arg || strlen(arg) >= 3 || strtol(&arg[0], nullptr, 10) == 0 ||
+    (unsigned int)strtol(&arg[0], nullptr, 10) > info.cpu_count) {
     obj->data.i = 1;
     /* NORM_ERR("voltage_mv: Invalid CPU number or you don't have that many "
       "CPUs! Displaying voltage for CPU 1."); */
   } else {
-    obj->data.i = atoi(&arg[0]);
+    obj->data.i = strtol(&arg[0], nullptr, 10);
   }
   obj->callbacks.print = &print_voltage_mv;
   END OBJ(voltage_v, 0) get_cpu_count();
-  if (!arg || !isdigit((unsigned char)arg[0]) || strlen(arg) >= 3 ||
-      atoi(&arg[0]) == 0 || (unsigned int)atoi(&arg[0]) > info.cpu_count) {
+  if (!arg || strlen(arg) >= 3 || strtol(&arg[0], nullptr, 10) == 0 ||
+    (unsigned int)strtol(&arg[0], nullptr, 10) > info.cpu_count) {
     obj->data.i = 1;
     /* NORM_ERR("voltage_v: Invalid CPU number or you don't have that many "
       "CPUs! Displaying voltage for CPU 1."); */
   } else {
-    obj->data.i = atoi(&arg[0]);
+    obj->data.i = strtol(&arg[0], nullptr, 10);
   }
   obj->callbacks.print = &print_voltage_v;
 
@@ -1017,20 +1017,20 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ(fs_used, &update_fs_stats) init_fs(obj, arg);
   obj->callbacks.print = &print_fs_used;
 #ifdef BUILD_GUI
-  END OBJ(hr, nullptr) obj->data.l = arg != nullptr ? atoi(arg) : 1;
+  END OBJ(hr, nullptr) obj->data.l = arg != nullptr ? strtol(arg, nullptr, 10) : 1;
   obj->callbacks.print = &new_hr;
 #endif /* BUILD_GUI */
   END OBJ(nameserver, &update_dns_data) parse_nameserver_arg(obj, arg);
   obj->callbacks.print = &print_nameserver;
   obj->callbacks.free = &free_dns_data;
-  END OBJ(offset, nullptr) obj->data.l = arg != nullptr ? atoi(arg) : 1;
+  END OBJ(offset, nullptr) obj->data.l = arg != nullptr ? strtol(arg, nullptr, 10) : 1;
   obj->callbacks.print = &new_offset;
-  END OBJ(voffset, nullptr) obj->data.l = arg != nullptr ? atoi(arg) : 1;
+  END OBJ(voffset, nullptr) obj->data.l = arg != nullptr ? strtol(arg, nullptr, 10) : 1;
   obj->callbacks.print = &new_voffset;
   END OBJ(save_coordinates, nullptr) obj->data.l =
-      arg != nullptr ? atoi(arg) : 0;
+      arg != nullptr ? strtol(arg, nullptr, 10) : 0;
   obj->callbacks.print = &new_save_coordinates;
-  END OBJ_ARG(goto, nullptr, "goto needs arguments") obj->data.l = atoi(arg);
+  END OBJ_ARG(goto, nullptr, "goto needs arguments") obj->data.l = strtol(arg, nullptr, 10);
   obj->callbacks.print = &new_goto;
 #ifdef BUILD_GUI
   END OBJ(tab, nullptr) scan_tab(obj, arg);
@@ -1493,7 +1493,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
       parse_net_stat_arg(obj, arg, free_at_crash);
   obj->callbacks.print = &print_totalup;
   END OBJ(updates, nullptr) obj->callbacks.print = &print_updates;
-  END OBJ_IF(if_updatenr, nullptr) obj->data.i = arg != nullptr ? atoi(arg) : 0;
+  END OBJ_IF(if_updatenr, nullptr) obj->data.i = arg != nullptr ? strtol(arg, nullptr, 10) : 0;
   if (obj->data.i == 0) {
     CRIT_ERR(obj, free_at_crash,
              "if_updatenr needs a number above 0 as argument");
@@ -1501,9 +1501,9 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   set_updatereset(obj->data.i > get_updatereset() ? obj->data.i
                                                   : get_updatereset());
   obj->callbacks.iftest = &updatenr_iftest;
-  END OBJ(alignr, nullptr) obj->data.l = arg != nullptr ? atoi(arg) : 1;
+  END OBJ(alignr, nullptr) obj->data.l = arg != nullptr ? strtol(arg, nullptr, 10) : 1;
   obj->callbacks.print = &new_alignr;
-  END OBJ(alignc, nullptr) obj->data.l = arg != nullptr ? atoi(arg) : 0;
+  END OBJ(alignc, nullptr) obj->data.l = arg != nullptr ? strtol(arg, nullptr, 10) : 0;
   obj->callbacks.print = &new_alignc;
   END OBJ(upspeed, &update_net_stats)
       parse_net_stat_arg(obj, arg, free_at_crash);

--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -144,7 +144,7 @@ static void X11_create_window() {
 #ifdef BUILD_XFT
   if (use_xft.get(*state)) {
     auto dpi = XGetDefault(display, "Xft", "dpi");
-    if (dpi) { xft_dpi = atoi(dpi); }
+    if (dpi) { xft_dpi = strtol(dpi, nullptr, 10); }
   }
 #endif                /* BUILD_XFT */
   update_text_area(); /* to position text/window on screen */

--- a/src/libmpdclient.cc
+++ b/src/libmpdclient.cc
@@ -731,17 +731,17 @@ mpd_Status *mpd_getStatus(mpd_Connection *connection) {
     mpd_ReturnElement *re = connection->returnElement;
 
     if (strcmp(re->name, "volume") == 0) {
-      status->volume = atoi(re->value);
+      status->volume = strtol(re->value, nullptr, 10);
     } else if (strcmp(re->name, "repeat") == 0) {
-      status->repeat = atoi(re->value);
+      status->repeat = strtol(re->value, nullptr, 10);
     } else if (strcmp(re->name, "random") == 0) {
-      status->random = atoi(re->value);
+      status->random = strtol(re->value, nullptr, 10);
     } else if (strcmp(re->name, "playlist") == 0) {
       status->playlist = strtol(re->value, nullptr, 10);
     } else if (strcmp(re->name, "playlistlength") == 0) {
-      status->playlistLength = atoi(re->value);
+      status->playlistLength = strtol(re->value, nullptr, 10);
     } else if (strcmp(re->name, "bitrate") == 0) {
-      status->bitRate = atoi(re->value);
+      status->bitRate = strtol(re->value, nullptr, 10);
     } else if (strcmp(re->name, "state") == 0) {
       if (strcmp(re->value, "play") == 0) {
         status->state = MPD_STATUS_STATE_PLAY;
@@ -753,33 +753,33 @@ mpd_Status *mpd_getStatus(mpd_Connection *connection) {
         status->state = MPD_STATUS_STATE_UNKNOWN;
       }
     } else if (strcmp(re->name, "song") == 0) {
-      status->song = atoi(re->value);
+      status->song = strtol(re->value, nullptr, 10);
     } else if (strcmp(re->name, "songid") == 0) {
-      status->songid = atoi(re->value);
+      status->songid = strtol(re->value, nullptr, 10);
     } else if (strcmp(re->name, "time") == 0) {
       char *tok = strchr(re->value, ':');
 
       /* the second strchr below is a safety check */
       if ((tok != nullptr) && (strchr(tok, 0) > (tok + 1))) {
-        /* atoi stops at the first non-[0-9] char: */
-        status->elapsedTime = atoi(re->value);
-        status->totalTime = atoi(tok + 1);
+        /* strtol stops at the first non-[0-9] char: */
+        status->elapsedTime = strtol(re->value, nullptr, 10);
+        status->totalTime = strtol(tok + 1, nullptr, 10);
       }
     } else if (strcmp(re->name, "error") == 0) {
       status->error = strndup(re->value, text_buffer_size.get(*state));
     } else if (strcmp(re->name, "xfade") == 0) {
-      status->crossfade = atoi(re->value);
+      status->crossfade = strtol(re->value, nullptr, 10);
     } else if (strcmp(re->name, "updating_db") == 0) {
-      status->updatingDb = atoi(re->value);
+      status->updatingDb = strtol(re->value, nullptr, 10);
     } else if (strcmp(re->name, "audio") == 0) {
       char *tok = strchr(re->value, ':');
 
       if ((tok != nullptr) && (strchr(tok, 0) > (tok + 1))) {
-        status->sampleRate = atoi(re->value);
-        status->bits = atoi(++tok);
+        status->sampleRate = strtol(re->value, nullptr, 10);
+        status->bits = strtol(++tok, nullptr, 10);
         tok = strchr(tok, ':');
         if ((tok != nullptr) && (strchr(tok, 0) > (tok + 1))) {
-          status->channels = atoi(tok + 1);
+          status->channels = strtol(tok + 1, nullptr, 10);
         }
       }
     }
@@ -848,11 +848,11 @@ mpd_Stats *mpd_getStats(mpd_Connection *connection) {
     mpd_ReturnElement *re = connection->returnElement;
 
     if (strcmp(re->name, "artists") == 0) {
-      stats->numberOfArtists = atoi(re->value);
+      stats->numberOfArtists = strtol(re->value, nullptr, 10);
     } else if (strcmp(re->name, "albums") == 0) {
-      stats->numberOfAlbums = atoi(re->value);
+      stats->numberOfAlbums = strtol(re->value, nullptr, 10);
     } else if (strcmp(re->name, "songs") == 0) {
-      stats->numberOfSongs = atoi(re->value);
+      stats->numberOfSongs = strtol(re->value, nullptr, 10);
     } else if (strcmp(re->name, "uptime") == 0) {
       stats->uptime = strtol(re->value, nullptr, 10);
     } else if (strcmp(re->name, "db_update") == 0) {
@@ -903,7 +903,7 @@ mpd_SearchStats *mpd_getSearchStats(mpd_Connection *connection) {
     re = connection->returnElement;
 
     if (strcmp(re->name, "songs") == 0) {
-      stats->numberOfSongs = atoi(re->value);
+      stats->numberOfSongs = strtol(re->value, nullptr, 10);
     } else if (strcmp(re->name, "playtime") == 0) {
       stats->playTime = strtol(re->value, nullptr, 10);
     }
@@ -1152,7 +1152,8 @@ mpd_InfoEntity *mpd_getNextInfoEntity(mpd_Connection *connection) {
       entity = mpd_newInfoEntity();
       entity->type = MPD_INFO_ENTITY_TYPE_SONG;
       entity->info.song = mpd_newSong();
-      entity->info.song->pos = atoi(connection->returnElement->value);
+      entity->info.song->pos =
+          strtol(connection->returnElement->value, nullptr, 10);
     } else {
       connection->error = 1;
       strncpy(connection->errorStr, "problem parsing song info",
@@ -1200,13 +1201,13 @@ mpd_InfoEntity *mpd_getNextInfoEntity(mpd_Connection *connection) {
             strndup(re->value, text_buffer_size.get(*state));
       } else if (entity->info.song->time == MPD_SONG_NO_TIME &&
                  strcmp(re->name, "Time") == 0) {
-        entity->info.song->time = atoi(re->value);
+        entity->info.song->time = strtol(re->value, nullptr, 10);
       } else if (entity->info.song->pos == MPD_SONG_NO_NUM &&
                  strcmp(re->name, "Pos") == 0) {
-        entity->info.song->pos = atoi(re->value);
+        entity->info.song->pos = strtol(re->value, nullptr, 10);
       } else if (entity->info.song->id == MPD_SONG_NO_ID &&
                  strcmp(re->name, "Id") == 0) {
-        entity->info.song->id = atoi(re->value);
+        entity->info.song->id = strtol(re->value, nullptr, 10);
       } else if ((entity->info.song->date == nullptr) &&
                  strcmp(re->name, "Date") == 0) {
         entity->info.song->date =
@@ -1425,7 +1426,7 @@ int mpd_sendAddIdCommand(mpd_Connection *connection, const char *file) {
 
   string = mpd_getNextReturnElementNamed(connection, "Id");
   if (string != nullptr) {
-    retval = atoi(string);
+    retval = strtol(string, nullptr, 10);
     free(string);
   }
 
@@ -1611,7 +1612,7 @@ int mpd_getUpdateId(mpd_Connection *connection) {
 
   jobid = mpd_getNextReturnElementNamed(connection, "updating_db");
   if (jobid != nullptr) {
-    ret = atoi(jobid);
+    ret = strtol(jobid, nullptr, 10);
     free(jobid);
   }
 
@@ -1740,11 +1741,11 @@ mpd_OutputEntity *mpd_getNextOutput(mpd_Connection *connection) {
 
     if (strcmp(re->name, "outputid") == 0) {
       if (output != nullptr && output->id >= 0) { return output; }
-      output->id = atoi(re->value);
+      output->id = strtol(re->value, nullptr, 10);
     } else if (strcmp(re->name, "outputname") == 0) {
       output->name = strndup(re->value, text_buffer_size.get(*state));
     } else if (strcmp(re->name, "outputenabled") == 0) {
-      output->enabled = atoi(re->value);
+      output->enabled = strtol(re->value, nullptr, 10);
     }
 
     mpd_getNextReturnElement(connection);

--- a/src/linux.cc
+++ b/src/linux.cc
@@ -954,9 +954,9 @@ void get_cpu_count(void) {
         subtoken = strtok_r(str2, "-", &saveptr2);
         if (subtoken == nullptr) break;
         if (subtoken1 < 0)
-          subtoken1 = atoi(subtoken);
+          subtoken1 = strtol(subtoken, nullptr, 10);
         else
-          subtoken2 = atoi(subtoken);
+          subtoken2 = strtol(subtoken, nullptr, 10);
       }
       if (subtoken2 > 0) info.cpu_count += subtoken2 - subtoken1;
     }
@@ -1339,7 +1339,7 @@ static int open_sysfs_sensor(const char *dir, const char *dev, const char *type,
       NORM_ERR("open_sysfs_sensor(): can't read from sysfs");
     } else {
       divbuf[divn] = '\0';
-      *divisor = atoi(divbuf);
+      *divisor = strtol(divbuf, nullptr, 10);
     }
     close(divfd);
   }
@@ -1365,7 +1365,7 @@ static double get_sysfs_info(int *fd, int divisor, char *devtype, char *type) {
       NORM_ERR("get_sysfs_info(): read from %s failed\n", devtype);
     } else {
       buf[n] = '\0';
-      val = atoi(buf);
+      val = strtol(buf, nullptr, 10);
     }
   }
 

--- a/src/net_stat.cc
+++ b/src/net_stat.cc
@@ -620,7 +620,7 @@ int update_dns_data() {
 }
 
 void parse_nameserver_arg(struct text_object *obj, const char *arg) {
-  obj->data.l = arg != nullptr ? atoi(arg) : 0;
+  obj->data.l = arg != nullptr ? strtol(arg, nullptr, 10) : 0;
 }
 
 void print_nameserver(struct text_object *obj, char *p,

--- a/src/read_tcpip.cc
+++ b/src/read_tcpip.cc
@@ -61,7 +61,7 @@ void parse_read_tcpip_arg(struct text_object *obj, const char *arg,
   sscanf(arg, "%s", rtd->host);
   sscanf(arg + strlen(rtd->host), "%u", &(rtd->port));
   if (rtd->port == 0) {
-    rtd->port = atoi(rtd->host);
+    rtd->port = strtol(rtd->host, nullptr, 10);
     strncpy(rtd->host, "localhost", 10);
   }
   if (rtd->port < 1 || rtd->port > 65535) {


### PR DESCRIPTION
**Descriptions**
* Pursuant to the comment by @su8 in #1223, replace most of the remaining instances of `atoi` and all three instances of `atol` with `strtol` to prevent undefined behavior.
* Testing revealed no changes in existing behavior.
* I tested all of the `atoi`-using variables I could in patched and unpatched `conky`, and none of them appeared to show changed behavior. I haven't been able to test anything related to `i8k.cc`, `ibm.cc`, `nvidia.cc` (don't have the hardware) or `openbsd.cc` (haven't managed to build `conky`). To be extra-safe, I've left those files out of the commit, but modified versions can be found in a separate branch called "untested-atoi." If I should push those as well, just let me know!
* Screenshots: There would be a lot of screenshots. I can probably get those arranged by sometime next week if necessary.

**Licenses**
* No new files.