### PR TITLE
Clean up error handling

### DIFF
--- a/src/common.cc
+++ b/src/common.cc
@@ -365,7 +365,7 @@ double loadgraphval(struct text_object *obj) {
 uint8_t cpu_percentage(struct text_object *obj) {
   if (static_cast<unsigned int>(obj->data.i) > info.cpu_count) {
     NORM_ERR("obj->data.i %i info.cpu_count %i", obj->data.i, info.cpu_count);
-    CRIT_ERR(nullptr, nullptr, "attempting to use more CPUs than you have!");
+    CRIT_ERR("attempting to use more CPUs than you have!");
   }
   if (info.cpu_usage != nullptr) {
     return round_to_positive_int(info.cpu_usage[obj->data.i] * 100.0);
@@ -376,7 +376,7 @@ uint8_t cpu_percentage(struct text_object *obj) {
 double cpu_barval(struct text_object *obj) {
   if (static_cast<unsigned int>(obj->data.i) > info.cpu_count) {
     NORM_ERR("obj->data.i %i info.cpu_count %i", obj->data.i, info.cpu_count);
-    CRIT_ERR(nullptr, nullptr, "attempting to use more CPUs than you have!");
+    CRIT_ERR("attempting to use more CPUs than you have!");
   }
   if (info.cpu_usage != nullptr) { return info.cpu_usage[obj->data.i]; }
   return 0.;

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1828,7 +1828,7 @@ void main_loop() {
 
     llua_update_info(&info, active_update_interval());
   }
-  clean_up(nullptr, nullptr);
+  clean_up();
 
 #ifdef HAVE_SYS_INOTIFY_H
   if (inotify_fd != -1) {
@@ -1850,7 +1850,7 @@ static void reload_config() {
              current_config.c_str(), getpid());
     return;
   }
-  clean_up(nullptr, nullptr);
+  clean_up();
   state = std::make_unique<lua::state>();
   conky::export_symbols(*state);
   sleep(1); /* slight pause */
@@ -1868,10 +1868,8 @@ void free_specials(special_t *&current) {
   clear_stored_graphs();
 }
 
-void clean_up_without_threads(void *memtofree1, void *memtofree2) {
-  free_and_zero(memtofree1);
-  free_and_zero(memtofree2);
-
+void clean_up(void) {
+  /* free_update_callbacks(); XXX: some new equivalent of this? */
   free_and_zero(info.cpu_usage);
   for (auto output : display_outputs()) output->cleanup();
   conky::shutdown_display_outputs();
@@ -1909,11 +1907,6 @@ void clean_up_without_threads(void *memtofree1, void *memtofree2) {
 
   conky::cleanup_config_settings(*state);
   state.reset();
-}
-
-void clean_up(void *memtofree1, void *memtofree2) {
-  /* free_update_callbacks(); XXX: some new equivalent of this? */
-  clean_up_without_threads(memtofree1, memtofree2);
 }
 
 static void set_default_configurations() {

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1724,7 +1724,7 @@ void main_loop() {
 #ifdef SIGNAL_BLOCKING
     /* block signals.  we will inspect for pending signals later */
     if (sigprocmask(SIG_BLOCK, &newmask, &oldmask) < 0) {
-      CRIT_ERR(nullptr, NULL, "unable to sigprocmask()");
+      CRIT_ERR("unable to sigprocmask()");
     }
 #endif
 
@@ -1751,7 +1751,7 @@ void main_loop() {
 #ifdef SIGNAL_BLOCKING
     /* unblock signals of interest and let handler fly */
     if (sigprocmask(SIG_SETMASK, &oldmask, nullptr) < 0) {
-      CRIT_ERR(nullptr, NULL, "unable to sigprocmask()");
+      CRIT_ERR("unable to sigprocmask()");
     }
 #endif
 
@@ -2105,7 +2105,7 @@ void initialisation(int argc, char **argv) {
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
   if ((kd = kvm_open("/dev/null", "/dev/null", "/dev/null", O_RDONLY,
                      "kvm_open")) == nullptr) {
-    CRIT_ERR(nullptr, NULL, "cannot read kvm");
+    CRIT_ERR("cannot read kvm");
   }
 #endif
 
@@ -2133,8 +2133,7 @@ void initialisation(int argc, char **argv) {
       case 'm':
         state->pushinteger(strtol(optarg, &conv_end, 10));
         if (*conv_end != 0) {
-          CRIT_ERR(nullptr, nullptr, "'%s' is a wrong xinerama-head index",
-                   optarg);
+          CRIT_ERR("'%s' is a wrong xinerama-head index", optarg);
         }
         head_index.lua_set(*state);
         break;
@@ -2170,7 +2169,7 @@ void initialisation(int argc, char **argv) {
       case 'u':
         state->pushinteger(dpi_scale(strtol(optarg, &conv_end, 10)));
         if (*conv_end != 0) {
-          CRIT_ERR(nullptr, nullptr, "'%s' is a wrong update-interval", optarg);
+          CRIT_ERR("'%s' is a wrong update-interval", optarg);
         }
         update_interval.lua_set(*state);
         break;
@@ -2178,8 +2177,7 @@ void initialisation(int argc, char **argv) {
       case 'i':
         state->pushinteger(strtol(optarg, &conv_end, 10));
         if (*conv_end != 0) {
-          CRIT_ERR(nullptr, nullptr, "'%s' is a wrong number of update-times",
-                   optarg);
+          CRIT_ERR("'%s' is a wrong number of update-times", optarg);
         }
         total_run_times.lua_set(*state);
         break;
@@ -2187,8 +2185,7 @@ void initialisation(int argc, char **argv) {
       case 'x':
         state->pushinteger(strtol(optarg, &conv_end, 10));
         if (*conv_end != 0) {
-          CRIT_ERR(nullptr, nullptr, "'%s' is a wrong value for the X-position",
-                   optarg);
+          CRIT_ERR("'%s' is a wrong value for the X-position", optarg);
         }
         gap_x.lua_set(*state);
         break;
@@ -2196,8 +2193,7 @@ void initialisation(int argc, char **argv) {
       case 'y':
         state->pushinteger(strtol(optarg, &conv_end, 10));
         if (*conv_end != 0) {
-          CRIT_ERR(nullptr, nullptr, "'%s' is a wrong value for the Y-position",
-                   optarg);
+          CRIT_ERR("'%s' is a wrong value for the Y-position", optarg);
         }
         gap_y.lua_set(*state);
         break;
@@ -2259,7 +2255,7 @@ void initialisation(int argc, char **argv) {
   memset(tmpstring2, 0, text_buffer_size.get(*state));
 
   if (!conky::initialize_display_outputs()) {
-    CRIT_ERR(nullptr, nullptr, "initialize_display_outputs() failed.");
+    CRIT_ERR("initialize_display_outputs() failed.");
   }
 #ifdef BUILD_GUI
   /* setup lua window globals */

--- a/src/core.cc
+++ b/src/core.cc
@@ -382,10 +382,10 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   if (!strcmp(s, #a)) {  \
     obj->cb_handle = create_cb_handle(n);
 #define __OBJ_IF obj_be_ifblock_if(ifblock_opaque, obj)
-#define __OBJ_ARG(...)                         \
-  if (!arg) {                                  \
-    free(s);                                   \
-    CRIT_ERR(obj, free_at_crash, __VA_ARGS__); \
+#define __OBJ_ARG(...)                              \
+  if (!arg) {                                       \
+    free(s);                                        \
+    CRIT_ERR_FREE(obj, free_at_crash, __VA_ARGS__); \
   }
 
 /* defines to be used below */
@@ -1510,8 +1510,8 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ_IF(if_updatenr, nullptr) obj->data.i =
       arg != nullptr ? strtol(arg, nullptr, 10) : 0;
   if (obj->data.i == 0) {
-    CRIT_ERR(obj, free_at_crash,
-             "if_updatenr needs a number above 0 as argument");
+    CRIT_ERR_FREE(obj, free_at_crash,
+                  "if_updatenr needs a number above 0 as argument");
   }
   set_updatereset(obj->data.i > get_updatereset() ? obj->data.i
                                                   : get_updatereset());
@@ -1754,7 +1754,8 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   if (obj->data.i > 0) {
     ++obj->data.i;
   } else {
-    CRIT_ERR(obj, free_at_crash, "audacious_title: invalid length argument");
+    CRIT_ERR_FREE(obj, free_at_crash,
+                  "audacious_title: invalid length argument");
   }
   obj->callbacks.print = &print_audacious_title;
   END OBJ(audacious_length, 0) obj->callbacks.print = &print_audacious_length;
@@ -1811,9 +1812,9 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   if (arg != nullptr) {
     obj->data.s = STRNDUP_ARG;
   } else {
-    CRIT_ERR(obj, free_at_crash,
-             "lua_bar needs arguments: <height>,<width> <function name> "
-             "[function parameters]");
+    CRIT_ERR_FREE(obj, free_at_crash,
+                  "lua_bar needs arguments: <height>,<width> <function name> "
+                  "[function parameters]");
   }
   obj->callbacks.barval = &lua_barval;
   obj->callbacks.free = &gen_free_opaque;
@@ -1827,9 +1828,9 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   if (buf != nullptr) {
     obj->data.s = buf;
   } else {
-    CRIT_ERR(obj, free_at_crash,
-             "lua_graph needs arguments: <function name> [height],[width] "
-             "[gradient colour 1] [gradient colour 2] [scale] [-t] [-l]");
+    CRIT_ERR_FREE(obj, free_at_crash,
+                  "lua_graph needs arguments: <function name> [height],[width] "
+                  "[gradient colour 1] [gradient colour 2] [scale] [-t] [-l]");
   }
   obj->callbacks.graphval = &lua_barval;
   obj->callbacks.free = &gen_free_opaque;
@@ -1839,9 +1840,9 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   if (arg != nullptr) {
     obj->data.s = STRNDUP_ARG;
   } else {
-    CRIT_ERR(obj, free_at_crash,
-             "lua_gauge needs arguments: <height>,<width> <function name> "
-             "[function parameters]");
+    CRIT_ERR_FREE(obj, free_at_crash,
+                  "lua_gauge needs arguments: <height>,<width> <function name> "
+                  "[function parameters]");
   }
   obj->callbacks.gaugeval = &lua_barval;
   obj->callbacks.free = &gen_free_opaque;
@@ -1897,40 +1898,40 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ_ARG(
       nvidia, 0,
       "nvidia needs an argument") if (set_nvidia_query(obj, arg, NONSPECIAL)) {
-    CRIT_ERR(obj, free_at_crash,
-             "nvidia: invalid argument"
-             " specified: '%s'",
-             arg);
+    CRIT_ERR_FREE(obj, free_at_crash,
+                  "nvidia: invalid argument"
+                  " specified: '%s'",
+                  arg);
   }
   obj->callbacks.print = &print_nvidia_value;
   obj->callbacks.free = &free_nvidia;
   END OBJ_ARG(
       nvidiabar, 0,
       "nvidiabar needs an argument") if (set_nvidia_query(obj, arg, BAR)) {
-    CRIT_ERR(obj, free_at_crash,
-             "nvidiabar: invalid argument"
-             " specified: '%s'",
-             arg);
+    CRIT_ERR_FREE(obj, free_at_crash,
+                  "nvidiabar: invalid argument"
+                  " specified: '%s'",
+                  arg);
   }
   obj->callbacks.barval = &get_nvidia_barval;
   obj->callbacks.free = &free_nvidia;
   END OBJ_ARG(
       nvidiagraph, 0,
       "nvidiagraph needs an argument") if (set_nvidia_query(obj, arg, GRAPH)) {
-    CRIT_ERR(obj, free_at_crash,
-             "nvidiagraph: invalid argument"
-             " specified: '%s'",
-             arg);
+    CRIT_ERR_FREE(obj, free_at_crash,
+                  "nvidiagraph: invalid argument"
+                  " specified: '%s'",
+                  arg);
   }
   obj->callbacks.graphval = &get_nvidia_barval;
   obj->callbacks.free = &free_nvidia;
   END OBJ_ARG(
       nvidiagauge, 0,
       "nvidiagauge needs an argument") if (set_nvidia_query(obj, arg, GAUGE)) {
-    CRIT_ERR(obj, free_at_crash,
-             "nvidiagauge: invalid argument"
-             " specified: '%s'",
-             arg);
+    CRIT_ERR_FREE(obj, free_at_crash,
+                  "nvidiagauge: invalid argument"
+                  " specified: '%s'",
+                  arg);
   }
   obj->callbacks.gaugeval = &get_nvidia_barval;
   obj->callbacks.free = &free_nvidia;
@@ -1940,7 +1941,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
       apcupsd, &update_apcupsd,
       "apcupsd needs arguments: <host> <port>") if (apcupsd_scan_arg(arg) !=
                                                     0) {
-    CRIT_ERR(obj, free_at_crash, "apcupsd needs arguments: <host> <port>");
+    CRIT_ERR_FREE(obj, free_at_crash, "apcupsd needs arguments: <host> <port>");
   }
   obj->callbacks.print = &gen_print_nothing;
   END OBJ(apcupsd_name, &update_apcupsd) obj->callbacks.print =

--- a/src/darwin.mm
+++ b/src/darwin.mm
@@ -930,7 +930,7 @@ void get_cpu_count() {
      */
     info.cpu_usage =
         static_cast<float *>(malloc((info.cpu_count + 1) * sizeof(float)));
-    if (info.cpu_usage == nullptr) { CRIT_ERR(nullptr, nullptr, "malloc"); }
+    if (info.cpu_usage == nullptr) { CRIT_ERR("malloc"); }
   }
 }
 

--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -866,7 +866,7 @@ void display_output_x11::load_fonts(bool utf8) {
         continue;
       }
 
-      CRIT_ERR(nullptr, nullptr, "can't load Xft font '%s'", "courier-12");
+      CRIT_ERR("can't load Xft font '%s'", "courier-12");
 
       continue;
     }
@@ -883,7 +883,7 @@ void display_output_x11::load_fonts(bool utf8) {
         xfont.fontset = XCreateFontSet(display, "fixed", &missing, &missingnum,
                                        &missingdrawn);
         if (xfont.fontset == nullptr) {
-          CRIT_ERR(nullptr, nullptr, "can't load font '%s'", "fixed");
+          CRIT_ERR("can't load font '%s'", "fixed");
         }
       }
     }
@@ -892,7 +892,7 @@ void display_output_x11::load_fonts(bool utf8) {
         (xfont.font = XLoadQueryFont(display, font.name.c_str())) == nullptr) {
       NORM_ERR("can't load font '%s'", font.name.c_str());
       if ((xfont.font = XLoadQueryFont(display, "fixed")) == nullptr) {
-        CRIT_ERR(nullptr, nullptr, "can't load font '%s'", "fixed");
+        CRIT_ERR("can't load font '%s'", "fixed");
       }
     }
   }

--- a/src/dragonfly.cc
+++ b/src/dragonfly.cc
@@ -279,7 +279,7 @@ void get_cpu_count(void) {
   }
 
   info.cpu_usage = (float *)malloc((info.cpu_count + 1) * sizeof(float));
-  if (info.cpu_usage == nullptr) { CRIT_ERR(nullptr, NULL, "malloc"); }
+  if (info.cpu_usage == nullptr) { CRIT_ERR("malloc"); }
 }
 
 struct cpu_info {

--- a/src/freebsd.cc
+++ b/src/freebsd.cc
@@ -551,10 +551,9 @@ char get_freq(char *p_client_buffer, size_t client_buffer_size,
     return 0;
   }
 
-  freq_sysctl = (char *)calloc(16, sizeof(char));
-  if (freq_sysctl == nullptr) { exit(-1); }
+  char freq_sysctl[16] = {0};
 
-  snprintf(freq_sysctl, 16, "dev.cpu.%d.freq", (cpu - 1));
+  snprintf(freq_sysctl, sizeof(freq_sysctl), "dev.cpu.%d.freq", (cpu - 1));
 
   if (GETSYSCTL(freq_sysctl, freq) == 0) {
     snprintf(p_client_buffer, client_buffer_size, p_format,
@@ -563,7 +562,6 @@ char get_freq(char *p_client_buffer, size_t client_buffer_size,
     snprintf(p_client_buffer, client_buffer_size, p_format, 0.0f);
   }
 
-  free(freq_sysctl);
   return 1;
 }
 

--- a/src/freebsd.cc
+++ b/src/freebsd.cc
@@ -309,7 +309,7 @@ void get_cpu_count(void) {
   }
 
   info.cpu_usage = (float *)malloc((info.cpu_count + 1) * sizeof(float));
-  if (info.cpu_usage == nullptr) { CRIT_ERR(nullptr, NULL, "malloc"); }
+  if (info.cpu_usage == nullptr) { CRIT_ERR("malloc"); }
 }
 
 struct cpu_info {

--- a/src/fs.cc
+++ b/src/fs.cc
@@ -192,14 +192,14 @@ void get_fs_type(const char *path, char *result) {
     fseek(mtab, 0, SEEK_SET);
     slash = strrchr(search_path, '/');
     if (slash == nullptr) {
-      CRIT_ERR(NULL, NULL, "invalid path '%s'", path);
+      CRIT_ERR("invalid path '%s'", path);
     } else {
       if (strlen(slash) == 1) /* trailing slash */
         *(slash) = '\0';
       else if (strlen(slash) > 1)
         *(slash + 1) = '\0';
       else
-        CRIT_ERR(nullptr, NULL, "found a crack in the matrix!");
+        CRIT_ERR("found a crack in the matrix!");
     }
   } while (strlen(search_path) > 0);
   free(search_path);

--- a/src/haiku.cc
+++ b/src/haiku.cc
@@ -97,7 +97,7 @@ void get_cpu_count(void) {
   info.cpu_count = si.cpu_count;
 
   info.cpu_usage = (float *)malloc((info.cpu_count + 1) * sizeof(float));
-  if (info.cpu_usage == nullptr) { CRIT_ERR(nullptr, NULL, "malloc"); }
+  if (info.cpu_usage == nullptr) { CRIT_ERR("malloc"); }
 }
 
 int update_cpu_usage() {
@@ -117,14 +117,14 @@ int update_cpu_usage() {
 
   if (!prev_cpuinfo) {
     prev_cpuinfo = (cpu_info *)malloc(malloc_cpu_size);
-    if (prev_cpuinfo == nullptr) { CRIT_ERR(nullptr, NULL, "malloc"); }
+    if (prev_cpuinfo == nullptr) { CRIT_ERR("malloc"); }
     memset(prev_cpuinfo, 0, malloc_cpu_size);
   }
 
   cpuinfo = (cpu_info *)malloc(malloc_cpu_size);
   memset(cpuinfo, 0, malloc_cpu_size);
 
-  if (cpuinfo == nullptr) { CRIT_ERR(nullptr, NULL, "malloc"); }
+  if (cpuinfo == nullptr) { CRIT_ERR("malloc"); }
 
   now = system_time();
   if (get_cpu_info(0, info.cpu_count, &cpuinfo[1]) == B_OK) {

--- a/src/i8k.cc
+++ b/src/i8k.cc
@@ -139,7 +139,8 @@ void print_i8k_ac_status(struct text_object *obj, char *p,
   void print_i8k_##name(struct text_object *obj, char *p, \
                         unsigned int p_max_size) {        \
     (void)obj;                                            \
-    snprintf(p, p_max_size, "%s", i8k.name);              \
+    const char *str = i8k.name ? i8k.name : "error";      \
+    snprintf(p, p_max_size, "%s", str);                   \
   }
 
 I8K_PRINT_GENERATOR(version)

--- a/src/i8k.cc
+++ b/src/i8k.cc
@@ -64,7 +64,6 @@ int update_i8k(void) {
     NORM_ERR(
         "/proc/i8k doesn't exist! use insmod to make sure the kernel driver is "
         "loaded...");
-    clean_up_without_threads(nullptr, NULL);
     return 1;
   }
 

--- a/src/i8k.cc
+++ b/src/i8k.cc
@@ -56,17 +56,14 @@ static char *i8k_procbuf = nullptr;
 int update_i8k(void) {
   FILE *fp;
 
-  if (!i8k_procbuf) { i8k_procbuf = (char *)malloc(128 * sizeof(char)); }
   if ((fp = fopen(PROC_I8K, "r")) == nullptr) {
-    free_and_zero(i8k_procbuf);
-    /*THREAD_CRIT_ERR(nullptr, NULL, "/proc/i8k doesn't exist! use insmod to
-      make sure the kernel " "driver is loaded...");*/
     NORM_ERR(
         "/proc/i8k doesn't exist! use insmod to make sure the kernel driver is "
         "loaded...");
     return 1;
   }
 
+  if (!i8k_procbuf) { i8k_procbuf = (char *)malloc(128 * sizeof(char)); }
   memset(&i8k_procbuf[0], 0, 128);
   if (fread(&i8k_procbuf[0], sizeof(char), 128, fp) == 0) {
     NORM_ERR("something wrong with /proc/i8k...");

--- a/src/ibm.cc
+++ b/src/ibm.cc
@@ -93,10 +93,10 @@ void get_ibm_acpi_fan(struct text_object *obj, char *p,
       if (sscanf(line, "speed: %u", &speed)) { break; }
     }
   } else {
-    CRIT_ERR(nullptr, NULL,
-             "can't open '%s': %s\nYou are not using the IBM ACPI. Remove "
-             "ibm* from your " PACKAGE_NAME " config file.",
-             fan, strerror(errno));
+    CRIT_ERR(
+        "can't open '%s': %s\nYou are not using the IBM ACPI. Remove "
+        "ibm* from your " PACKAGE_NAME " config file.",
+        fan, strerror(errno));
   }
 
   fclose(fp);
@@ -144,10 +144,10 @@ int get_ibm_acpi_temps(void) {
       }
     }
   } else {
-    CRIT_ERR(nullptr, NULL,
-             "can't open '%s': %s\nYou are not using the IBM ACPI. Remove "
-             "ibm* from your " PACKAGE_NAME " config file.",
-             thermal, strerror(errno));
+    CRIT_ERR(
+        "can't open '%s': %s\nYou are not using the IBM ACPI. Remove "
+        "ibm* from your " PACKAGE_NAME " config file.",
+        thermal, strerror(errno));
   }
 
   fclose(fp);
@@ -191,10 +191,10 @@ void get_ibm_acpi_volume(struct text_object *obj, char *p,
       if (sscanf(line, "mute: %s", mute)) { break; }
     }
   } else {
-    CRIT_ERR(nullptr, NULL,
-             "can't open '%s': %s\nYou are not using the IBM ACPI. Remove "
-             "ibm* from your " PACKAGE_NAME " config file.",
-             volume, strerror(errno));
+    CRIT_ERR(
+        "can't open '%s': %s\nYou are not using the IBM ACPI. Remove "
+        "ibm* from your " PACKAGE_NAME " config file.",
+        volume, strerror(errno));
   }
 
   fclose(fp);
@@ -235,10 +235,10 @@ void get_ibm_acpi_brightness(struct text_object *obj, char *p,
       if (sscanf(line, "level: %u", &brightness)) { break; }
     }
   } else {
-    CRIT_ERR(nullptr, NULL,
-             "can't open '%s': %s\nYou are not using the IBM ACPI. Remove "
-             "ibm* from your " PACKAGE_NAME " config file.",
-             filename, strerror(errno));
+    CRIT_ERR(
+        "can't open '%s': %s\nYou are not using the IBM ACPI. Remove "
+        "ibm* from your " PACKAGE_NAME " config file.",
+        filename, strerror(errno));
   }
 
   fclose(fp);
@@ -275,10 +275,10 @@ void get_ibm_acpi_thinklight(struct text_object *obj, char *p,
       if (sscanf(line, "status: %s", thinklight)) { break; }
     }
   } else {
-    CRIT_ERR(nullptr, NULL,
-             "can't open '%s': %s\nYou are not using the IBM "
-             "ACPI. Remove ibm* from your " PACKAGE_NAME " config file.",
-             filename, strerror(errno));
+    CRIT_ERR(
+        "can't open '%s': %s\nYou are not using the IBM "
+        "ACPI. Remove ibm* from your " PACKAGE_NAME " config file.",
+        filename, strerror(errno));
   }
 
   fclose(fp);

--- a/src/ical.cc
+++ b/src/ical.cc
@@ -111,14 +111,14 @@ void parse_ical_args(struct text_object *obj, const char *arg,
   if (sscanf(arg, "%d %s", &num, filename) != 2) {
     free(filename);
     free(obj);
-    CRIT_ERR(free_at_crash, free_at_crash2,
-             "wrong number of arguments for $ical");
+    CRIT_ERR_FREE(free_at_crash, free_at_crash2,
+                  "wrong number of arguments for $ical");
   }
   file = fopen(filename, "r");
   if (!file) {
     free(obj);
     free(free_at_crash);
-    CRIT_ERR(filename, free_at_crash2, "Can't read file %s", filename);
+    CRIT_ERR_FREE(filename, free_at_crash2, "Can't read file %s", filename);
     return;
   }
   free(filename);

--- a/src/iconv_tools.cc
+++ b/src/iconv_tools.cc
@@ -44,9 +44,9 @@ static iconv_t **iconv_cd = 0;
 
 int register_iconv(iconv_t *new_iconv) {
   iconv_cd = (void ***)realloc(iconv_cd, sizeof(iconv_t *) * (iconv_count + 1));
-  if (!iconv_cd) { CRIT_ERR(nullptr, NULL, "Out of memory"); }
+  if (!iconv_cd) { CRIT_ERR("Out of memory"); }
   iconv_cd[iconv_count] = (void **)malloc(sizeof(iconv_t));
-  if (!iconv_cd[iconv_count]) { CRIT_ERR(nullptr, NULL, "Out of memory"); }
+  if (!iconv_cd[iconv_count]) { CRIT_ERR("Out of memory"); }
   memcpy(iconv_cd[iconv_count], new_iconv, sizeof(iconv_t));
   iconv_count++;
   return iconv_count;
@@ -110,12 +110,12 @@ void init_iconv_start(struct text_object *obj, void *free_at_crash,
   char iconv_to[ICONV_CODEPAGE_LENGTH];
 
   if (iconv_converting) {
-    CRIT_ERR(obj, free_at_crash,
-             "You must stop your last iconv conversion before "
-             "starting another");
+    CRIT_ERR_FREE(obj, free_at_crash,
+                  "You must stop your last iconv conversion before "
+                  "starting another");
   }
   if (sscanf(arg, "%s %s", iconv_from, iconv_to) != 2) {
-    CRIT_ERR(obj, free_at_crash, "Invalid arguments for iconv_start");
+    CRIT_ERR_FREE(obj, free_at_crash, "Invalid arguments for iconv_start");
   } else {
     iconv_t new_iconv;
 

--- a/src/journal.cc
+++ b/src/journal.cc
@@ -66,10 +66,11 @@ void init_journal(const char *type, const char *arg, struct text_object *obj,
   args = sscanf(arg, "%d %6s", &j->wantedlines, tmp.get());
   if (args < 1 || args > 2) {
     free_journal(obj);
-    CRIT_ERR(obj, free_at_crash,
-             "%s a number of lines as 1st argument and optionally a journal "
-             "type as 2nd argument",
-             type);
+    CRIT_ERR_FREE(
+        obj, free_at_crash,
+        "%s a number of lines as 1st argument and optionally a journal "
+        "type as 2nd argument",
+        type);
   }
   if (j->wantedlines > 0 && j->wantedlines <= MAX_JOURNAL_LINES) {
     if (args > 1) {
@@ -81,8 +82,9 @@ void init_journal(const char *type, const char *arg, struct text_object *obj,
 #endif /* SD_JOURNAL_CURRENT_USER */
       } else {
         free_journal(obj);
-        CRIT_ERR(obj, free_at_crash,
-                 "invalid arg for %s, type must be 'system' or 'user'", type);
+        CRIT_ERR_FREE(obj, free_at_crash,
+                      "invalid arg for %s, type must be 'system' or 'user'",
+                      type);
       }
     } else {
       NORM_ERR("You should type a 'user' or 'system' as an argument");
@@ -90,9 +92,10 @@ void init_journal(const char *type, const char *arg, struct text_object *obj,
 
   } else {
     free_journal(obj);
-    CRIT_ERR(obj, free_at_crash,
-             "invalid arg for %s, number of lines must be between 1 and %d",
-             type, MAX_JOURNAL_LINES);
+    CRIT_ERR_FREE(
+        obj, free_at_crash,
+        "invalid arg for %s, number of lines must be between 1 and %d", type,
+        MAX_JOURNAL_LINES);
   }
   obj->data.opaque = j;
 }

--- a/src/logging.h
+++ b/src/logging.h
@@ -61,7 +61,7 @@ class obj_create_error : public std::runtime_error {
   obj_create_error(const std::string &msg) : std::runtime_error(msg) {}
 };
 
-void clean_up(void *memtofree1, void *memtofree2);
+void clean_up(void);
 
 template <typename... Args>
 inline void gettextize_format(const char *format, Args &&...args) {
@@ -84,7 +84,9 @@ template <typename... Args>
 inline void CRIT_ERR(void *memtofree1, void *memtofree2, const char *format,
                      Args &&...args) {
   NORM_ERR(format, args...);
-  clean_up(memtofree1, memtofree2);
+  free(memtofree1);
+  free(memtofree2);
+  clean_up();
   exit(EXIT_FAILURE);
 }
 

--- a/src/logging.h
+++ b/src/logging.h
@@ -79,15 +79,21 @@ void NORM_ERR(const char *format, Args &&...args) {
   fputs("\n", stderr);
 }
 
-/* critical error */
+/* critical error with additional cleanup */
 template <typename... Args>
-inline void CRIT_ERR(void *memtofree1, void *memtofree2, const char *format,
-                     Args &&...args) {
+inline void CRIT_ERR_FREE(void *memtofree1, void *memtofree2,
+                          const char *format, Args &&...args) {
   NORM_ERR(format, args...);
   free(memtofree1);
   free(memtofree2);
   clean_up();
   exit(EXIT_FAILURE);
+}
+
+/* critical error */
+template <typename... Args>
+inline void CRIT_ERR(const char *format, Args &&...args) {
+  CRIT_ERR_FREE(nullptr, nullptr, format, args...);
 }
 
 namespace conky {

--- a/src/logging.h
+++ b/src/logging.h
@@ -62,7 +62,6 @@ class obj_create_error : public std::runtime_error {
 };
 
 void clean_up(void *memtofree1, void *memtofree2);
-void clean_up_without_threads(void *memtofree1, void *memtofree2);
 
 template <typename... Args>
 inline void gettextize_format(const char *format, Args &&...args) {
@@ -87,14 +86,6 @@ inline void CRIT_ERR(void *memtofree1, void *memtofree2, const char *format,
   NORM_ERR(format, args...);
   clean_up(memtofree1, memtofree2);
   exit(EXIT_FAILURE);
-}
-
-template <typename... Args>
-inline void THREAD_CRIT_ERR(void *memtofree1, void *memtofree2,
-                            const char *format, Args &&...args) {
-  NORM_ERR(format, args...);
-  clean_up_without_threads(memtofree1, memtofree2);
-  return;
 }
 
 namespace conky {

--- a/src/main.cc
+++ b/src/main.cc
@@ -359,7 +359,7 @@ int main(int argc, char **argv) {
     return EXIT_FAILURE;
   } catch (obj_create_error &e) {
     std::cerr << e.what() << std::endl;
-    clean_up(nullptr, nullptr);
+    clean_up();
     return EXIT_FAILURE;
   } catch (std::exception &e) {
     std::cerr << PACKAGE_NAME ": " << e.what() << std::endl;

--- a/src/main.cc
+++ b/src/main.cc
@@ -317,7 +317,7 @@ int main(int argc, char **argv) {
         break;
       case 'q':
         if (freopen("/dev/null", "w", stderr) == nullptr) {
-          CRIT_ERR(nullptr, nullptr, "could not open /dev/null as stderr!");
+          CRIT_ERR("could not open /dev/null as stderr!");
         }
         break;
       case 'h':

--- a/src/mboxscan.cc
+++ b/src/mboxscan.cc
@@ -137,10 +137,10 @@ static void mbox_scan(char *args, char *output, size_t max_len) {
       free(copy_args);
     }
     if (strlen(mbox_mail_spool) < 1) {
-      CRIT_ERR(nullptr, nullptr,
-               "Usage: ${mboxscan [-n <number of messages to print>] "
-               "[-fw <from width>] [-sw <subject width>] "
-               "[-t <delay in sec> mbox]}");
+      CRIT_ERR(
+          "Usage: ${mboxscan [-n <number of messages to print>] "
+          "[-fw <from width>] [-sw <subject width>] "
+          "[-t <delay in sec> mbox]}");
     }
 
     /* allowing $MAIL in the config */
@@ -150,8 +150,7 @@ static void mbox_scan(char *args, char *output, size_t max_len) {
     }
 
     if (stat(mbox_mail_spool, &statbuf) != 0) {
-      CRIT_ERR(nullptr, nullptr, "can't stat %s: %s", mbox_mail_spool,
-               strerror(errno));
+      CRIT_ERR("can't stat %s: %s", mbox_mail_spool, strerror(errno));
     }
     args_ok = 1; /* args-computing necessary only once */
   }

--- a/src/net_stat.cc
+++ b/src/net_stat.cc
@@ -530,7 +530,7 @@ int interface_up(struct text_object *obj) {
 #else
   if ((fd = socket(PF_INET, SOCK_DGRAM | SOCK_CLOEXEC, 0)) < 0) {
 #endif
-    CRIT_ERR(nullptr, nullptr, "could not create sockfd");
+    CRIT_ERR("could not create sockfd");
     return 0;
   }
   strncpy(ifr.ifr_name, dev, IFNAMSIZ);

--- a/src/nvidia.cc
+++ b/src/nvidia.cc
@@ -1150,10 +1150,10 @@ double get_nvidia_barval(struct text_object *obj) {
       case ATTR_FREQS_STRING:  // mtrfreq (calculate out of memfreqmax)
         if (strcmp(nvs->token, "memTransferRate") != 0) {
           // Just in case error for silly devs
-          CRIT_ERR(nullptr, NULL,
-                   "%s: attribute is 'ATTR_FREQS_STRING' but token is not "
-                   "\"memTransferRate\" (arg: '%s')",
-                   nvs->command, nvs->arg);
+          CRIT_ERR(
+              "%s: attribute is 'ATTR_FREQS_STRING' but token is not "
+              "\"memTransferRate\" (arg: '%s')",
+              nvs->command, nvs->arg);
           return 0;
         }
         temp1 =
@@ -1171,8 +1171,8 @@ double get_nvidia_barval(struct text_object *obj) {
         break;
 
       default:  // Throw error if unsupported args are used
-        CRIT_ERR(nullptr, NULL, "%s: invalid argument specified: '%s'",
-                 nvs->command, nvs->arg);
+        CRIT_ERR("%s: invalid argument specified: '%s'", nvs->command,
+                 nvs->arg);
     }
   }
 

--- a/src/openbsd.cc
+++ b/src/openbsd.cc
@@ -310,13 +310,13 @@ void get_cpu_count() {
   info.cpu_count = cpu_count;
 
   info.cpu_usage = malloc(info.cpu_count * sizeof(float));
-  if (info.cpu_usage == nullptr) { CRIT_ERR(nullptr, NULL, "malloc"); }
+  if (info.cpu_usage == nullptr) { CRIT_ERR("malloc"); }
 
 #ifndef OLDCPU
   assert(fresh == nullptr); /* XXX Is this leaking memory? */
   /* XXX Where shall I free this? */
   if (nullptr == (fresh = calloc(cpu_count, sizeof(int64_t) * CPUSTATES))) {
-    CRIT_ERR(nullptr, NULL, "calloc");
+    CRIT_ERR("calloc");
   }
 #endif
 }

--- a/src/proc.cc
+++ b/src/proc.cc
@@ -439,7 +439,7 @@ void scan_cmdline_to_pid_arg(struct text_object *obj, const char *arg,
     }
     if (obj->data.s[i - 1] == ' ') { obj->data.s[i - 1] = 0; }
   } else {
-    CRIT_ERR(obj, free_at_crash, "${cmdline_to_pid commandline}");
+    CRIT_ERR_FREE(obj, free_at_crash, "${cmdline_to_pid commandline}");
   }
 }
 

--- a/src/pulseaudio.cc
+++ b/src/pulseaudio.cc
@@ -221,7 +221,7 @@ void init_pulseaudio(struct text_object *obj) {
   // This function connects to the pulse server
   if (pa_context_connect(pulseaudio->context, nullptr, (pa_context_flags_t)0,
                          nullptr) < 0) {
-    CRIT_ERR(nullptr, NULL, "Cannot connect to pulseaudio");
+    CRIT_ERR("Cannot connect to pulseaudio");
     return;
   }
   pa_threaded_mainloop_start(pulseaudio->mainloop);

--- a/src/read_tcpip.cc
+++ b/src/read_tcpip.cc
@@ -65,8 +65,9 @@ void parse_read_tcpip_arg(struct text_object *obj, const char *arg,
     strncpy(rtd->host, "localhost", 10);
   }
   if (rtd->port < 1 || rtd->port > 65535) {
-    CRIT_ERR(obj, free_at_crash,
-             "read_tcp and read_udp need a port from 1 to 65535 as argument");
+    CRIT_ERR_FREE(
+        obj, free_at_crash,
+        "read_tcp and read_udp need a port from 1 to 65535 as argument");
   }
 
   obj->data.opaque = rtd;
@@ -91,15 +92,15 @@ void parse_tcp_ping_arg(struct text_object *obj, const char *arg,
       break;
     default:  // this point should never be reached
       free(hostname);
-      CRIT_ERR(obj, free_at_crash, "tcp_ping: Reading arguments failed");
+      CRIT_ERR_FREE(obj, free_at_crash, "tcp_ping: Reading arguments failed");
   }
   if ((he = gethostbyname(hostname)) == nullptr) {
     NORM_ERR("tcp_ping: Problem with resolving '%s', using 'localhost' instead",
              hostname);
     if ((he = gethostbyname("localhost")) == nullptr) {
       free(hostname);
-      CRIT_ERR(obj, free_at_crash,
-               "tcp_ping: Resolving 'localhost' also failed");
+      CRIT_ERR_FREE(obj, free_at_crash,
+                    "tcp_ping: Resolving 'localhost' also failed");
     }
   }
   if (he != nullptr) {

--- a/src/scroll.cc
+++ b/src/scroll.cc
@@ -160,9 +160,9 @@ void parse_scroll_arg(struct text_object *obj, const char *arg,
     free(obj->next);
 #endif
     free(free_at_crash2);
-    CRIT_ERR(obj, free_at_crash,
-             "scroll needs arguments: [left|right|wait] <length> [<step>] "
-             "[interval] <text>");
+    CRIT_ERR_FREE(obj, free_at_crash,
+                  "scroll needs arguments: [left|right|wait] <length> [<step>] "
+                  "[interval] <text>");
   }
   n1 += n2;
 

--- a/src/sony.cc
+++ b/src/sony.cc
@@ -64,10 +64,10 @@ void get_sony_fanspeed(struct text_object *obj, char *p_client_buffer,
       if (sscanf(line, "%u", &speed)) { break; }
     }
   } else {
-    CRIT_ERR(nullptr, NULL,
-             "can't open '%s': %s\nEnable sony support or remove "
-             "sony* from your " PACKAGE_NAME " config file.",
-             fan, strerror(errno));
+    CRIT_ERR(
+        "can't open '%s': %s\nEnable sony support or remove "
+        "sony* from your " PACKAGE_NAME " config file.",
+        fan, strerror(errno));
   }
 
   fclose(fp);

--- a/src/tailhead.cc
+++ b/src/tailhead.cc
@@ -91,14 +91,14 @@ void init_tailhead(const char *type, const char *arg, struct text_object *obj,
   args = sscanf(arg, "%s %d %d", tmp.get(), &ht->wantedlines, &ht->max_uses);
   if (args < 2 || args > 3) {
     free_tailhead(obj);
-    CRIT_ERR(obj, free_at_crash,
-             "%s needs a file as 1st and a number of lines as 2nd argument",
-             type);
+    CRIT_ERR_FREE(
+        obj, free_at_crash,
+        "%s needs a file as 1st and a number of lines as 2nd argument", type);
   }
   if (ht->max_uses < 1) {
     free_tailhead(obj);
-    CRIT_ERR(obj, free_at_crash,
-             "invalid arg for %s, next_check must be larger than 0", type);
+    CRIT_ERR_FREE(obj, free_at_crash,
+                  "invalid arg for %s, next_check must be larger than 0", type);
   }
   if (ht->wantedlines > 0 && ht->wantedlines <= MAX_HEADTAIL_LINES) {
     ht->logfile = to_real_path(tmp.get());
@@ -106,9 +106,10 @@ void init_tailhead(const char *type, const char *arg, struct text_object *obj,
     ht->current_use = 0;
   } else {
     free_tailhead(obj);
-    CRIT_ERR(obj, free_at_crash,
-             "invalid arg for %s, number of lines must be between 1 and %d",
-             type, MAX_HEADTAIL_LINES);
+    CRIT_ERR_FREE(
+        obj, free_at_crash,
+        "invalid arg for %s, number of lines must be between 1 and %d", type,
+        MAX_HEADTAIL_LINES);
   }
   obj->data.opaque = ht;
 }
@@ -147,9 +148,9 @@ static void print_tailhead(const char *type, struct text_object *obj, char *p,
             i = read(fd, p, p_max_size - 1);
             tailstring(p, i, ht->wantedlines);
           } else {
-            CRIT_ERR(nullptr, nullptr,
-                     "If you are seeing this then there is a bug in the code, "
-                     "report it !");
+            CRIT_ERR(
+                "If you are seeing this then there is a bug in the code, "
+                "report it !");
           }
         }
         close(fd);
@@ -169,16 +170,16 @@ static void print_tailhead(const char *type, struct text_object *obj, char *p,
             i = fread(p, 1, p_max_size - 1, fp);
             tailstring(p, i, ht->wantedlines);
           } else {
-            CRIT_ERR(nullptr, nullptr,
-                     "If you are seeing this then there is a bug in the code, "
-                     "report it !");
+            CRIT_ERR(
+                "If you are seeing this then there is a bug in the code, "
+                "report it !");
           }
           fclose(fp);
         }
       }
       ht->buffer = strdup(p);
     } else {
-      CRIT_ERR(nullptr, nullptr, "$%s can't find information about %s", type,
+      CRIT_ERR("$%s can't find information about %s", type,
                ht->logfile.c_str());
     }
   }

--- a/src/tcp-portmon.cc
+++ b/src/tcp-portmon.cc
@@ -44,15 +44,14 @@ int tcp_portmon_init(struct text_object *obj, const char *arg) {
   argc = sscanf(arg, "%d %d %31s %d", &port_begin, &port_end, itembuf,
                 &connection_index);
   if ((argc != 3) && (argc != 4)) {
-    CRIT_ERR(nullptr, NULL, "tcp_portmon: requires 3 or 4 arguments");
+    CRIT_ERR("tcp_portmon: requires 3 or 4 arguments");
   }
   if ((port_begin < 1) || (port_begin > 65535) || (port_end < 1) ||
       (port_end > 65535)) {
-    CRIT_ERR(nullptr, NULL, "tcp_portmon: port values must be from 1 to 65535");
+    CRIT_ERR("tcp_portmon: port values must be from 1 to 65535");
   }
   if (port_begin > port_end) {
-    CRIT_ERR(nullptr, NULL,
-             "tcp_portmon: starting port must be <= ending port");
+    CRIT_ERR("tcp_portmon: starting port must be <= ending port");
   }
   if (strncmp(itembuf, "count", 31) == EQUAL) {
     item = COUNT;
@@ -73,16 +72,15 @@ int tcp_portmon_init(struct text_object *obj, const char *arg) {
   } else if (strncmp(itembuf, "lservice", 31) == EQUAL) {
     item = LOCALSERVICE;
   } else {
-    CRIT_ERR(nullptr, NULL, "tcp_portmon: invalid item specified");
+    CRIT_ERR("tcp_portmon: invalid item specified");
   }
   if ((argc == 3) && (item != COUNT)) {
-    CRIT_ERR(nullptr, NULL,
-             "tcp_portmon: 3 argument form valid only for \"count\" "
-             "item");
+    CRIT_ERR(
+        "tcp_portmon: 3 argument form valid only for \"count\" "
+        "item");
   }
   if ((argc == 4) && (connection_index < 0)) {
-    CRIT_ERR(nullptr, NULL,
-             "tcp_portmon: connection index must be non-negative");
+    CRIT_ERR("tcp_portmon: connection index must be non-negative");
   }
   /* ok, args looks good. save the text object data */
   pmd = (tcp_port_monitor_data *)malloc(sizeof(struct tcp_port_monitor_data));
@@ -98,9 +96,9 @@ int tcp_portmon_init(struct text_object *obj, const char *arg) {
   if (!pmc) {
     pmc = create_tcp_port_monitor_collection();
     if (!pmc) {
-      CRIT_ERR(nullptr, NULL,
-               "tcp_portmon: unable to create port monitor "
-               "collection");
+      CRIT_ERR(
+          "tcp_portmon: unable to create port monitor "
+          "collection");
     }
   }
 
@@ -114,9 +112,9 @@ int tcp_portmon_init(struct text_object *obj, const char *arg) {
     /* add the newly created monitor to the collection */
     if (insert_new_tcp_port_monitor_into_collection(pmc, port_begin, port_end,
                                                     &pma) != 0) {
-      CRIT_ERR(nullptr, NULL,
-               "tcp_portmon: unable to add port monitor to "
-               "collection");
+      CRIT_ERR(
+          "tcp_portmon: unable to add port monitor to "
+          "collection");
     }
   }
   return 0;

--- a/src/template.cc
+++ b/src/template.cc
@@ -77,7 +77,7 @@ static char *backslash_escape(const char *src, char **templates,
             break;
           }
           if (tmpl_num == 0) {
-            CRIT_ERR(
+            CRIT_ERR_FREE(
                 nullptr, nullptr,
                 "invalid template argument \\0; arguments must start at \\1");
           }
@@ -210,8 +210,7 @@ char *find_and_replace_templates(const char *inbuf) {
         *(p - 1) = '\0';
       } else {
         // we ran into the end of string without finding a closing }, bark
-        CRIT_ERR(nullptr, nullptr,
-                 "cannot find a closing '}' in template expansion");
+        CRIT_ERR("cannot find a closing '}' in template expansion");
       }
     } else {
       templ = p + 1;

--- a/src/text_object.cc
+++ b/src/text_object.cc
@@ -72,9 +72,7 @@ int append_object(struct text_object *root, struct text_object *obj) {
 
   /* update pointers of the list to append to */
   if (end != nullptr) {
-    if (end->next != nullptr) {
-      CRIT_ERR(nullptr, nullptr, "huston, we have a lift-off");
-    }
+    if (end->next != nullptr) { CRIT_ERR("huston, we have a lift-off"); }
     end->next = obj;
   } else {
     root->next = obj;
@@ -124,7 +122,7 @@ static int push_ifblock(struct ifblock_stack_obj **ifblock_stack_top,
   switch (type) {
     case IFBLOCK_ENDIF:
       if ((*ifblock_stack_top) == nullptr) {
-        CRIT_ERR(nullptr, nullptr, "got an endif without matching if");
+        CRIT_ERR("got an endif without matching if");
       }
       (*ifblock_stack_top)->obj->ifblock_next = obj;
       /* if there's some else in between, remove and free it */
@@ -140,7 +138,7 @@ static int push_ifblock(struct ifblock_stack_obj **ifblock_stack_top,
       break;
     case IFBLOCK_ELSE:
       if ((*ifblock_stack_top) == nullptr) {
-        CRIT_ERR(nullptr, nullptr, "got an else without matching if");
+        CRIT_ERR("got an else without matching if");
       }
       (*ifblock_stack_top)->obj->ifblock_next = obj;
       /* falls through */
@@ -153,7 +151,7 @@ static int push_ifblock(struct ifblock_stack_obj **ifblock_stack_top,
       *ifblock_stack_top = stackobj;
       break;
     default:
-      CRIT_ERR(nullptr, nullptr, "push_ifblock() misuse detected!");
+      CRIT_ERR("push_ifblock() misuse detected!");
   }
   return 0;
 }

--- a/src/text_object.cc
+++ b/src/text_object.cc
@@ -72,7 +72,7 @@ int append_object(struct text_object *root, struct text_object *obj) {
 
   /* update pointers of the list to append to */
   if (end != nullptr) {
-    if (end->next != nullptr) { CRIT_ERR("huston, we have a lift-off"); }
+    if (end->next != nullptr) { CRIT_ERR("houston, we have a lift-off"); }
     end->next = obj;
   } else {
     root->next = obj;


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [n/a] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

* Describe the changes, why they were necessary, etc

This fixes error handling in i8k (#945) and freebsd `get_freq`. Both would abort in cases they didn't need to, and the freebsd code can actually be made infallible. This also refactors a few cleanup and logging functions to simplify code around the program.

* Describe how the changes will affect existing behaviour.

Conky will no longer segfault or exit when i8k variables fail to open `/proc/i8k`. Behavior is otherwise unchanged.

* Describe how you tested and validated your changes.

Tested with the conkyrc from #945.

* Include any relevant screenshots/evidence demonstrating that the changes work and have been tested.
