### PR TITLE
Fix warning caused by nonsense `break` condition

### DIFF
--- a/src/linux.cc
+++ b/src/linux.cc
@@ -578,11 +578,9 @@ void update_net_interfaces(FILE *net_dev_fp, bool is_first_update,
     for (unsigned int k = 0; k < conf.ifc_len / sizeof(struct ifreq); k++) {
       struct net_stat *ns2;
 
-      if (!(((struct ifreq *)conf.ifc_buf) + k)) break;
-
-      ns2 = get_net_stat(((struct ifreq *)conf.ifc_buf)[k].ifr_ifrn.ifrn_name,
+      ns2 = get_net_stat(conf.ifc_req[k].ifr_ifrn.ifrn_name,
                          nullptr, NULL);
-      ns2->addr = ((struct ifreq *)conf.ifc_buf)[k].ifr_ifru.ifru_addr;
+      ns2->addr = conf.ifc_req[k].ifr_ifru.ifru_addr;
       char temp_addr[18];
       snprintf(temp_addr, sizeof(temp_addr), "%u.%u.%u.%u, ",
                ns2->addr.sa_data[2] & 255, ns2->addr.sa_data[3] & 255,


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [ ] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

This fixes a warning that appeared with `cmake .. -DMAINTAINER_MODE=ON` on Linux:
```
[1/4] Building CXX object src/CMakeFiles/conky_core.dir/linux.cc.o
FAILED: src/CMakeFiles/conky_core.dir/linux.cc.o 
/usr/bin/c++ -D_LARGEFILE64_SOURCE -D_POSIX_C_SOURCE=200809L -I3rdparty/toluapp/include -Ibuild-maint -I/usr/include/freetype2 -Ibuild-maint/data -ggdb -Wall -W -Wextra -Wunused -pedantic -Werror -Wno-format -Wno-unknown-pragmas -Wno-error=pragmas -Wimplicit-fallthrough=2 -std=c++17 -MD -MT src/CMakeFiles/conky_core.dir/linux.cc.o -MF src/CMakeFiles/conky_core.dir/linux.cc.o.d -o src/CMakeFiles/conky_core.dir/linux.cc.o -c src/linux.cc
src/linux.cc: In function 'void update_net_interfaces(FILE*, bool, double)':
src/linux.cc:581:44: error: comparing the result of pointer addition '(((ifreq*)conf.ifconf::ifc_ifcu.ifconf::<unnamed union>::ifcu_buf) + ((sizetype)(((long unsigned int)k) * 40)))' and NULL [-Werror=address]
  581 |       if (!(((struct ifreq *)conf.ifc_buf) + k)) break;
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
cc1plus: all warnings being treated as errors
ninja: build stopped: subcommand failed.
```

The commit message explains why the warning appeared and why the condition was never triggered (and was motivated by a condition that could not occur). Runtime behavior remains the same.

There are no relevant issues I could find, and this is just a fix for compilation, so no docs need to be changed.