### PR TITLE
core: reset selected_font when clearing fonts

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1874,10 +1874,12 @@ void clean_up(void) {
   for (auto output : display_outputs()) output->cleanup();
   conky::shutdown_display_outputs();
 #ifdef BUILD_GUI
-  if (!display_output() || !display_output()->graphical())
+  if (!display_output() || !display_output()->graphical()) {
     fonts.clear();  // in set_default_configurations a font is set but not
                     // loaded
-#endif              /* BUILD_GUI */
+    selected_font = 0;
+  }
+#endif /* BUILD_GUI */
 
   if (info.first_process != nullptr) {
     free_all_processes();


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [n/a] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

Fixes #1525. Tested with the conkyrc from that bug, sending conky sigusr1 to induce a config reload. Crashes before this patch, and does not after; no other behavior changes.
