### PR TITLE
gradient: initialize alpha when converting from rgb

### DIFF
--- a/src/gradient.cc
+++ b/src/gradient.cc
@@ -57,6 +57,7 @@ Colour gradient_factory::convert_to_rgb(long *const array) {
   c.red = scaled_rgb[0] / SCALE;
   c.green = scaled_rgb[1] / SCALE;
   c.blue = scaled_rgb[2] / SCALE;
+  c.alpha = 255;
 
   return c;
 }

--- a/tests/test-gradient.cc
+++ b/tests/test-gradient.cc
@@ -32,8 +32,11 @@
 #include <conky.h>
 #include <gradient.h>
 
+#include <iomanip>
+#include <iostream>
+
 const int width = 4;
-const Colour colour = Colour::from_argb32(0x996633);  // brown
+const Colour colour = Colour::from_argb32(0xff996633);  // brown
 const long expected_hue = 256;
 const long expected_value = 0x99;   // max(0x99, 0x66, 0x33)
 const long expected_chroma = 0x66;  // (0x99 - 0x33)
@@ -44,6 +47,15 @@ const long expected_green = 0x66;
 const long expected_blue = 0x33;
 
 const long full_scale = conky::gradient_factory::SCALE360;
+
+std::ostream& operator<<(std::ostream& s, const Colour& c) {
+  s << '#';
+  s << std::setfill('0');
+  s << std::setw(2);
+  s << std::setbase(16);
+  s << (int)c.alpha << (int)c.red << (int)c.green << (int)c.blue;
+  return s;
+}
 
 TEST_CASE("gradient_factory::convert_from_rgb returns correct value") {
 #ifdef BUILD_X11


### PR DESCRIPTION
Fixes #1485. We weren't initializing alpha when extracting colors from gradients.

# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [n/a] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3
