### PR TITLE
Implement vgoto

### DIFF
--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -2359,6 +2359,11 @@ values:
       - (interface)
   - name: version
     desc: Git version number. DragonFly only.
+  - name: vgoto
+    desc: The next element will be printed at vertical position 'y'. See
+      also $goto.
+    args:
+      - y
   - name: voffset
     desc: |-
       Change vertical offset by N pixels. Negative values will

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -982,6 +982,10 @@ static int text_size_updater(char *s, int special_index) {
         last_font_height += current->arg;
       } else if (current->type == GOTO) {
         if (current->arg > cur_x) { w = static_cast<int>(current->arg); }
+      } else if (current->type == VGOTO) {
+        if (current->arg > cur_y) {
+          last_font_height = static_cast<int>(current->arg);
+        }
       } else if (current->type == TAB) {
         int start = current->arg;
         int step = current->width;
@@ -1516,6 +1520,20 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
 #endif /* BUILD_GUI */
             cur_x = static_cast<int>(current->arg) + text_start_x;
             for (auto output : display_outputs()) output->gotox(cur_x);
+          }
+          break;
+
+        case VGOTO:
+          if (current->arg >= 0) {
+#ifdef BUILD_GUI
+            cur_y =
+                static_cast<int>(current->arg) + text_start_y + font_ascent();
+            // make sure shades are 1 pixel to the bottom of the text
+            if (draw_mode == BG) cur_y++;
+#endif /* BUILD_GUI */
+            cur_y =
+                static_cast<int>(current->arg) + text_start_y + font_ascent();
+            for (auto output : display_outputs()) output->gotoy(cur_y);
           }
           break;
       }

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1510,11 +1510,11 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
         case GOTO:
           if (current->arg >= 0) {
 #ifdef BUILD_GUI
-            cur_x = static_cast<int>(current->arg);
+            cur_x = static_cast<int>(current->arg) + text_start_x;
             // make sure shades are 1 pixel to the right of the text
             if (draw_mode == BG) { cur_x++; }
 #endif /* BUILD_GUI */
-            cur_x = static_cast<int>(current->arg);
+            cur_x = static_cast<int>(current->arg) + text_start_x;
             for (auto output : display_outputs()) output->gotox(cur_x);
           }
           break;

--- a/src/core.cc
+++ b/src/core.cc
@@ -1034,6 +1034,9 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ_ARG(goto, nullptr, "goto needs arguments") obj->data.l =
       strtol(arg, nullptr, 10);
   obj->callbacks.print = &new_goto;
+  END OBJ_ARG(vgoto, nullptr, "vgoto needs arguments") obj->data.l =
+      strtol(arg, nullptr, 10);
+  obj->callbacks.print = &new_vgoto;
 #ifdef BUILD_GUI
   END OBJ(tab, nullptr) scan_tab(obj, arg);
   obj->callbacks.print = &new_tab;

--- a/src/nvidia.cc
+++ b/src/nvidia.cc
@@ -315,6 +315,7 @@ const char *translate_nvidia_special_type[] = {
     "",             // SAVE_COORDINATES
     "",             // FONT
     "",             // GOTO
+    "",             // VGOTO
     ""              // TAB
 };
 

--- a/src/specials.cc
+++ b/src/specials.cc
@@ -794,6 +794,11 @@ void new_goto(struct text_object *obj, char *p, unsigned int p_max_size) {
   new_special(p, GOTO)->arg = dpi_scale(obj->data.l);
 }
 
+void new_vgoto(struct text_object *obj, char *p, unsigned int p_max_size) {
+  if (p_max_size == 0) { return; }
+  new_special(p, VGOTO)->arg = dpi_scale(obj->data.l);
+}
+
 void scan_tab(struct text_object *obj, const char *arg) {
   struct tab *t;
 

--- a/src/specials.h
+++ b/src/specials.h
@@ -57,6 +57,7 @@ enum special_types {
   SAVE_COORDINATES,
   FONT,
   GOTO,
+  VGOTO,
   TAB
 };
 
@@ -115,6 +116,7 @@ void new_save_coordinates(struct text_object *, char *, unsigned int);
 void new_alignr(struct text_object *, char *, unsigned int);
 void new_alignc(struct text_object *, char *, unsigned int);
 void new_goto(struct text_object *, char *, unsigned int);
+void new_vgoto(struct text_object *, char *, unsigned int);
 void new_tab(struct text_object *, char *, unsigned int);
 
 void clear_stored_graphs();


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [x] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

This implements a vertical `goto`, to match the existing horizontal one. This has been requested by a number of users. Closes #450, and is based in part on the patch there by @easysid.
  
Tested against the following conkyrc:
```
conky.config = {
	out_to_wayland = true,
	use_xft= true,
	font= 'DejaVu Sans:style=medium:size=9'
}
conky.text = [[
foo bar${vgoto 0}${goto 0}text after vgoto

line 1
line 2
another
line 4
line 5
]]
```

This is still a draft because it seems to cause some issues calculating height--with the above conkyrc, on the first iteration, everything looks as expected, but at the beginning of the second iteration, the whole displayed output moves downward, and the bottom line gets cut off. I'll have to debug what's happening there. I have seen similar jumps previously, so it seems more likely that this is exacerbating an existing misbehavior than introducing a completely new one.