### PR TITLE
ncurses color fixes

### DIFF
--- a/src/core.cc
+++ b/src/core.cc
@@ -748,20 +748,18 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   obj->callbacks.graphval = &diskiographval_write;
 #endif /* BUILD_GUI */
   END OBJ(color, nullptr)
+  if (false
 #ifdef BUILD_GUI
-      if (out_to_gui(*state)) {
-    Colour c = arg != nullptr ? parse_color(arg) : default_color.get(*state);
-    obj->data.l = c.to_argb32();
-    set_current_text_color(c);
-  }
+  || out_to_gui(*state)
 #endif /* BUILD_GUI */
 #ifdef BUILD_NCURSES
-  if (out_to_ncurses.get(*state)) {
+  || out_to_ncurses.get(*state)
+#endif /* BUILD_NCURSES */
+) {
     Colour c = arg != nullptr ? parse_color(arg) : default_color.get(*state);
     obj->data.l = c.to_argb32();
     set_current_text_color(c);
   }
-#endif /* BUILD_NCURSES */
   obj->callbacks.print = &new_fg;
 #ifdef BUILD_GUI
   END OBJ(color0, nullptr) Colour c = color[0].get(*state);

--- a/src/display-ncurses.cc
+++ b/src/display-ncurses.cc
@@ -128,8 +128,8 @@ bool display_output_ncurses::shutdown() { return false; }
 
 void display_output_ncurses::set_foreground_color(Colour c) {
   int nccolor = to_ncurses(c);
-  init_pair(nccolor, nccolor, COLOR_BLACK);
-  attron(COLOR_PAIR(nccolor));
+  init_pair(nccolor+1, nccolor, COLOR_BLACK);
+  attron(COLOR_PAIR(nccolor+1));
 }
 
 void display_output_ncurses::begin_draw_text() {

--- a/src/specials.cc
+++ b/src/specials.cc
@@ -666,14 +666,16 @@ void new_stippled_hr(struct text_object *obj, char *p,
 #endif /* BUILD_GUI */
 
 void new_fg(struct text_object *obj, char *p, unsigned int p_max_size) {
+  if (false
 #ifdef BUILD_GUI
-  if (display_output() && display_output()->graphical()) {
-    new_special(p, FG)->arg = obj->data.l;
-  }
+  || (display_output() && display_output()->graphical())
 #endif /* BUILD_GUI */
 #ifdef BUILD_NCURSES
-  if (out_to_ncurses.get(*state)) { new_special(p, FG)->arg = obj->data.l; }
+  || out_to_ncurses.get(*state)
 #endif /* BUILD_NCURSES */
+  ) {
+    new_special(p, FG)->arg = obj->data.l;
+  }
   UNUSED(obj);
   UNUSED(p);
   UNUSED(p_max_size);


### PR DESCRIPTION
This fixes a couple bugs with ncurses display backend.

The first is that when both ncurses and a graphical backend are enabled at the same time, they each cause one "special" to be emitted for `${color}` objects, causing colors to be visually "doubled", e.g. lasting two lines of text instead of one. Instead, only emit a single special in the condition that ncurses or a graphical backend is enabled.

The second is that d51bf688bae4a682ff84aeb710d638f0987a742a mistakenly assumed that it was valid to call `init_pair` with a first argument of any ncurses color ID. In fact, the first argument of `init_pair` is a pair ID, and pair ID 0 is reserved; this contrasts with 0 as a color ID, which is black. To fix using black, use pair IDs offset by one from the corresponding color ID.

# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [n/a] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3
