### PR TITLE
Fix create/destroy/set/get Lua Rsvg functions.

### DIFF
--- a/doc/lua.yaml
+++ b/doc/lua.yaml
@@ -34,35 +34,53 @@ values:
     desc: |-
       Call this function to return a new cairo_font_extents_t
       structure. A creation function for this structure is not provided
-      by the cairo API. After calling this, you should use
-      tolua.takeownership() on the return value to ensure ownership is
+      by the cairo API.
+
+      After calling this, you should use
+      `tolua.takeownership(cfe)` on the return value to ensure ownership is
       passed properly.
   - name: cairo_font_extents_t:destroy(structure)
     desc: |-
       Call this function to free memory allocated by
       cairo_font_extents_t:create.
+
+      You should call `tolua.releaseownership(cfe)` before calling this function to
+      avoid double-frees, but only if you previously called
+      `tolua.takeownership(cfe)`
   - name: cairo_matrix_t:create()
     desc: |-
       Call this function to return a new cairo_matrix_t structure.
       A creation function for this structure is not provided by the
-      cairo API. After calling this, you should use
-      tolua.takeownership() on the return value to ensure ownership is
+      cairo API.
+
+      After calling this, you should use
+      `tolua.takeownership(cm)` on the return value to ensure ownership is
       passed properly.
   - name: cairo_matrix_t:destroy(structure)
     desc: |-
       Call this function to free memory allocated by
       cairo_matrix_t:create.
+
+      You should call `tolua.releaseownership(cm)` before calling this function to
+      avoid double-frees, but only if you previously called
+      `tolua.takeownership(cm)`
   - name: cairo_text_extents_t:create()
     desc: |-
       Call this function to return a new cairo_text_extents_t
       structure. A creation function for this structure is not provided
-      by the cairo API. After calling this, you should use
-      tolua.takeownership() on the return value to ensure ownership is
+      by the cairo API.
+
+      After calling this, you should use
+      `tolua.takeownership(cte)` on the return value to ensure ownership is
       passed properly.
   - name: cairo_text_extents_t:destroy(structure)
     desc: |-
       Call this function to free memory allocated by
       cairo_text_extents_t:create.
+
+      You should call `tolua.releaseownership(cte)` before calling this function to
+      avoid double-frees, but only if you previously called
+      `tolua.takeownership(cte)`
   - name: conky_build_arch
     desc: |-
       A string containing the build architecture for this
@@ -123,3 +141,47 @@ values:
 
       NOTE: This table is only defined when X support is
       enabled.
+  - name: RsvgRectangle:create()
+    desc: |-
+      Call this method to return a new RsvgRectangle
+      structure. A creation function for this structure is not provided
+      by the Rsvg API.
+
+      After calling this, you should use `tolua.takeownership(rect)` on the return
+      value to ensure ownership is passed properly.
+  - name: RsvgRectangle:destroy()
+    desc: |-
+      Call this method to free memory allocated by
+      `RsvgRectangle:create`.
+
+      You should call `tolua.releaseownership(rect)` before calling this function to
+      avoid double-frees, but only if you previously called
+      `tolua.takeownership(rect)`
+  - name: RsvgRectangle:set(x, y, width, height)
+    desc: |-
+      Sets the values of an existing RsvgRectangle.
+  - name: RsvgRectangle:get()
+    desc: |-
+      Gets the values of an existing RsvgRectangle.
+  - name: RsvgDimensionData:create()
+    desc: |-
+      Call this method to return a new RsvgDimensionData
+      structure. A creation function for this structure is not provided
+      by the Rsvg API.
+
+      After calling this, you should use `tolua.takeownership(rect)` on the return
+      value to ensure ownership is passed properly.
+  - name: RsvgDimensionData:destroy()
+    desc: |-
+      Call this method to free memory allocated by
+      `RsvgDimensionData:create`.
+
+      You should call `tolua.releaseownership(dd)` before calling this function to
+      avoid double-frees, but only if you previously called
+      `tolua.takeownership(dd)`
+  - name: RsvgDimensionData:set(x, y, width, height)
+    desc: |-
+      Sets the values of an existing RsvgDimensionData.
+  - name: RsvgDimensionData:get()
+    desc: |-
+      Gets the values of an existing RsvgDimensionData.

