### PR TITLE
Reset selected_font after drawing shades/outline

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1610,6 +1610,7 @@ void draw_stuff() {
       text_offset_x = text_offset_y = 0;
     }
 
+    selected_font = 0;
     set_foreground_color(default_color.get(*state));
     unset_display_output();
   }


### PR DESCRIPTION
Fixes #828.

The font wasn't reset after drawing the shades, so the text was drawn with the last selected font as default font.