### PR TITLE
display-output: allow no outputs

### DIFF
--- a/src/display-output.cc
+++ b/src/display-output.cc
@@ -154,7 +154,7 @@ bool initialize_display_outputs() {
   if (active_display_outputs.size()) return true;
 
   std::cerr << "Unable to find a usable display output." << std::endl;
-  return false;
+  return true;
 }
 
 bool shutdown_display_outputs() {


### PR DESCRIPTION
Some users rely on this behavior, which quietly changed in 281097a2a562ef58e5604a3519f739c715ba5410.

Fixes #1479.

# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [n/a] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

This restores the old behavior prior to 281097a2a562ef58e5604a3519f739c715ba5410: we warn but do not exit when no display outputs are specified.