### PR TITLE
hwmon: Fix device name path for some devices.

### DIFF
--- a/src/linux.cc
+++ b/src/linux.cc
@@ -1213,7 +1213,12 @@ static void get_dev_path(const char *dir, const char *dev, char *out_buf) {
 
     snprintf(path, 512, "%s%s/name", dir, namelist[i]->d_name);
     name_fd = open(path, O_RDONLY);
-    if (name_fd < 0) continue;
+    if (name_fd < 0) {
+      snprintf(path, 512, "%s%s/device/name", dir, namelist[i]->d_name);
+      name_fd = open(path, O_RDONLY);
+      if (name_fd < 0)
+        continue;
+    }
     size = read(name_fd, name, strlen(dev));
     if (size < strlen(dev)) {
       close(name_fd);


### PR DESCRIPTION
# Checklist
- [ X] I have described the changes
- [ X] I have linked to any relevant GitHub issues, if applicable
- [ X] Documentation in `doc/` has been updated
- [ X] All new code is licensed under GPLv3

## Description

I recently obtained a different motherboard that has the f71889a hwmon chipset but doesn't include /sys/class/hwmon/hwmonN/name but rather needs hwmonN/device/name when I refer to it as f71889a in the config. This commit checks for hwmonN/name first and if it fails tries hwmonN/device/name.