### PR TITLE
Use cmake macros for cxx standards and compiler/linker options

### DIFF
--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -114,7 +114,7 @@ endif()
 
 set(
   COVERAGE_COMPILER_FLAGS
-  "-g -O0 -fprofile-arcs -ftest-coverage -fprofile-instr-generate -fcoverage-mapping"
+  -g -O0 -fprofile-arcs -ftest-coverage -fprofile-instr-generate -fcoverage-mapping
   CACHE INTERNAL "")
 
 set(CMAKE_CXX_FLAGS_COVERAGE ${COVERAGE_COMPILER_FLAGS}
@@ -145,8 +145,7 @@ endif() # NOT CMAKE_BUILD_TYPE STREQUAL "Debug"
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
   link_libraries(gcov)
 else()
-  set(CMAKE_EXE_LINKER_FLAGS
-      "${CMAKE_EXE_LINKER_FLAGS} -fprofile-instr-generate")
+  add_link_options($<$<NOT:$<COMPILE_LANG_AND_ID:C,GNU>>:-fprofile-instr-generate>)
 endif()
 
 # Defines a target for running and collection code coverage information Builds
@@ -412,9 +411,10 @@ function(SETUP_TARGET_FOR_COVERAGE_GCOVR_HTML)
 endfunction() # SETUP_TARGET_FOR_COVERAGE_GCOVR_HTML
 
 function(APPEND_COVERAGE_COMPILER_FLAGS)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILER_FLAGS}"
-      PARENT_SCOPE)
+  foreach(_opt ${COVERAGE_COMPILER_FLAGS})
+    add_compile_options($<$<COMPILE_LANGUAGE:C>:${_opt}>)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:${_opt}>)
+  endforeach()
   message(
     STATUS "Appending code coverage compiler flags: ${COVERAGE_COMPILER_FLAGS}")
 endfunction() # APPEND_COVERAGE_COMPILER_FLAGS

--- a/cmake/ConkyBuildOptions.cmake
+++ b/cmake/ConkyBuildOptions.cmake
@@ -37,12 +37,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif(NOT CMAKE_BUILD_TYPE)
 
 # -std options for all build types
-set(CMAKE_C_FLAGS "-std=c99 ${CMAKE_C_FLAGS}"
-    CACHE STRING "Flags used by the C compiler during all build types."
-    FORCE)
-set(CMAKE_CXX_FLAGS "-std=c++17 ${CMAKE_CXX_FLAGS}"
-    CACHE STRING "Flags used by the C++ compiler during all build types."
-    FORCE)
+set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -78,7 +73,8 @@ if(MAINTAINER_MODE)
 
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       set(USING_CLANG true)
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+      add_compile_options($<$<COMPILE_LANG_AND_ID:CXX,Clang>:-stdlib=libc++>)
+      add_link_options($<$<COMPILE_LANG_AND_ID:CXX,Clang>:-stdlib=libc++>)
     endif()
 endif(MAINTAINER_MODE)
 


### PR DESCRIPTION
In the current cmake files, compiler flags are always appended to itself, leading to multiplication of the same flags in each cmake run, giving flags like `-std=c++17 -std=c++17 -std=c++17 -std=c++17 ...`.

This fix replaces this with ore appropriate tools and macros from cmake.

This change should not influence current builds. Tested with existing tests and github actions.