### PR TITLE
Update Lua cairo bindings.

### DIFF
--- a/cmake/ConkyPlatformChecks.cmake
+++ b/cmake/ConkyPlatformChecks.cmake
@@ -370,7 +370,7 @@ include_directories(3rdparty/toluapp/include)
 if(BUILD_X11)
   # Check for libraries used by Lua bindings
   if(BUILD_LUA_CAIRO)
-    pkg_check_modules(CAIRO REQUIRED cairo cairo-xlib)
+    pkg_check_modules(CAIRO REQUIRED cairo>=1.14 cairo-xlib)
     set(luacairo_libs ${CAIRO_LIBRARIES} ${LUA_LIBRARIES})
     set(luacairo_includes ${CAIRO_INCLUDE_DIRS} ${LUA_INCLUDE_DIRS})
     find_program(APP_PATCH patch)

--- a/lua/cairo.pkg
+++ b/lua/cairo.pkg
@@ -908,3 +908,10 @@ void cairo_matrix_transform_distance(cairo_matrix_t * matrix, double *dx, double
 void cairo_matrix_transform_point(cairo_matrix_t * matrix, double *x, double *y);
 
 void cairo_debug_reset_static_data(void);
+
+void cairo_surface_set_device_scale (cairo_surface_t *surface,
+                                double x_scale,
+                                double y_scale);
+void cairo_surface_get_device_scale (cairo_surface_t *surface,
+                                double *x_scale,
+                                double *y_scale);


### PR DESCRIPTION
This adds 2 missing functions: cairo_surface_set_device_scale and cairo_surface_get_device_scale, and also requires cario 1.14 or newer.

This addresses the comments in #1083.

# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [x] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3
