### PR TITLE
lua cairo: Add cairo_surface_create_for_rectangle

### DIFF
--- a/lua/cairo.pkg
+++ b/lua/cairo.pkg
@@ -706,6 +706,12 @@ const char *cairo_status_to_string(cairo_status_t status);
 cairo_surface_t *cairo_surface_create_similar(cairo_surface_t * other,
 		cairo_content_t content, int width, int height);
 
+cairo_surface_t *cairo_surface_create_for_rectangle (cairo_surface_t	*target,
+		double x,
+		double y,
+		double width,
+		double height);
+
 cairo_surface_t *cairo_surface_reference(cairo_surface_t * surface);
 
 void cairo_surface_finish(cairo_surface_t * surface);


### PR DESCRIPTION

# Checklist
- [X] I have described the changes
- [X] I have linked to any relevant GitHub issues, if applicable
- [ ] Documentation in `doc/` has been updated - Most of the lua api is undocumented.
- [X] All new code is licensed under GPLv3

## Description
Adds the function for cairo_surface_create_for_rectangle copied from the cairo header files. Personally I use this to ensure that Items can't draw outside there designated area. Sometimes for example with variable length text it is more desirable to cut off the end then render over something else. This function makes that easier.

I have tested this in a configuration i'm working on based off polycore, its probably not done enough to push anywhere yet though and it also requires some other changes that i'll send PR's for when they are more finalised. I figured seen as this is simple and isolated I may as well just send a PR through for it now.
