### PR TITLE
Add an option to disable storing graph data explicitly

### DIFF
--- a/doc/config_settings.yaml
+++ b/doc/config_settings.yaml
@@ -445,6 +445,13 @@ values:
     default: rgb
   - name: stippled_borders
     desc: Border stippling (dashing) in pixels.
+  - name: store_graph_data_explicitly
+    desc:  |-
+      Enable storing graph data explicitly by ID. This avoids resets while
+      using conditional colors. This option should be disabled while using
+      graphs indirectly e.g. via execpi or lua_parse. Otherwise the graph
+      stays emtpy. The default value is true.
+    default: true
   - name: temperature_unit
     desc: |-
       Desired output unit of all objects displaying a temperature.

--- a/src/specials.cc
+++ b/src/specials.cc
@@ -67,6 +67,9 @@ conky::range_config_setting<int> default_gauge_width(
     "default_gauge_width", 0, std::numeric_limits<int>::max(), 40, false);
 conky::range_config_setting<int> default_gauge_height(
     "default_gauge_height", 0, std::numeric_limits<int>::max(), 25, false);
+
+conky::simple_config_setting<bool> store_graph_data_explicitly(
+    "store_graph_data_explicitly", true, true);
 #endif /* BUILD_GUI */
 
 conky::simple_config_setting<std::string> console_graph_ticks(
@@ -596,11 +599,15 @@ void new_graph(struct text_object *obj, char *buf, int buf_max_size,
   }
 #endif
 
-  if (s->graph) { s->graph = retrieve_graph(g->id, s->graph_width); }
+  if (store_graph_data_explicitly.get(*state)) {
+    if (s->graph) { s->graph = retrieve_graph(g->id, s->graph_width); }
 
-  graph_append(s, val, g->flags);
+    graph_append(s, val, g->flags);
 
-  store_graph(g->id, s);
+    store_graph(g->id, s);
+  } else {
+    graph_append(s, val, g->flags);
+  }
 
   if (out_to_stdout.get(*state)) { new_graph_in_shell(s, buf, buf_max_size); }
 }


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [x] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description
Hello,

This option (store_graph_data_explicitly) can be disabled to use graphs indirectly via execpi or lua_parse. Otherwise the graph stays empty (see https://github.com/brndnmtthws/conky/issues/1039 https://github.com/brndnmtthws/conky/issues/1109).
The default value is true to keep avoiding resets while using conditional colors (see https://github.com/brndnmtthws/conky/commit/594d0c85baff7e930ec4c9568690bb53d3cd5d2a).

I have tested the previous behavior with this config (see https://github.com/brndnmtthws/conky/issues/441#issuecomment-410746937, store_graph_data_explicitly not set (default true)). The config (see https://github.com/brndnmtthws/conky/issues/1109#issuecomment-983818042) is not empty after setting store_graph_data_explicitly = false.

Thanks in advance.