### PR TITLE
More X11 cleanup

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -772,7 +772,6 @@ static int get_string_width_special(char *s, int special_index) {
   if (display_output() == nullptr || !display_output()->graphical()) {
     return strlen(s);
   }
-  if (!out_to_x.get(*state)) { return strlen(s); }
 
   p = strndup(s, text_buffer_size.get(*state));
   final = p;
@@ -846,7 +845,8 @@ int last_font_height;
 void update_text_area() {
   int x = 0, y = 0;
 
-  if (!out_to_x.get(*state)) { return; }
+  if (display_output() == nullptr || !display_output()->graphical()) { return; }
+
   /* update text size if it isn't fixed */
 #ifdef OWN_WINDOW
   if (fixed_size == 0)
@@ -957,7 +957,6 @@ static int text_size_updater(char *s, int special_index) {
 
   for (int i = 0; i < special_index; i++) { current = current->next; }
 
-  if (!out_to_x.get(*state)) { return 0; }
   if (display_output() == nullptr || !display_output()->graphical()) {
     return 0;
   }
@@ -1168,7 +1167,7 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
       switch (current->type) {
 #ifdef BUILD_GUI
         case HORIZONTAL_LINE:
-          if (out_to_x.get(*state)) {
+          if (display_output() && display_output()->graphical()) {
             int h = current->height;
             int mid = font_ascent() / 2;
 
@@ -1184,7 +1183,7 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
           break;
 
         case STIPPLED_HR:
-          if (out_to_x.get(*state)) {
+          if (display_output() && display_output()->graphical()) {
             int h = current->height;
             char tmp_s = current->arg;
             int mid = font_ascent() / 2;
@@ -1202,7 +1201,7 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
           break;
 
         case BAR:
-          if (out_to_x.get(*state)) {
+          if (display_output() && display_output()->graphical()) {
             int h, by;
             double bar_usage, scale;
             if (cur_x - text_start_x > mw && mw > 0) { break; }
@@ -1230,7 +1229,7 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
           break;
 
         case GAUGE: /* new GAUGE  */
-          if (out_to_x.get(*state)) {
+          if (display_output() && display_output()->graphical()) {
             int h, by = 0;
             unsigned long last_colour = current_color;
 #ifdef BUILD_MATH
@@ -1280,7 +1279,7 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
           break;
 
         case GRAPH:
-          if (out_to_x.get(*state)) {
+          if (display_output() && display_output()->graphical()) {
             int h, by, i = 0, j = 0;
             int colour_idx = 0;
             unsigned long last_colour = current_color;
@@ -1416,7 +1415,7 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
           break;
 
         case FONT:
-          if (out_to_x.get(*state)) {
+          if (display_output() && display_output()->graphical()) {
             int old = font_ascent();
 
             cur_y -= font_ascent();
@@ -1596,7 +1595,6 @@ void draw_stuff() {
   for (auto output : display_outputs()) output->begin_draw_stuff();
 #ifdef BUILD_GUI
   llua_draw_pre_hook();
-  //  if (out_to_x.get(*state)) {
   for (auto output : display_outputs()) {
     if (!output->graphical()) continue;
     // XXX: we assume a single graphical display
@@ -2212,7 +2210,9 @@ void initialisation(int argc, char **argv) {
   conky::set_config_settings(*state);
 
 #ifdef BUILD_GUI
-  if (out_to_x.get(*state)) { current_text_color = default_color.get(*state); }
+  if (display_output() && display_output()->graphical()) {
+    current_text_color = default_color.get(*state);
+  }
 #endif
 
   /* generate text and get initial size */

--- a/src/conky.h
+++ b/src/conky.h
@@ -336,7 +336,7 @@ void draw_stuff();
 int percent_print(char *, int, unsigned);
 void human_readable(long long, char *, int);
 
-#ifdef BUILD_X11
+#ifdef BUILD_GUI
 
 /* UTF-8 */
 extern conky::simple_config_setting<bool> utf8_mode;

--- a/src/scroll.cc
+++ b/src/scroll.cc
@@ -51,9 +51,9 @@ inline int scroll_character_length(char c) {
 
     return len;
   }
-#else  /* BUILD_X11 */
+#else  /* BUILD_GUI */
   (void)c;
-#endif /* BUILD_X11 */
+#endif /* BUILD_GUI */
 
   return 1;
 }

--- a/src/scroll.cc
+++ b/src/scroll.cc
@@ -29,6 +29,7 @@
 #include <vector>
 #include "conky.h"
 #include "core.h"
+#include "display-output.hh"
 #include "logging.h"
 #include "specials.h"
 #include "text_object.h"
@@ -321,7 +322,7 @@ void print_scroll(struct text_object *obj, char *p, unsigned int p_max_size) {
 
 #ifdef BUILD_GUI
   // reset color when scroll is finished
-  if (out_to_x.get(*state)) {
+  if (display_output() && display_output()->graphical()) {
     new_special(p + strlen(p), FG)->arg = sd->resetcolor;
   }
 #endif

--- a/src/specials.cc
+++ b/src/specials.cc
@@ -43,6 +43,7 @@
 #include "colours.h"
 #include "common.h"
 #include "conky.h"
+#include "display-output.hh"
 
 struct special_t *specials = nullptr;
 
@@ -389,7 +390,7 @@ void new_gauge_in_x11(struct text_object *obj, char *buf, double usage) {
   struct special_t *s = nullptr;
   auto *g = static_cast<struct gauge *>(obj->special_data);
 
-  if (!out_to_x.get(*state)) { return; }
+  if (display_output() == nullptr || !display_output()->graphical()) { return; }
 
   if (g == nullptr) { return; }
 
@@ -415,7 +416,9 @@ void new_gauge(struct text_object *obj, char *p, unsigned int p_max_size,
   }
 
 #ifdef BUILD_GUI
-  if (out_to_x.get(*state)) { new_gauge_in_x11(obj, p, usage); }
+  if (display_output() && display_output()->graphical()) {
+    new_gauge_in_x11(obj, p, usage);
+  }
   if (out_to_stdout.get(*state)) {
     new_gauge_in_shell(obj, p, p_max_size, usage);
   }
@@ -429,7 +432,7 @@ void new_font(struct text_object *obj, char *p, unsigned int p_max_size) {
   struct special_t *s;
   unsigned int tmp = selected_font;
 
-  if (!out_to_x.get(*state)) { return; }
+  if (display_output() == nullptr || !display_output()->graphical()) { return; }
 
   if (p_max_size == 0) { return; }
 
@@ -606,7 +609,7 @@ void new_graph(struct text_object *obj, char *buf, int buf_max_size,
 }
 
 void new_hr(struct text_object *obj, char *p, unsigned int p_max_size) {
-  if (!out_to_x.get(*state)) { return; }
+  if (display_output() == nullptr || !display_output()->graphical()) { return; }
 
   if (p_max_size == 0) { return; }
 
@@ -636,7 +639,7 @@ void new_stippled_hr(struct text_object *obj, char *p,
   struct special_t *s = nullptr;
   auto *sh = static_cast<struct stippled_hr *>(obj->special_data);
 
-  if (!out_to_x.get(*state)) { return; }
+  if (display_output() == nullptr || !display_output()->graphical()) { return; }
 
   if ((sh == nullptr) || (p_max_size == 0)) { return; }
 
@@ -649,7 +652,9 @@ void new_stippled_hr(struct text_object *obj, char *p,
 
 void new_fg(struct text_object *obj, char *p, unsigned int p_max_size) {
 #ifdef BUILD_GUI
-  if (out_to_x.get(*state)) { new_special(p, FG)->arg = obj->data.l; }
+  if (display_output() && display_output()->graphical()) {
+    new_special(p, FG)->arg = obj->data.l;
+  }
 #endif /* BUILD_GUI */
 #ifdef BUILD_NCURSES
   if (out_to_ncurses.get(*state)) { new_special(p, FG)->arg = obj->data.l; }
@@ -661,7 +666,7 @@ void new_fg(struct text_object *obj, char *p, unsigned int p_max_size) {
 
 #ifdef BUILD_GUI
 void new_bg(struct text_object *obj, char *p, unsigned int p_max_size) {
-  if (!out_to_x.get(*state)) { return; }
+  if (display_output() == nullptr || !display_output()->graphical()) { return; }
 
   if (p_max_size == 0) { return; }
 
@@ -697,7 +702,7 @@ static void new_bar_in_x11(struct text_object *obj, char *buf, double usage) {
   struct special_t *s = nullptr;
   auto *b = static_cast<struct bar *>(obj->special_data);
 
-  if (!out_to_x.get(*state)) { return; }
+  if (display_output() == nullptr || !display_output()->graphical()) { return; }
 
   if (b == nullptr) { return; }
 
@@ -724,7 +729,9 @@ void new_bar(struct text_object *obj, char *p, unsigned int p_max_size,
   }
 
 #ifdef BUILD_GUI
-  if (out_to_x.get(*state)) { new_bar_in_x11(obj, p, usage); }
+  if (display_output() && display_output()->graphical()) {
+    new_bar_in_x11(obj, p, usage);
+  }
   if (out_to_stdout.get(*state)) {
     new_bar_in_shell(obj, p, p_max_size, usage);
   }


### PR DESCRIPTION
I needed those to get something displayed with SDL. There are still some more around but I wasn't sure how to deal with them.

Maybe the NULL test is not always required, but I haven't tried removing them yet. Maybe we should introduce some helper function instead to lower the verbosity?