### PR TITLE
Follow up to #1361

### DIFF
--- a/src/colours.cc
+++ b/src/colours.cc
@@ -121,8 +121,7 @@ long manually_get_x11_color(const char *name) {
 
       argb[skip_alpha + i / 2] = val;
     }
-    long out;
-    memcpy(static_cast<void *>(&out), argb, 4);
+    long out = (argb[0] << 24) | (argb[1] << 16) | (argb[2] << 8) | argb[3];
     return out;
   }
 err:


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [n/a] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

#1361 accidentally broke parsing of hex colors in Wayland-only builds; fix the incorrect colors that resulted.