### PR TITLE
Fix build on FreeBSD.

### DIFF
--- a/src/freebsd.cc
+++ b/src/freebsd.cc
@@ -544,14 +544,12 @@ void get_acpi_fan(char *p_client_buffer, size_t client_buffer_size) {
 char get_freq(char *p_client_buffer, size_t client_buffer_size,
               const char *p_format, int divisor, unsigned int cpu) {
   int freq;
-  char *freq_sysctl;
+  char freq_sysctl[16] = {0};
 
   if (!p_client_buffer || client_buffer_size <= 0 || !p_format ||
       divisor <= 0) {
     return 0;
   }
-
-  char freq_sysctl[16] = {0};
 
   snprintf(freq_sysctl, sizeof(freq_sysctl), "dev.cpu.%d.freq", (cpu - 1));
 


### PR DESCRIPTION
The freq_sysctl varaible is being redefined with a different type.

Update the first definition directly.

The error was:

```
FAILED: src/CMakeFiles/conky.dir/freebsd.cc.o 
/usr/local/libexec/ccache/c++ -D_LARGEFILE64_SOURCE -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700 -D__BSD_VISIBLE=1 -I/wrkdirs/usr/ports/sysutils/conky/work/conky-1.19.2/3rdparty/toluapp/include -I/wrkdirs/usr/ports/sysutils/conky/work/.build -I/usr/local/include/freetype2 -I/usr/local/include/libepoll-shim -I/usr/local/include/pango-1.0 -I/usr/local/include/glib-2.0 -I/usr/local/lib/glib-2.0/include -I/usr/local/include/harfbuzz -I/usr/local/include/libpng16 -I/usr/local/include/fribidi -I/usr/local/include/cairo -I/usr/local/include/pixman-1 -I/usr/local/include/lua53 -I/usr/local/include/libxml2 -I/wrkdirs/usr/ports/sysutils/conky/work/.build/data -I/wrkdirs/usr/ports/sysutils/conky/work/.build/src -O2 -pipe -DLIBICONV_PLUG -fstack-protector-strong -isystem /usr/local/include -fno-strict-aliasing  -DLIBICONV_PLUG -isystem /usr/local/include -O2 -pipe -DLIBICONV_PLUG -fstack-protector-strong -isystem /usr/local/include -fno-strict-aliasing  -DLIBICONV_PLUG -isystem /usr/local/include  -DNDEBUG -std=c++17 -stdlib=libc++ -MD -MT src/CMakeFiles/conky.dir/freebsd.cc.o -MF src/CMakeFiles/conky.dir/freebsd.cc.o.d -o src/CMakeFiles/conky.dir/freebsd.cc.o -c /wrkdirs/usr/ports/sysutils/conky/work/conky-1.19.2/src/freebsd.cc
/wrkdirs/usr/ports/sysutils/conky/work/conky-1.19.2/src/freebsd.cc:77:16: warning: 'gnu_inline' attribute without 'extern' in C++ treated as externally available, this changed in Clang 10 [-Wgnu-inline-cpp-without-extern]
__attribute__((gnu_inline)) inline void proc_find_top(struct process **cpu,
               ^
/wrkdirs/usr/ports/sysutils/conky/work/conky-1.19.2/src/freebsd.cc:554:8: error: redefinition of 'freq_sysctl' with a different type: 'char[16]' vs 'char *'
  char freq_sysctl[16] = {0};
       ^
/wrkdirs/usr/ports/sysutils/conky/work/conky-1.19.2/src/freebsd.cc:547:9: note: previous definition is here
  char *freq_sysctl;
        ^
1 warning and 1 error generated.
```