### PR TITLE
[Docs] Improve speedgraphs' scale description

### DIFF
--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -455,10 +455,10 @@ values:
   - name: downspeedgraph
     desc: |-
       Download speed graph, colours defined in hex, minus the #.
-      If scale is non-zero, it becomes the scale for the graph. Uses a
-      logarithmic scale (to see small numbers) when you use -l switch. Takes
-      the switch '-t' to use a temperature gradient, which makes the
-      gradient values change depending on the amplitude of a particular
+      If scale is non-zero, it defines the maximum value of the graph (in bytes
+      per second). Uses a logarithmic scale (to see small numbers) when you use
+      -l switch. Takes the switch '-t' to use a temperature gradient, which makes
+      the gradient values change depending on the amplitude of a particular
       graph value (try it and see).
     args:
       - (netdev)
@@ -2253,8 +2253,7 @@ values:
       similar fashion as TZ environment variable. For hints, look in
       /usr/share/zoneinfo. e.g. US/Pacific, Europe/Zurich, etc.
     args:
-      - (timezone
-      - (format))
+      - (timezone (format))
   - name: uid_name
     desc: Username of user with this uid.
     args:
@@ -2312,11 +2311,12 @@ values:
   - name: upspeedgraph
     desc: |-
       Upload speed graph, colours defined in hex, minus the #. If
-      scale is non-zero, it becomes the scale for the graph. Uses a
-      logarithmic scale (to see small numbers) when you use the -l switch.
-      Takes the switch '-t' to use a temperature gradient, which makes the
-      gradient values change depending on the amplitude of a particular
-      graph value (try it and see).
+      scale is non-zero, it defines the maximum value of the graph
+      (in bytes per second). Uses a logarithmic scale (to see small
+      numbers) when you use the -l switch. Takes the switch '-t' to
+      use a temperature gradient, which makes the gradient values
+      change depending on the amplitude of a particular graph value
+      (try it and see).
     args:
       - (netdev)
       - (height),(width)


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [x] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

* **Describe the changes, why they were necessary, etc**
The `upspeedgraph` and `downspeedgraph` documentation was missing information on how the scale works. I was trying to set a correct scale, and in practice this value ends up setting the maximum value for the Y axis, in **bytes per second** (I gathered this from `net_stat.h` and testing empirically with known network values in my PC).

    I've also fixed a typo in the args of `tztime` (misplaced parenthesis)

* **Describe how the changes will affect existing behaviour.**
This change doesn't change the behaviour of the application.

* **Describe how you tested and validated your changes.**
I haven't tested this change, but `cmake` compiled everything ok on this branch.

* **Include any relevant screenshots/evidence demonstrating that the changes work and have been tested.**
Let me know if I need to share anything else for this change! :)