### PR TITLE
lua cairo: Add mesh patterns.

### DIFF
--- a/lua/cairo.pkg
+++ b/lua/cairo.pkg
@@ -108,7 +108,20 @@ typedef enum _cairo_status {
 	CAIRO_STATUS_NEGATIVE_COUNT,
 	CAIRO_STATUS_INVALID_CLUSTERS,
 	CAIRO_STATUS_INVALID_SLANT,
-	CAIRO_STATUS_INVALID_WEIGHT
+	CAIRO_STATUS_INVALID_WEIGHT,
+	CAIRO_STATUS_INVALID_SIZE,
+	CAIRO_STATUS_USER_FONT_NOT_IMPLEMENTED,
+	CAIRO_STATUS_DEVICE_TYPE_MISMATCH,
+	CAIRO_STATUS_DEVICE_ERROR,
+	CAIRO_STATUS_INVALID_MESH_CONSTRUCTION,
+	CAIRO_STATUS_DEVICE_FINISHED,
+	CAIRO_STATUS_JBIG2_GLOBAL_MISSING,
+	CAIRO_STATUS_PNG_ERROR,
+	CAIRO_STATUS_FREETYPE_ERROR,
+	CAIRO_STATUS_WIN32_GDI_ERROR,
+	CAIRO_STATUS_TAG_ERROR,
+
+	CAIRO_STATUS_LAST_STATUS
 } cairo_status_t;
 
 typedef enum _cairo_content {
@@ -839,7 +852,9 @@ typedef enum _cairo_pattern_type {
 	CAIRO_PATTERN_TYPE_SOLID,
 	CAIRO_PATTERN_TYPE_SURFACE,
 	CAIRO_PATTERN_TYPE_LINEAR,
-	CAIRO_PATTERN_TYPE_RADIAL
+	CAIRO_PATTERN_TYPE_RADIAL,
+	CAIRO_PATTERN_TYPE_MESH,
+    CAIRO_PATTERN_TYPE_RASTER_SOURCE
 } cairo_pattern_type_t;
 
 cairo_pattern_type_t cairo_pattern_get_type(cairo_pattern_t * pattern);
@@ -886,6 +901,46 @@ cairo_status_t cairo_pattern_get_linear_points(cairo_pattern_t * pattern,
 cairo_status_t cairo_pattern_get_radial_circles(cairo_pattern_t * pattern,
 		double *x0, double *y0, double *r0,
 		double *x1, double *y1, double *r1);
+
+cairo_pattern_t *cairo_pattern_create_mesh (void);
+
+void cairo_mesh_pattern_begin_patch (cairo_pattern_t *pattern);
+
+void cairo_mesh_pattern_end_patch (cairo_pattern_t *pattern);
+
+void cairo_mesh_pattern_curve_to (cairo_pattern_t *pattern,
+		double x1, double y1,
+		double x2, double y2,
+		double x3, double y3);
+
+void cairo_mesh_pattern_line_to (cairo_pattern_t *pattern,
+		double x, double y);
+
+void cairo_mesh_pattern_move_to (cairo_pattern_t *pattern,
+		double x, double y);
+
+void cairo_mesh_pattern_set_control_point (cairo_pattern_t *pattern,
+		unsigned int point_num, double x, double y);
+
+void cairo_mesh_pattern_set_corner_color_rgb (cairo_pattern_t *pattern,
+		unsigned int corner_num, double red, double green, double blue);
+
+void cairo_mesh_pattern_set_corner_color_rgba (cairo_pattern_t *pattern,
+		unsigned int corner_num, double red, double green, double blue,
+		double alpha);
+
+cairo_status_t cairo_mesh_pattern_get_patch_count (cairo_pattern_t *pattern,
+		unsigned int *count);
+
+cairo_path_t *cairo_mesh_pattern_get_path (cairo_pattern_t *pattern,
+		unsigned int patch_num);
+
+cairo_status_t cairo_mesh_pattern_get_corner_color_rgba (cairo_pattern_t *pattern,
+		unsigned int patch_num, unsigned int corner_num,
+		double *red, double *green, double *blue, double *alpha);
+
+cairo_status_t cairo_mesh_pattern_get_control_point (cairo_pattern_t *pattern,
+		unsigned int patch_num, unsigned int point_num, double *x, double *y);
 
 void cairo_matrix_init(cairo_matrix_t * matrix, double xx, double yx, double
 		xy, double yy, double x0, double y0);


### PR DESCRIPTION
# Description

Copied in the mesh pattern related functions from the upstream cairo.h file, also updated cairo_status_t and cairo_pattern_type_t to include an updated list as both have mesh related values

Fixes #912

![shot-2023-04-12_12-55-34](https://user-images.githubusercontent.com/3827011/231406965-c3fc6c04-cffb-48fa-bd5e-336dc25ece8c.jpg)

Enjoy all the Office 2000 word art options :-)

# Checklist
- [X] I have described the changes
- [X] I have linked to any relevant GitHub issues, if applicable
- [ ] Documentation in `doc/` has been updated - This part of the bindings isn't currently documented.
- [X] All new code is licensed under GPLv3