--- a/lua/librsvg-helper.h
+++ b/lua/librsvg-helper.h
@@ -29,17 +29,31 @@
 #include <librsvg/rsvg.h>
 #include <stdlib.h>
 
-RsvgDimensionData *rsvgDimensionDataCreate(void) {
+RsvgDimensionData *rsvg_dimension_data_create(void) {
   return (RsvgDimensionData *)calloc(1, sizeof(RsvgDimensionData));
 }
 
-void rsvgDimensionDataGet(RsvgDimensionData *dd, int *width, int *height,
-                          double *em, double *ex) {
+void rsvg_dimension_data_destroy(RsvgDimensionData *pointer) {
+  if (pointer) { free(pointer); }
+}
+
+void rsvg_dimension_data_get(RsvgDimensionData *dd, int *width, int *height,
+                             double *em, double *ex) {
   if (dd) {
     *width = dd->width;
     *height = dd->height;
     *em = dd->em;
     *ex = dd->ex;
+  }
+}
+
+void rsvg_dimension_data_set(RsvgDimensionData *dd, int width, int height,
+                             double em, double ex) {
+  if (dd) {
+    dd->width = width;
+    dd->height = height;
+    dd->em = em;
+    dd->ex = ex;
   }
 }
 
@@ -76,6 +90,32 @@ int rsvg_destroy_handle(RsvgHandle *handle) {
   if (handle) { g_object_unref(handle); }
 
   return 0;
+}
+
+RsvgRectangle *rsvg_rectangle_create(void) {
+  return calloc(1, sizeof(RsvgRectangle));
+}
+
+void rsvg_rectangle_destroy(RsvgRectangle *rect) { free(rect); }
+
+void rsvg_rectangle_set(RsvgRectangle *rect, double x, double y, double width,
+                        double height) {
+  if (rect) {
+    rect->x = x;
+    rect->y = y;
+    rect->width = width;
+    rect->height = height;
+  }
+}
+
+void rsvg_rectangle_get(RsvgRectangle *rect, double *x, double *y,
+                        double *width, double *height) {
+  if (rect) {
+    *x = rect->x;
+    *y = rect->y;
+    *width = rect->width;
+    *height = rect->height;
+  }
 }
 
 #endif /* _LIBRSVG_HELPER_H_ */

--- a/lua/rsvg.pkg
+++ b/lua/rsvg.pkg
@@ -61,9 +61,12 @@ typedef struct _RsvgDimensionData {
     int height;
     double em;
     double ex;
-    static tolua_outside RsvgDimensionData * rsvgDimensionDataCreate @ create();
-    tolua_outside void rsvgDimensionDataGet @ get(int * width, int * height,
+    static tolua_outside RsvgDimensionData* rsvg_dimension_data_create @ create();
+    static tolua_outside void rsvg_dimension_data_destroy @ destroy(RsvgDimensionData *);
+    tolua_outside void rsvg_dimension_data_get @ get(int * width, int * height,
                                                   double * em, double * ex);
+    tolua_outside void rsvg_dimension_data_set @ get(int width, int height,
+                                                  double em, double ex);
 } RsvgDimensionData;
 
 /**
@@ -82,6 +85,11 @@ typedef struct _RsvgRectangle {
     double y;
     double width;
     double height;
+
+	static tolua_outside RsvgRectangle* rsvg_rectangle_create @ create();
+	static tolua_outside void rsvg_rectangle_destroy @ destroy(RsvgRectangle *pointer);
+	tolua_outside void rsvg_rectangle_set @ set(double x, double y, double width, double height);
+	tolua_outside void rsvg_rectangle_get @ get(double *x, double *y, double *width, double *height);
 } RsvgRectangle;
 
 const char  *rsvg_handle_get_base_uri (RsvgHandle * handle);


### PR DESCRIPTION
We need an interface to be able to create/destroy/set/get the RsvgRectangle and RsvgDimensionData structs via Lua, which were missing or incomplete.

Documentation was also missing, which has been updated.

# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [x] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3
