### PR TITLE
cmake/config.h.in: Added missing BUILD_ prefix to #cmakedefine for MO…

### DIFF
--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -48,7 +48,7 @@
 
 #cmakedefine OWN_WINDOW 1
 
-#cmakedefine MOUSE_EVENTS 1
+#cmakedefine BUILD_MOUSE_EVENTS 1
 
 #cmakedefine BUILD_XDAMAGE 1
 


### PR DESCRIPTION
…USE_EVENTS

Mouse events were introduced by commit 7fbdfbd4d45a99b06def7065d66e02337323066d which states in the commit message that MOUSE_EVENTS was also renamed to BUILD_MOUSE_EVENTS. However, this renamal seems to have been incomplete, as the respective option in cmake/config.h.in was left to MOUSE_EVENTS. This commit fixes this.

Closes: https://github.com/brndnmtthws/conky/issues/1380
Signed-off-by: Jaak Ristioja <jaak@ristioja.ee>

# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [ ] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

* Describe the changes, why they were necessary, etc
* Describe how the changes will affect existing behaviour.
* Describe how you tested and validated your changes.
* Include any relevant screenshots/evidence demonstrating that the changes work and have been tested.
