### PR TITLE
Add man page to releases.

### DIFF
--- a/.github/workflows/publish-appimage.yml
+++ b/.github/workflows/publish-appimage.yml
@@ -23,7 +23,6 @@ jobs:
           sudo apt-get install -yqq --no-install-recommends \
             audacious-dev \
             cmake \
-            docbook2x \
             gawk \
             lcov \
             libaudclient-dev \
@@ -50,7 +49,11 @@ jobs:
             libxml2-dev \
             libxmmsclient-dev \
             libxnvctrl-dev \
-            ncurses-dev
+            ncurses-dev \
+            pandoc \
+            python3 \
+            &&
+            pip3 install --upgrade pyyaml
       - name: Checkout
         uses: actions/checkout@v3
       - name: Import GPG Deploy Key
@@ -69,6 +72,11 @@ jobs:
         with:
           name: conky-x86_64.AppImage.sha256
           path: conky-x86_64.AppImage.sha256
+      - name: Upload man page artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: conky.1
+          path: conky.1
       - name: Create Conky Release
         id: create_release
         uses: softprops/action-gh-release@v1
@@ -81,3 +89,4 @@ jobs:
           files: |
             conky-x86_64.AppImage
             conky-x86_64.AppImage.sha256
+            conky.1

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -34,6 +34,7 @@ cmake                                  \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo    \
   -DRELEASE=ON                         \
   -DBUILD_AUDACIOUS=ON                 \
+  -DBUILD_DOCS=ON                      \
   -DBUILD_HTTP=ON                      \
   -DBUILD_ICAL=ON                      \
   -DBUILD_ICONV=ON                     \
@@ -80,3 +81,6 @@ do
 done
 
 mv conky*.AppImage* "$OLD_CWD"
+
+# Copy the latest man page, which will be attached to releases
+mv doc/conky.1 "$OLD_CWD"


### PR DESCRIPTION
In addition to building an appimage for each commit to main and release, we'll include the man page so people can grab it without having to install pandoc.

This addresses #1247 and #1254.

# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [x] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3