### PR TITLE
top: do not print ${top mem 1} as inf if $mem not used

### DIFF
--- a/src/top.cc
+++ b/src/top.cc
@@ -388,6 +388,11 @@ static void process_find_top(struct process **cpu, struct process **mem,
 }
 
 int update_top() {
+  // if nothing else has ever set up info, we need to update it here, because
+  // info.memmax is used to print percentages in `print_top_mem`
+  if (info.memmax == 0) {
+    update_meminfo();
+  }
   process_find_top(info.cpu, info.memu, info.time
 #ifdef BUILD_IOSTATS
                    ,


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [n/a] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

This adds a call to `update_meminfo()` before attempting to update top processes, because they depend on the meminfo being sane. This fixes issue #960.

Tested with the below conkyrc:
```
conky.config = { 
    out_to_console = true,
    out_to_x = false,
    update_interval = 1,
} 
 
conky.text = [[
${color grey}Name              PID   CPU%   MEM%
${color lightgrey} ${top name 1} ${top pid 1} ${top cpu 1} ${top mem 1}
]]
```
