### PR TITLE
Fix colors when Wayland and X11 backends coexist

### DIFF
--- a/src/colours.cc
+++ b/src/colours.cc
@@ -104,14 +104,14 @@ long manually_get_x11_color(const char *name) {
   unsigned short r, g, b;
   size_t len = strlen(name);
   if (OsLookupColor(-1, name, len, &r, &g, &b)) {
-    return 0x000000ff | ((r & 0xff) << 24) | ((g & 0xff) << 16) |
-           ((b & 0xff) << 8);
+    return 0xff000000 | ((r & 0xff) << 16) | ((g & 0xff) << 8) | (b & 0xff);
   }
   if (name[0] == '#') {
     name++;
     len--;
   }
   if (len == 6 || len == 8) {
+    bool skip_alpha = (len == 6);
     unsigned char argb[4] = {0xff, 0, 0, 0};
     for (size_t i = 0; i + 1 < len; i += 2) {
       int nib1 = hex_nibble_value(name[i]);
@@ -119,7 +119,7 @@ long manually_get_x11_color(const char *name) {
       if (nib1 < 0 || nib2 < 0) { goto err; }
       int val = (nib1 << 4) + nib2;
 
-      argb[3 - i / 2] = val;
+      argb[skip_alpha + i / 2] = val;
     }
     long out;
     memcpy(static_cast<void *>(&out), argb, 4);

--- a/src/display-wayland.cc
+++ b/src/display-wayland.cc
@@ -662,15 +662,15 @@ void display_output_wayland::cleanup() {
 }
 
 void display_output_wayland::set_foreground_color(long c) {
-#ifdef BUILD_ARGB
-  current_color = (c & ~0xff) | own_window_argb_value.get(*state);
-#else
   current_color = c;
+#ifdef BUILD_ARGB
+  uint8_t a = own_window_argb_value.get(*state);
+#else
+  uint8_t a = current_color >> 24;
 #endif /* BUILD_ARGB */
-  uint8_t r = current_color >> 24;
-  uint8_t g = current_color >> 16;
-  uint8_t b = current_color >> 8;
-  uint8_t a = current_color;
+  uint8_t r = current_color >> 16;
+  uint8_t g = current_color >> 8;
+  uint8_t b = current_color;
   if (global_window->cr) {
     cairo_set_source_rgba(global_window->cr, r / 255.0, g / 255.0, b / 255.0,
                           a / 255.0);
@@ -703,9 +703,9 @@ void display_output_wayland::draw_string_at(int x, int y, const char *s,
   adjust_coords(x, y);
   pango_layout_set_text(window->layout, s, strlen(s));
   cairo_save(window->cr);
-  uint8_t r = current_color >> 24;
-  uint8_t g = current_color >> 16;
-  uint8_t b = current_color >> 8;
+  uint8_t r = current_color >> 16;
+  uint8_t g = current_color >> 8;
+  uint8_t b = current_color;
   unsigned int a = pango_fonts[selected_font].font_alpha;
   cairo_set_source_rgba(global_window->cr, r / 255.0, g / 255.0, b / 255.0,
                         a / 65535.);
@@ -811,10 +811,10 @@ void display_output_wayland::clear_text(int exposures) {
 #endif
   }
 #endif
-  uint8_t r = color >> 24;
-  uint8_t g = color >> 16;
-  uint8_t b = color >> 8;
-  uint8_t a = color;
+  uint8_t a = color >> 24;
+  uint8_t r = color >> 16;
+  uint8_t g = color >> 8;
+  uint8_t b = color;
   cairo_set_source_rgba(window->cr, r / 255.0, g / 255.0, b / 255.0, a / 255.);
   cairo_set_operator(window->cr, CAIRO_OPERATOR_SOURCE);
   cairo_paint(window->cr);


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [n/a] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

This makes the Wayland backend use 32-bit ARGB (with alpha in MSB) to store colors. This matches the common case of 24-bit color under X11, but isn't strictly correct in general; for that, I think we need a larger refactor that introduces a backend-independent color representation, as our current representation depends on not just the backend but also the current screen and its X11 colormap (which includes current color depth).

The only observable impact of this change should be that it fixes #1352. Tested by toggling `out_to_wayland` in a config file where `out_to_x=true` is already present, in a build with both backends enabled.