### PR TITLE
Update doc/man/md.j2 about auto sensing config changes

### DIFF
--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -52,12 +52,12 @@ cmake -G Ninja                         \
   -DBUILD_WLAN=ON                      \
   -DBUILD_X11=ON                       \
   -DBUILD_XMMS2=ON                     \
-  -DCMAKE_INSTALL_PREFIX=/usr          \
+  -DCMAKE_INSTALL_PREFIX=./AppDir/usr  \
   "$REPO_ROOT"
 
 # build project and install files into AppDir
 ninja
-cmake --install AppDir --prefix "/usr"
+ninja install
 
 wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
 

--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -58,10 +58,10 @@ values:
   - name: adt746xfan
     desc: Fan speed from therm_adt746x.
   - name: alignc
+    default: 0
     desc: |-
       Align text to centre, with a shift of N (num) pixels. A
-      negative N (num) shifts to the right. Defaults to 0. So
-      a value of 0 is optional.
+      negative N (num) shifts to the right.
     args:
       - (num)
   - name: alignr

--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -58,7 +58,10 @@ values:
   - name: adt746xfan
     desc: Fan speed from therm_adt746x.
   - name: alignc
-    desc: Align text to centre.
+    desc: |-
+      Align text to centre, with a shift of N (num) pixels. A
+      negative N (num) shifts to the right. Defaults to 0. So
+      a value of 0 is optional.
     args:
       - (num)
   - name: alignr

--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -775,8 +775,11 @@ values:
     desc: |-
       Hwmon sensor from sysfs (Linux 2.6). Parameter dev can be:
       1. Number. e.g `1` means hwmon1.
-      2. Module name. e.g. `k10temp` means the first hwmon device whose module
-      name is `k10temp.
+      2. The way the name is stated by the appropriate 
+         `/sys/class/hwmon/*/name` file. Which might be slightly 
+         different compared to the output of the lsmod command.
+         e.g. `nct6793` means the first hwmon device which lsmod
+         reffers to as `nct6775`.
       3. Omitted. Then the first hwmon device (hwmon0) will be used.
 
       Parameter type is either `in` or `vol` meaning voltage; `fan` meaning fan;

--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -65,7 +65,10 @@ values:
     args:
       - (num)
   - name: alignr
-    desc: Right-justify text, with space of N.
+    default: 0
+    desc: |-
+      Right-justify text, with a shift of N (num) pixels. A
+      negative N (num) shifts to the right.
     args:
       - (num)
   - name: apcupsd

--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -68,7 +68,8 @@ values:
     default: 0
     desc: |-
       Right-justify text, with a shift of N (num) pixels. A
-      negative N (num) shifts to the right.
+      negative N (num) is accepted, and actually makes no
+      difference.
     args:
       - (num)
   - name: apcupsd


### PR DESCRIPTION
Partially fix bug #1301. 
Add to the man page that in many cases, if the user just waits a few seconds after a new configuration has been written to disk, conky is likely to sense its configuration has changed. And reload the new configuration automatically. 