### PR TITLE
Fix man page formatting.

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -27,7 +27,7 @@ if(BUILD_DOCS)
     )
     add_custom_target(conky.1
         ALL
-        COMMAND ${APP_PANDOC} -f markdown -t man ${CMAKE_CURRENT_BINARY_DIR}/man.md > ${CMAKE_CURRENT_BINARY_DIR}/conky.1
+        COMMAND ${APP_PANDOC} --standalone -f markdown -t man ${CMAKE_CURRENT_BINARY_DIR}/man.md > ${CMAKE_CURRENT_BINARY_DIR}/conky.1
         SOURCES config_settings.yaml variables.yaml lua.yaml man.md.j2
     )
     add_dependencies(conky.1 man.md)

--- a/doc/README.md
+++ b/doc/README.md
@@ -30,7 +30,7 @@ process:
    ```
 2. Run `pandoc` to convert the markdown into a man page:
    ```console
-   $ pandoc -f markdown -t man.md > conky.1
+   $ pandoc --standalone -f markdown -t man man.md > conky.1
    ```
 
 These steps are also part of the CMake build, and can be executed by configuring

--- a/doc/man.md.j2
+++ b/doc/man.md.j2
@@ -1,12 +1,14 @@
+% conky(1)
+%
+% 2012-05-03
+
 # NAME
 
 conky - A system monitor for X
 
 # SYNOPSIS
 
-**conky**
-
-\[ *options* \]
+**conky** \[ *options* \]
 
 # DESCRIPTION
 


### PR DESCRIPTION
## Description
* The new markdown-based man page was being rendered without the `.TH` metadata by `pandoc-2.19.2`, which resulted in line breaks and other formatting not appearing in the final product. To fix this, add `%` statements with the original title and date and run `pandoc` with options `--standalone -f markdown -t man man.md`. The instructions in `README.md` have also been updated to that effect.
* Only the man page is affected.
* I rebuilt `conky` and verified the formatting of the man page.
* Here are screenshots of the current and fixed man pages:
![man-page-before](https://user-images.githubusercontent.com/74497663/195347655-25f26e19-aae2-4870-9d44-b864e971eb37.png)
![man-page-after](https://user-images.githubusercontent.com/74497663/195347664-295a60ed-e0d1-44ed-9423-da52e626a7b1.png)

