### PR TITLE
gradients: fix saturation/luma calculations for 32-bit systems

### DIFF
--- a/src/gradient.cc
+++ b/src/gradient.cc
@@ -199,7 +199,7 @@ namespace {
 // Using Rec.2020 color space
 // Y' = 0.2627 x R + 0.6780 x G + 0.0593 x B
 long get_luma(long *const rgb) {
-  return 360L * (2627L * rgb[0] + 6780L * rgb[1] + 593L * rgb[2]) / 10000L;
+  return 360L * (uint64_t)(2627L * rgb[0] + 6780L * rgb[1] + 593L * rgb[2]) / 10000L;
 }
 
 // Using Rec.2020 color space

--- a/src/gradient.cc
+++ b/src/gradient.cc
@@ -156,7 +156,7 @@ void hsv_gradient_factory::convert_from_scaled_rgb(long *const scaled,
   auto value = get_value(scaled);
   auto minimum = get_minimum(scaled);
   auto chroma = value - minimum;
-  auto saturation = (SCALE360 * chroma) / value;
+  long saturation = (SCALE360 * (uint64_t)chroma) / value;
 
   target[0] = get_hue(scaled, chroma, value);
   target[1] = saturation;


### PR DESCRIPTION
This should fix #1463.

# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [n/a] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3
