### PR TITLE
fixed bug 1630: wrong CPU values when no ${top *} var was used

### DIFF
--- a/src/linux.cc
+++ b/src/linux.cc
@@ -902,7 +902,11 @@ void determine_longstat_file(void) {
 #define MAX_PROCSTAT_LINELEN 255
   FILE *stat_fp;
   static int reported = 0;
+  static bool first = true;
   char buf[MAX_PROCSTAT_LINELEN + 1];
+
+  if (! first) return;
+  first = false;
 
   if (!(stat_fp = open_file("/proc/stat", &reported))) return;
   while (!feof(stat_fp) &&
@@ -1000,6 +1004,7 @@ int update_stat(void) {
   }
 
   if (!stat_template) {
+    determine_longstat_file();
     stat_template =
         KFLAG_ISSET(KFLAG_IS_LONGSTAT) ? TMPL_LONGSTAT : TMPL_SHORTSTAT;
   }


### PR DESCRIPTION
Fixes bug https://github.com/brndnmtthws/conky/issues/1630

This fix detects the `/proc/stat` format the first time it's accessed... which, in turn, fixes incorrect CPU usage values in Linux.

# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [ ] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3
