### PR TITLE
Fix and test graph parsing

### DIFF
--- a/src/common.cc
+++ b/src/common.cc
@@ -352,10 +352,7 @@ void print_no_update(struct text_object *obj, char *p,
 
 #ifdef BUILD_GUI
 void scan_loadgraph_arg(struct text_object *obj, const char *arg) {
-  char *buf = nullptr;
-
-  buf = scan_graph(obj, arg, 0);
-  free_and_zero(buf);
+  scan_graph(obj, arg, 0);
 }
 
 double loadgraphval(struct text_object *obj) {

--- a/src/core.cc
+++ b/src/core.cc
@@ -725,11 +725,9 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   DBGP2("Adding $cpubar for CPU %d", obj->data.i);
 #ifdef BUILD_GUI
   END OBJ(cpugraph, &update_cpu_usage) get_cpu_count();
-  char *buf = nullptr;
   SCAN_CPU(arg, obj->data.i);
-  buf = scan_graph(obj, arg, 1);
+  scan_graph(obj, arg, 1);
   DBGP2("Adding $cpugraph for CPU %d", obj->data.i);
-  free_and_zero(buf);
   obj->callbacks.graphval = &cpu_barval;
   obj->callbacks.free = &free_cpu;
   END OBJ(loadgraph, &update_load_average) scan_loadgraph_arg(obj, arg);
@@ -1244,13 +1242,9 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ(memwithbuffersbar, &update_meminfo) scan_bar(obj, arg, 1);
   obj->callbacks.barval = &mem_with_buffers_barval;
 #ifdef BUILD_GUI
-  END OBJ(memgraph, &update_meminfo) char *buf = nullptr;
-  buf = scan_graph(obj, arg, 1);
-  free_and_zero(buf);
+  END OBJ(memgraph, &update_meminfo) scan_graph(obj, arg, 1);
   obj->callbacks.graphval = &mem_barval;
-  END OBJ(memwithbuffersgraph, &update_meminfo) char *buf = nullptr;
-  buf = scan_graph(obj, arg, 1);
-  free_and_zero(buf);
+  END OBJ(memwithbuffersgraph, &update_meminfo) scan_graph(obj, arg, 1);
   obj->callbacks.graphval = &mem_with_buffers_barval;
 #endif /* BUILD_GUI*/
 #ifdef HAVE_SOME_SOUNDCARD_H
@@ -1829,8 +1823,9 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ_ARG(
       lua_graph, nullptr,
       "lua_graph needs arguments: <function name> [height],[width] [gradient "
-      "colour 1] [gradient colour 2] [scale] [-t] [-l]") char *buf = nullptr;
-  buf = scan_graph(obj, arg, 100);
+      "colour 1] [gradient colour 2] [scale] [-t] [-l]") auto [buf, skip] =
+      scan_command(arg);
+  scan_graph(obj, arg + skip, 100);
   if (buf != nullptr) {
     obj->data.s = buf;
   } else {
@@ -1967,9 +1962,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ(apcupsd_loadbar, &update_apcupsd) scan_bar(obj, arg, 100);
   obj->callbacks.barval = &apcupsd_loadbarval;
 #ifdef BUILD_GUI
-  END OBJ(apcupsd_loadgraph, &update_apcupsd) char *buf = nullptr;
-  buf = scan_graph(obj, arg, 100);
-  free_and_zero(buf);
+  END OBJ(apcupsd_loadgraph, &update_apcupsd) scan_graph(obj, arg, 100);
   obj->callbacks.graphval = &apcupsd_loadbarval;
   END OBJ(apcupsd_loadgauge, &update_apcupsd) scan_gauge(obj, arg, 100);
   obj->callbacks.gaugeval = &apcupsd_loadbarval;

--- a/src/diskio.cc
+++ b/src/diskio.cc
@@ -172,8 +172,8 @@ void print_diskio_write(struct text_object *obj, char *p,
 
 #ifdef BUILD_GUI
 void parse_diskiograph_arg(struct text_object *obj, const char *arg) {
-  char *buf = nullptr;
-  buf = scan_graph(obj, arg, 0);
+  auto [buf, skip] = scan_command(arg);
+  scan_graph(obj, arg + skip, 0);
 
   obj->data.opaque = prepare_diskio_stat(dev_name(buf));
   free_and_zero(buf);

--- a/src/exec.cc
+++ b/src/exec.cc
@@ -274,7 +274,9 @@ void scan_exec_arg(struct text_object *obj, const char *arg,
   } else if ((execflag & EF_GAUGE) != 0u) {
     cmd = scan_gauge(obj, cmd, 100);
   } else if ((execflag & EF_GRAPH) != 0u) {
-    cmd = scan_graph(obj, cmd, 100);
+    auto [buf, skip] = scan_command(cmd);
+    scan_graph(obj, cmd + skip, 100);
+    cmd = buf;
     if (cmd == nullptr) {
       NORM_ERR("error parsing arguments to execgraph object");
     }

--- a/src/net_stat.cc
+++ b/src/net_stat.cc
@@ -333,8 +333,8 @@ void print_v6addrs(struct text_object *obj, char *p, unsigned int p_max_size) {
 void parse_net_stat_graph_arg(struct text_object *obj, const char *arg,
                               void *free_at_crash) {
   /* scan arguments and get interface name back */
-  char *buf = nullptr;
-  buf = scan_graph(obj, arg, 0);
+  auto [buf, skip] = scan_command(arg);
+  scan_graph(obj, arg + skip, 0);
 
   // default to DEFAULTNETDEV
   if (buf != nullptr) {

--- a/src/nvidia.cc
+++ b/src/nvidia.cc
@@ -454,9 +454,11 @@ int set_nvidia_query(struct text_object *obj, const char *arg,
     case BAR:
       arg = scan_bar(obj, arg, 100);
       break;
-    case GRAPH:
-      arg = scan_graph(obj, arg, 100);
-      break;
+    case GRAPH: {
+      auto [buf, skip] = scan_command(arg);
+      scan_graph(obj, arg + skip, 100);
+      arg = buf;
+    } break;
     case GAUGE:
       arg = scan_gauge(obj, arg, 100);
       break;

--- a/src/specials.cc
+++ b/src/specials.cc
@@ -298,6 +298,7 @@ char *scan_graph(struct text_object *obj, const char *args, double defscale) {
       return strndup(buf, text_buffer_size.get(*state));
     }
     g->scale = defscale;
+    /* [command] [height],[width] [color1] [color2] */
     if (sscanf(argstr, "%1023s %d,%d %s %s", buf, &g->height, &g->width,
                first_colour_name, last_colour_name) == 5) {
       apply_graph_colours(g, first_colour_name, last_colour_name);
@@ -307,6 +308,7 @@ char *scan_graph(struct text_object *obj, const char *args, double defscale) {
     buf[0] = '\0';
     g->height = default_graph_height.get(*state);
     g->width = default_graph_width.get(*state);
+    /* [color1] [color2] [scale] */
     if (sscanf(argstr, "%s %s %lf", first_colour_name, last_colour_name,
                &g->scale) == 3) {
       apply_graph_colours(g, first_colour_name, last_colour_name);
@@ -315,18 +317,21 @@ char *scan_graph(struct text_object *obj, const char *args, double defscale) {
                  : nullptr;
     }
     g->scale = defscale;
+    /* [color1] [color2] */
     if (sscanf(argstr, "%s %s", first_colour_name, last_colour_name) == 2) {
       apply_graph_colours(g, first_colour_name, last_colour_name);
       return *quoted_cmd != 0
                  ? strndup(quoted_cmd, text_buffer_size.get(*state))
                  : nullptr;
     }
+    /* [command] [color1] [color2] [scale] */
     if (sscanf(argstr, "%1023s %s %s %lf", buf, first_colour_name,
                last_colour_name, &g->scale) == 4) {
       apply_graph_colours(g, first_colour_name, last_colour_name);
       return strndup(buf, text_buffer_size.get(*state));
     }
     g->scale = defscale;
+    /* [command] [color1] [color2] */
     if (sscanf(argstr, "%1023s %s %s", buf, first_colour_name,
                last_colour_name) == 3) {
       apply_graph_colours(g, first_colour_name, last_colour_name);
@@ -336,17 +341,20 @@ char *scan_graph(struct text_object *obj, const char *args, double defscale) {
     buf[0] = '\0';
     first_colour_name[0] = '\0';
     last_colour_name[0] = '\0';
+    /* [height],[width] [scale] */
     if (sscanf(argstr, "%d,%d %lf", &g->height, &g->width, &g->scale) == 3) {
       return *quoted_cmd != 0
                  ? strndup(quoted_cmd, text_buffer_size.get(*state))
                  : nullptr;
     }
     g->scale = defscale;
+    /* [height],[width] */
     if (sscanf(argstr, "%d,%d", &g->height, &g->width) == 2) {
       return *quoted_cmd != 0
                  ? strndup(quoted_cmd, text_buffer_size.get(*state))
                  : nullptr;
     }
+    /* [command] [height],[width] [scale] */
     if (sscanf(argstr, "%1023s %d,%d %lf", buf, &g->height, &g->width,
                &g->scale) < 4) {
       g->scale = defscale;

--- a/src/specials.cc
+++ b/src/specials.cc
@@ -257,8 +257,8 @@ bool scan_graph(struct text_object *obj, const char *argstr, double defscale) {
   memset(g, 0, sizeof(struct graph));
   obj->special_data = g;
 
-  /* zero width means all space that is available */
   g->id = ++graph_count;
+  /* zero width means all space that is available */
   g->width = default_graph_width.get(*state);
   g->height = default_graph_height.get(*state);
   g->colours_set = false;
@@ -269,22 +269,22 @@ bool scan_graph(struct text_object *obj, const char *argstr, double defscale) {
 
   if (argstr == nullptr) return false;
 
-  /* set tempgrad to true, if '-t' specified.
-   * It doesn#t matter where the argument is exactly. */
+  /* set tempgrad to true if '-t' specified.
+   * It doesn't matter where the argument is exactly. */
   if ((strstr(argstr, " " TEMPGRAD) != nullptr) ||
       strncmp(argstr, TEMPGRAD, strlen(TEMPGRAD)) == 0) {
     g->tempgrad = TRUE;
   }
-  /* set showlog-flag, if '-l' specified
-   * It doesn#t matter where the argument is exactly. */
+  /* set showlog flag if '-l' specified.
+   * It doesn't matter where the argument is exactly. */
   if ((strstr(argstr, " " LOGGRAPH) != nullptr) ||
       strncmp(argstr, LOGGRAPH, strlen(LOGGRAPH)) == 0) {
     g->flags |= SF_SHOWLOG;
   }
 
   /* all the following functions try to interpret the beginning of a
-   * a string with different formaters. If successfully the return from
-   * this whole function */
+   * a string with different format strings. If successful, they return from
+   * the function */
 
   /* interpret the beginning(!) of the argument string as:
    * '[height],[width] [color1] [color2] [scale]'

--- a/src/specials.h
+++ b/src/specials.h
@@ -29,6 +29,7 @@
 #ifndef _SPECIALS_H
 #define _SPECIALS_H
 
+#include <tuple>
 #include "colours.h"
 
 /* special stuff in text_buffer */
@@ -92,7 +93,8 @@ const char *scan_bar(struct text_object *, const char *, double);
 const char *scan_gauge(struct text_object *, const char *, double);
 #ifdef BUILD_GUI
 void scan_font(struct text_object *, const char *);
-char *scan_graph(struct text_object *, const char *, double);
+std::pair<char *, size_t> scan_command(const char *);
+bool scan_graph(struct text_object *, const char *, double);
 void scan_tab(struct text_object *, const char *);
 void scan_stippled_hr(struct text_object *, const char *);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(test_srcs ${test_srcs} test-core.cc)
 set(test_srcs ${test_srcs} test-diskio.cc)
 set(test_srcs ${test_srcs} test-fs.cc)
 set(test_srcs ${test_srcs} test-gradient.cc)
+set(test_srcs ${test_srcs} test-graph.cc)
 set(test_srcs ${test_srcs} test-colours.cc)
 
 add_executable(test-conky test-common.cc ${test_srcs})

--- a/tests/test-graph.cc
+++ b/tests/test-graph.cc
@@ -1,0 +1,205 @@
+/*
+ *
+ * Conky, a system monitor, based on torsmo
+ *
+ * Any original torsmo code is licensed under the BSD license
+ *
+ * All code written since the fork of torsmo is licensed under the GPL
+ *
+ * Please see COPYING for details
+ *
+ * Copyright (c) 2005-2021 Brenden Matthews, Philip Kovacs, et. al.
+ *	(see AUTHORS)
+ * All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <tuple>
+#include "catch2/catch.hpp"
+#include "conky.h"
+#include "lua-config.hh"
+#include "specials.h"
+
+#ifdef BUILD_GUI
+
+#define SF_SHOWLOG (1 << 1)
+
+// Specific value doesn't matter, but we check if the same one comes back
+constexpr double default_scale = M_PI;
+
+constexpr double default_width = 0;
+constexpr double default_height = 25;
+
+struct graph {
+  int id;
+  char flags;
+  int width, height;
+  bool colours_set;
+  Colour first_colour, last_colour;
+  double scale;
+  char tempgrad;
+};
+
+static std::pair<struct graph, char *> test_parse(const char *s) {
+  struct text_object obj;
+  char *command = scan_graph(&obj, s, default_scale);
+  auto g = static_cast<struct graph *>(obj.special_data);
+  struct graph graph = *g;
+  free(g);
+  return {graph, command};
+}
+
+std::string unquote(const std::string &s) {
+  auto out = s;
+  out.erase(remove(out.begin(), out.end(), '\"'), out.end());
+  return out;
+}
+
+TEST_CASE("scan_graph correctly parses input strings") {
+  state = std::make_unique<lua::state>();
+  conky::export_symbols(*state);
+
+  SECTION("Trivial parse") {
+    auto [g, command] = test_parse("");
+
+    REQUIRE(g.width == default_width);
+    REQUIRE(g.height == default_height);
+  }
+
+  /* test parsing combinations of options */
+  const char *command_options[] = {"\"foo bar\"", "\"ls -t\"", "foo-test", ""};
+  const char *size_options[][2] = {{"30", "500"}, {"80", ""}, {"", ""}};
+  const char *color_options[][2] = {{"orange", "blue"},
+                                    {"#deadff", "#392014"},
+                                    {"000000", "000000"},
+                                    {"", ""}};
+  const char *scale_options[] = {"0.5", ""};
+
+  SECTION(
+      "subset of [command] [height,width] [color1 color2] [scale] [-t] [-l]") {
+    for (auto command : command_options) {
+      for (auto size : size_options) {
+        for (auto colors : color_options) {
+          for (auto scale : scale_options) {
+            bool ends_at_first_size = false;
+
+            /* build an argument string by combining the selected options */
+            std::string s;
+            s += command;
+            s += " ";
+            if (*size[0] != '\0') {
+              s += size[0];
+              s += ",";
+              if (*size[1] == '\0') {
+                /* if the size is just a height, it has to be the end of the
+                 * argument string */
+                ends_at_first_size = true;
+              } else {
+                s += size[1];
+              }
+              s += " ";
+            }
+            if (!ends_at_first_size) {
+              s += colors[0];
+              s += " ";
+              s += colors[1];
+              s += " ";
+              s += scale;
+            }
+
+            /* parse the argument string */
+            auto [g, parsed_command] = test_parse(s.c_str());
+
+            printf("command: %s\n", s.c_str());
+
+            /* validate parsing of each component */
+            if (*command == '\0') {
+              REQUIRE(parsed_command == nullptr);
+            } else {
+              REQUIRE(parsed_command != nullptr);
+              REQUIRE(std::string(parsed_command) == unquote(command));
+            }
+
+            if (*size[0] == '\0') {
+              REQUIRE(g.width == default_width);
+              REQUIRE(g.height == default_height);
+            } else {
+              REQUIRE(g.height == atoi(size[0]));
+              REQUIRE(g.width == atoi(size[1]));
+            }
+
+            /* if second half of size is empty, no subsequent values should be
+             * set
+             */
+            if (ends_at_first_size) {
+              REQUIRE(g.colours_set == false);
+              continue;
+            }
+
+            if (*colors[0] == '\0') {
+              REQUIRE(g.colours_set == false);
+            } else {
+              REQUIRE(g.colours_set == true);
+              REQUIRE(g.first_colour == parse_color(colors[0]));
+              REQUIRE(g.last_colour == parse_color(colors[1]));
+            }
+
+            if (*scale == '\0') {
+              REQUIRE(g.scale == default_scale);
+            } else {
+              REQUIRE(g.scale == 0.5);
+            }
+
+            REQUIRE(g.flags == 0);
+            REQUIRE(g.tempgrad == 0);
+          }
+        }
+      }
+    }
+  }
+
+  SECTION("[height,width] [color1 color2] [scale] [-t] [-l]") {
+    auto [g, command] = test_parse("21,340 orange blue 0.5 -t -l");
+
+    REQUIRE(command == nullptr);
+    REQUIRE(g.width == 340);
+    REQUIRE(g.height == 21);
+    REQUIRE(g.colours_set == true);
+    REQUIRE(g.scale == 0.5);
+    REQUIRE(g.flags == SF_SHOWLOG);
+    REQUIRE(g.tempgrad == true);
+  }
+
+  SECTION("-t location") {
+    {
+      auto [g, command] = test_parse("\"ls -t\" 21,340 red blue 0.5");
+      REQUIRE(g.tempgrad == false);
+    }
+    {
+      auto [g, command] = test_parse("foo-test 21,340 red blue 0.5");
+      REQUIRE(g.tempgrad == false);
+    }
+    {
+      auto [g, command] = test_parse("foo-test -t 21,340 red blue 0.5");
+      REQUIRE(g.tempgrad == true);
+    }
+    {
+      auto [g, command] = test_parse("21,340 -t red blue 0.5");
+      REQUIRE(g.tempgrad == true);
+    }
+  }
+}
+
+#endif /* BUILD_GUI */

--- a/tests/test-graph.cc
+++ b/tests/test-graph.cc
@@ -202,4 +202,28 @@ TEST_CASE("scan_graph correctly parses input strings") {
   }
 }
 
+TEST_CASE("scan_command correctly parses input strings") {
+  SECTION("parse commands") {
+    const char *command_options[][2] = {{"\"foo bar\"", "foo bar"},
+                                        {"\"foo bar\"\tbaz", "foo bar"},
+                                        {"\"foo bar\"\nbaz", "foo bar"},
+                                        {"\"foo bar\" baz", "foo bar"},
+                                        {"one two", "one"},
+                                        {"\"ls -t\"", "ls -t"},
+                                        {"\"ls -t\" 4309", "ls -t"},
+                                        {"foo-test", "foo-test"},
+                                        {"foo-test a b c", "foo-test"},
+                                        {"", ""}};
+    for (auto [command, expected_parsed] : command_options) {
+      auto [parsed, len] = scan_command(command);
+      REQUIRE(std::string(parsed) == expected_parsed);
+      if (command[0] == '"') {
+        REQUIRE(len == strlen(expected_parsed) + 2);
+      } else {
+        REQUIRE(len == strlen(expected_parsed));
+      }
+    }
+  }
+}
+
 #endif /* BUILD_GUI */


### PR DESCRIPTION
Fixes #1428.

# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [x] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

First I did a couple cleanups (adding comments and moving an enveloping `if` into an early-return) to `scan_graph` to make it easier to read and edit. Then I reorganized the cases to correct the misparsing that was introduced in 5e98c49c. But I still wasn't happy with how the code looked, so I wanted to simplify it further. I added a test case that exercises the parser on its own, then separated out parsing of a quoted command prefix from `scan_graph`, as it's a separate concern and not all callers even accept a command prefix (and some consider one optional, such as the net graphs). This cuts the number of cases that `scan_graph` has to handle in half.

I tested against a few conkyrc files from #1428 to verify that this PR corrects the regression, but more testing would be appreciated as it seems this impacted quite a few people (sorry!). This PR shouldn't change any behavior other than fixing the bug, but because it does touch all users of graphs, it would be good to give it some fairly thorough testing.