### PR TITLE
colours: cache X11 pixel values

### DIFF
--- a/src/colours.cc
+++ b/src/colours.cc
@@ -31,6 +31,10 @@
 #include "logging.h"
 #include "x11-color.h"
 
+#ifdef BUILD_X11
+std::unordered_map<Colour, unsigned long, Colour::Hash> Colour::x11_pixels;
+#endif /* BUILD_X11 */
+
 static int hex_nibble_value(char c) {
   if (c >= '0' && c <= '9') {
     return c - '0';


### PR DESCRIPTION
Fixes #1442.

# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [n/a] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

This adds an `unordered_map` keeping track of the X11 pixel values for X11 colors we've allocated. The original design allocated X11 colors at parsing time and represented colors with pixel values everywhere. Now that we represent colors in a backend-independent way, we allocate X11 colors when we set the color in the backend. This means that we reallocate colors every time we draw, which creates a leak of X resources that the server has to track. To avoid this, we can simply cache the X11 pixel values we create, fixing the observed performance regression and server-side memory growth.

I tested this under XWayland against the conkyrc from #1442, after modifying the update_interval from 1.0 to 0.01 in order to speed up the resource leak. I first reproduced the memory leak and then verified that it no longer occurs with this patch.