### PR TITLE
colours: parse 3-digit colour specifications again

### DIFF
--- a/tests/test-colours.cc
+++ b/tests/test-colours.cc
@@ -4,6 +4,22 @@
 #include <config.h>
 
 TEST_CASE("parse_color correctly parses colours", "[colours][parse_color]") {
+  SECTION("parsing abbreviated hex color") {
+    auto colour = parse_color("#abc");
+    REQUIRE(colour.alpha == 255);
+    REQUIRE(colour.red == 0xaa);
+    REQUIRE(colour.green == 0xbb);
+    REQUIRE(colour.blue == 0xcc);
+  }
+
+  SECTION("parsing abbreviated hex color with alpha") {
+    auto colour = parse_color("#4abc");
+    REQUIRE(colour.alpha == 0x44);
+    REQUIRE(colour.red == 0xaa);
+    REQUIRE(colour.green == 0xbb);
+    REQUIRE(colour.blue == 0xcc);
+  }
+
   SECTION("parsing hex red") {
     auto colour = parse_color("#ff0000");
     REQUIRE(colour.alpha == 255);


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [n/a] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

Restores the ability to parse colors of the form `#xxx`. Includes a test of this and the four-character format with leading alpha.

Fixes #1478.