### PR TITLE
Premultiply background colors for X11

### DIFF
--- a/src/colours.h
+++ b/src/colours.h
@@ -57,27 +57,35 @@ public:
   static Colour from_argb32(uint32_t argb);
 
 #ifdef BUILD_X11
-  unsigned long to_x11_color(Display *display, int screen) {
-    if(display == nullptr) {
+  unsigned long to_x11_color(Display *display, int screen,
+                             bool premultiply = false) {
+    if (display == nullptr) {
       /* cannot work if display is not open */
       return 0;
     }
 
-    XColor xcolor;
-    xcolor.pixel = 0;
+    XColor xcolor{};
     xcolor.red = red * 257;
     xcolor.green = green * 257;
     xcolor.blue = blue * 257;
     if (XAllocColor(display, DefaultColormap(display, screen), &xcolor) == 0) {
-      //NORM_ERR("can't allocate X color");
+      // NORM_ERR("can't allocate X color");
       return 0;
     }
 
-    return static_cast<unsigned long>(xcolor.pixel);
+    unsigned long pixel = static_cast<unsigned long>(xcolor.pixel) & 0xffffff;
+#ifdef BUILD_ARGB
+    if (have_argb_visual) {
+      if (premultiply)
+        pixel = (red * alpha / 255) << 16 | (green * alpha / 255) << 8 |
+                (blue * alpha / 255);
+      pixel |= ((unsigned long)alpha << 24);
+    }
+#endif /* BUILD_ARGB */
+    return pixel;
   }
 #endif /* BUILD_X11 */
 };
-
 
 extern Colour error_colour;
 

--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -642,8 +642,8 @@ int display_output_x11::calc_text_width(const char *s) {
 void display_output_x11::draw_string_at(int x, int y, const char *s, int w) {
 #ifdef BUILD_XFT
   if (use_xft.get(*state)) {
-    XColor c;
-    XftColor c2;
+    XColor c{};
+    XftColor c2{};
 
     c.pixel = current_color.to_x11_color(display, screen);
     // query color on custom colormap

--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -606,14 +606,10 @@ void display_output_x11::cleanup() {
 }
 
 void display_output_x11::set_foreground_color(Colour c) {
+  current_color = c;
 #ifdef BUILD_ARGB
   if (have_argb_visual) {
-    current_color = c;
     current_color.alpha = own_window_argb_value.get(*state);
-  } else {
-#endif /* BUILD_ARGB */
-    current_color = c;
-#ifdef BUILD_ARGB
   }
 #endif /* BUILD_ARGB */
   XSetForeground(display, window.gc, current_color.to_x11_color(display, screen));

--- a/src/gui.cc
+++ b/src/gui.cc
@@ -41,10 +41,6 @@
 #include <iostream>
 #endif
 
-#ifdef BUILD_ARGB
-bool have_argb_visual;
-#endif /* BUILD_ARGB */
-
 /* basic display attributes */
 int display_width;
 int display_height;

--- a/src/gui.h
+++ b/src/gui.h
@@ -29,14 +29,9 @@
 #include "x11.h"
 #endif /* BUILD_X11 */
 
+#include "colour-settings.h"
 #include "colours.h"
 #include "setting.hh"
-#include "colour-settings.h"
-
-#if defined(BUILD_ARGB) && defined(OWN_WINDOW)
-/* true if use_argb_visual=true and argb visual was found*/
-extern bool have_argb_visual;
-#endif
 
 #ifdef BUILD_X11
 extern Display *display;

--- a/src/x11.cc
+++ b/src/x11.cc
@@ -515,6 +515,7 @@ void x11_init_window(lua::state &l __attribute__((unused)), bool own) {
       depth = CopyFromParent;
       visual = CopyFromParent;
 #ifdef BUILD_ARGB
+      have_argb_visual = false;
     }
 #endif /* BUILD_ARGB */
 

--- a/src/x11.cc
+++ b/src/x11.cc
@@ -68,6 +68,10 @@ Display *display = nullptr;
 /* Window stuff */
 struct conky_x11_window window;
 
+#ifdef BUILD_ARGB
+bool have_argb_visual;
+#endif /* BUILD_ARGB */
+
 conky::simple_config_setting<std::string> display_name("display", std::string(),
                                                        false);
 

--- a/src/x11.cc
+++ b/src/x11.cc
@@ -409,7 +409,7 @@ namespace {
 void do_set_background(Window win, uint8_t alpha) {
   Colour colour = background_colour.get(*state);
   colour.alpha = alpha;
-  unsigned long xcolor = colour.to_x11_color(display, screen);
+  unsigned long xcolor = colour.to_x11_color(display, screen, true);
   XSetWindowBackground(display, win, xcolor);
 }
 }  // namespace

--- a/src/x11.h
+++ b/src/x11.h
@@ -37,8 +37,12 @@
 #include <X11/extensions/Xdbe.h>
 #endif
 
-#include "colours.h"
 #include "setting.hh"
+
+#ifdef BUILD_ARGB
+/* true if use_argb_visual=true and argb visual was found*/
+extern bool have_argb_visual;
+#endif /* BUILD_ARGB */
 
 #define ATOM(a) XInternAtom(display, #a, False)
 


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [n/a] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

Fixes #1416. Tested with the following config on both Wayland and X11 builds:
```
conky.config = {
	alignment='bottom_middle',
	background=false,
	border_width=1,
	cpu_avg_samples=2,
	draw_borders=true,
	draw_shades=true,
	double_buffer=true,
	out_to_x=true,
	out_to_wayland=true,
	own_window=true,
	own_window_transparent=false,
	own_window_colour='ffffff',
	own_window_class='Conky',
	own_window_type='desktop',
	own_window_argb_visual=true,
	own_window_argb_value = 182,
	update_interval=1.0,
	use_xft=true,
	font="Sans:size=8",
	default_color='efefef',
	default_shade_color='black',
	color1='ffffff',
}
conky.text = 
[[
test${alignr}test
${color1}${font Sans:size=8:bold}$nodename [$sysname $kernel $machine]$font
]]
```