### PR TITLE
Combine vim ftdetect commands

### DIFF
--- a/extras/vim/ftdetect/conkyrc.vim
+++ b/extras/vim/ftdetect/conkyrc.vim
@@ -1,5 +1,3 @@
 " Vim filetype detection file for Conky config files
-"
 
-au BufNewFile,BufRead *conkyrc set filetype=conkyrc
-au BufNewFile,BufRead conky.conf set filetype=conkyrc
+au BufNewFile,BufRead *conkyrc,conky.conf set filetype=conkyrc


### PR DESCRIPTION
## Description

Combines 2 vim commands into one.

Causes [very] slightly less memory to be used by Vim during its runtime.