### PR TITLE
Separate docs & extras (syntax files) build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,9 @@ set(conky_sources ${CMAKE_BINARY_DIR}/config.h ${CMAKE_BINARY_DIR}/build.h)
 add_subdirectory(lua)
 add_subdirectory(data)
 add_subdirectory(doc)
-add_subdirectory(extras)
+if(BUILD_EXTRAS)
+  add_subdirectory(extras)
+endif(BUILD_EXTRAS)
 
 # Include 3rdparty toluapp
 add_subdirectory(3rdparty/toluapp)

--- a/cmake/ConkyBuildOptions.cmake
+++ b/cmake/ConkyBuildOptions.cmake
@@ -85,7 +85,8 @@ mark_as_advanced(RELEASE)
 
 option(MAINTAINER_MODE "Enable maintainer mode" false)
 
-option(BUILD_DOCS "Build documentation & extras (syntax files for editors)" false)
+option(BUILD_DOCS "Build documentation" false)
+option(BUILD_EXTRAS "Build extras (includes syntax files for editors)" false)
 
 option(BUILD_I18N "Enable if you want internationalization support" true)
 if(BUILD_I18N)

--- a/cmake/ConkyPlatformChecks.cmake
+++ b/cmake/ConkyPlatformChecks.cmake
@@ -485,10 +485,12 @@ if(BUILD_DOCS)
     message(FATAL_ERROR "Unable to find program 'pandoc'")
   endif(NOT APP_PANDOC)
   mark_as_advanced(APP_PANDOC)
+endif(BUILD_DOCS)
 
+
+if(BUILD_DOCS OR BUILD_EXTRAS)
   # Python3 with Jinja2 and PyYaml required for manpage generation.
   find_package(Python3 REQUIRED COMPONENTS Interpreter)
-  include(CMakePrintHelpers)
   execute_process(
     COMMAND ${Python3_EXECUTABLE} -c "import yaml"
     RESULT_VARIABLE EXIT_CODE
@@ -514,7 +516,7 @@ if(BUILD_DOCS)
       "The \"Jinja2\" Python3 package is not installed. Please install it using the following command: \"pip3 install Jinja2\"."
     )
   endif()
-endif(BUILD_DOCS)
+endif(BUILD_DOCS OR BUILD_EXTRAS)
 
 if(CMAKE_BUILD_TYPE MATCHES "Debug")
   set(DEBUG true)

--- a/extras/CMakeLists.txt
+++ b/extras/CMakeLists.txt
@@ -18,27 +18,25 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-if(BUILD_DOCS)
-    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/nano)
-    add_custom_target(conky.nanorc
-        ALL
-        COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/doc/render.py nano/conky.nanorc.j2 > ${CMAKE_CURRENT_BINARY_DIR}/nano/conky.nanorc
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        SOURCES
-        ${CMAKE_SOURCE_DIR}/doc/variables.yaml
-        ${CMAKE_SOURCE_DIR}/doc/config_settings.yaml
-        ${CMAKE_SOURCE_DIR}/doc/lua.yaml
-        ${CMAKE_CURRENT_SOURCE_DIR}/nano/conky.nanorc.j2
-    )
-    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/vim/syntax)
-    add_custom_target(conkyrc.vim
-        ALL
-        COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/doc/render.py vim/syntax/conkyrc.vim.j2 > ${CMAKE_CURRENT_BINARY_DIR}/vim/syntax/conkyrc.vim
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        SOURCES
-        ${CMAKE_SOURCE_DIR}/doc/variables.yaml
-        ${CMAKE_SOURCE_DIR}/doc/config_settings.yaml
-        ${CMAKE_SOURCE_DIR}/doc/lua.yaml
-        ${CMAKE_CURRENT_SOURCE_DIR}/vim/syntax/conkyrc.vim.j2
-    )
-endif(BUILD_DOCS)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/nano)
+add_custom_target(conky.nanorc
+    ALL
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/doc/render.py nano/conky.nanorc.j2 > ${CMAKE_CURRENT_BINARY_DIR}/nano/conky.nanorc
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    SOURCES
+    ${CMAKE_SOURCE_DIR}/doc/variables.yaml
+    ${CMAKE_SOURCE_DIR}/doc/config_settings.yaml
+    ${CMAKE_SOURCE_DIR}/doc/lua.yaml
+    ${CMAKE_CURRENT_SOURCE_DIR}/nano/conky.nanorc.j2
+)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/vim/syntax)
+add_custom_target(conkyrc.vim
+    ALL
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/doc/render.py vim/syntax/conkyrc.vim.j2 > ${CMAKE_CURRENT_BINARY_DIR}/vim/syntax/conkyrc.vim
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    SOURCES
+    ${CMAKE_SOURCE_DIR}/doc/variables.yaml
+    ${CMAKE_SOURCE_DIR}/doc/config_settings.yaml
+    ${CMAKE_SOURCE_DIR}/doc/lua.yaml
+    ${CMAKE_CURRENT_SOURCE_DIR}/vim/syntax/conkyrc.vim.j2
+)


### PR DESCRIPTION
Rather than piggybacking on the BUILD_DOCS flag, use BUILD_EXTRAS to enable building the nano & vim syntax files. This is so that people can generate the extras without having to install pandoc.

# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [x] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3