### PR TITLE
X11: Fix segfault on SIGINT

### DIFF
--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -222,7 +222,10 @@ bool display_output_x11::initialize() {
   return true;
 }
 
-bool display_output_x11::shutdown() { return false; }
+bool display_output_x11::shutdown() {
+  deinit_x11();
+  return true;
+}
 
 bool display_output_x11::main_loop_wait(double t) {
   /* wait for X event or timeout */

--- a/src/x11.cc
+++ b/src/x11.cc
@@ -80,7 +80,6 @@ static void update_workarea();
 static Window find_desktop_window(Window *p_root, Window *p_desktop);
 static Window find_subwindow(Window win, int w, int h);
 static void init_x11();
-static void deinit_x11();
 
 /********************* <SETTINGS> ************************/
 namespace priv {
@@ -275,7 +274,7 @@ static void init_x11() {
   DBGP("leave init_x11()");
 }
 
-static void deinit_x11() {
+void deinit_x11() {
   if (display) {
     DBGP("deinit_x11()");
     XCloseDisplay(display);

--- a/src/x11.h
+++ b/src/x11.h
@@ -104,6 +104,7 @@ void set_transparent_background(Window win);
 void get_x11_desktop_info(Display *current_display, Atom atom);
 void set_struts(int);
 void x11_init_window(lua::state &l, bool own);
+void deinit_x11();
 
 #ifdef BUILD_XDBE
 void xdbe_swap_buffers(void);


### PR DESCRIPTION
`deinit_x11()` was called too late, and it seems some libs like xinerama and xcb-render add cleanup hooks but forget to remove them when they get unloaded.