### PR TITLE
Haiku fixes

### DIFF
--- a/cmake/Conky.cmake
+++ b/cmake/Conky.cmake
@@ -122,6 +122,15 @@ if(OS_SOLARIS)
   set(conky_libs ${conky_libs} -L/usr/local/lib)
 endif(OS_SOLARIS)
 
+if(OS_HAIKU)
+  # For asprintf
+  add_definitions(-D_GNU_SOURCE) # Standard definitions
+  set(
+    CMAKE_REQUIRED_DEFINITIONS
+    "${CMAKE_REQUIRED_DEFINITIONS} -D_GNU_SOURCE"
+    )
+endif(OS_HAIKU)
+
 # Do version stuff
 set(VERSION_MAJOR "1")
 set(VERSION_MINOR "19")

--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -56,10 +56,11 @@
 #include "display-x11.hh"
 #include "gui.h"
 #include "llua.h"
-#include "x11.h"
 
 /* TODO: cleanup global namespace */
 #ifdef BUILD_X11
+
+#include "x11.h"
 
 // TODO: cleanup externs (move to conky.h ?)
 #ifdef OWN_WINDOW

--- a/src/haiku.cc
+++ b/src/haiku.cc
@@ -175,6 +175,10 @@ double get_battery_perct_bar(struct text_object *obj) {
   return batperct;
 }
 
+void get_battery_power_draw(char *buffer, unsigned int n, const char *bat) {
+  // TODO
+}
+
 int open_acpi_temperature(const char *name) { return -1; }
 
 void get_acpi_ac_adapter(char *p_client_buffer, size_t client_buffer_size,

--- a/src/timeinfo.cc
+++ b/src/timeinfo.cc
@@ -35,6 +35,7 @@
 #include <clocale>
 #include <cstring>
 #include <ctime>
+#include <stdio.h>
 #include "conky.h"
 #include "logging.h"
 #include "text_object.h"


### PR DESCRIPTION
This fixes build on Haiku:
- we don't use X11 so the headers aren't installed by default,
- asprintf needs `_GNU_SOURCE` and is in `stdio.h` as on Linux btw, but we probably don't include this one in the existing includes already,
- added a stub for `get_battery_power_draw()`.