### PR TITLE
Show cached memory as in free (Linux only)

### DIFF
--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -665,6 +665,8 @@ values:
       - (interval)
   - name: free_bufcache
     desc: Amount of memory cached or buffered, as reported by free. Linux only.
+  - name: free_cached
+    desc: Amount of memory cached, as reported by free. Linux only.
   - name: freq
     desc: |-
       Returns CPU #n's frequency in MHz. CPUs are counted from 1.

--- a/src/common.cc
+++ b/src/common.cc
@@ -532,6 +532,12 @@ void print_free_bufcache(struct text_object *obj, char *p,
                  p_max_size);
 }
 
+void print_free_cached(struct text_object *obj, char *p,
+                         unsigned int p_max_size) {
+  human_readable(apply_base_multiplier(obj->data.s, info.free_cached), p,
+                 p_max_size);
+}
+
 void print_evaluate(struct text_object *obj, char *p, unsigned int p_max_size) {
   std::vector<char> buf(text_buffer_size.get(*state));
   evaluate(obj->data.s, &buf[0], buf.size());

--- a/src/common.h
+++ b/src/common.h
@@ -146,6 +146,7 @@ void print_threads(struct text_object *, char *, unsigned int);
 void print_buffers(struct text_object *, char *, unsigned int);
 void print_cached(struct text_object *, char *, unsigned int);
 void print_free_bufcache(struct text_object *, char *, unsigned int);
+void print_free_cached(struct text_object *, char *, unsigned int);
 
 void print_evaluate(struct text_object *, char *, unsigned int);
 

--- a/src/conky.h
+++ b/src/conky.h
@@ -170,7 +170,7 @@ struct information {
       memmax, memdirty, shmem, legacymem, memactive, meminactive, memwired,
       memlaundry;
   unsigned long long swap, swapfree, swapmax;
-  unsigned long long bufmem, buffers, cached, free_bufcache;
+  unsigned long long bufmem, buffers, cached, free_bufcache, free_cached;
 
   unsigned short procs;
   unsigned short run_procs;

--- a/src/core.cc
+++ b/src/core.cc
@@ -1212,6 +1212,9 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ(free_bufcache, &update_meminfo) obj->data.s = STRNDUP_ARG;
   obj->callbacks.print = &print_free_bufcache;
   obj->callbacks.free = &gen_free_opaque;
+  END OBJ(free_cached, &update_meminfo) obj->data.s = STRNDUP_ARG;
+  obj->callbacks.print = &print_free_cached;
+  obj->callbacks.free = &gen_free_opaque;
 #endif /* __linux__ */
 #ifdef __FreeBSD__
   END OBJ(memactive, &update_meminfo) obj->data.s = STRNDUP_ARG;

--- a/src/linux.cc
+++ b/src/linux.cc
@@ -192,7 +192,7 @@ int update_meminfo(void) {
   info.memmax = info.memdirty = info.swap = info.swapfree = info.swapmax =
       info.memwithbuffers = info.buffers = info.cached = info.memfree =
           info.memeasyfree = info.legacymem = info.shmem = info.memavail =
-              info.free_bufcache = 0;
+              info.free_bufcache = info.free_cached = 0;
 
   if (!(meminfo_fp = open_file("/proc/meminfo", &reported))) { return 0; }
 
@@ -261,7 +261,8 @@ int update_meminfo(void) {
   info.memeasyfree = cureasyfree;
   info.legacymem =
       info.memmax - (info.memfree + info.buffers + info.cached + sreclaimable);
-  info.free_bufcache = info.cached + info.buffers + sreclaimable;
+  info.free_cached = info.cached + sreclaimable;
+  info.free_bufcache = info.free_cached + info.buffers;
 
   fclose(meminfo_fp);
   return 0;


### PR DESCRIPTION
# Checklist
- ○ I have described the changes
- I have linked to any relevant GitHub issues, if applicable (N/A)
- ○ Documentation in `doc/` has been updated
- ○ All new code is licensed under GPLv3

## Description

* Describe the changes, why they were necessary, etc
On Linux, `free` includes `SReclaimable` in its reported figure for `cached`, which differs from the `conky` variable `$cached`. Add a variable `$free_cached` that reports the same figure as `free` would.

* Describe how the changes will affect existing behaviour.
There are no changes to existing behavior.

* Describe how you tested and validated your changes.
I built `conky` and tested under `Xfce`.

* Include any relevant screenshots/evidence demonstrating that the changes work and have been tested.
This screenshot shows the output of `$free_bufcache`, `$buffers`, `$cached` and `$free_cached` with `free -hw` for comparison:
![conky](https://github.com/brndnmtthws/conky/assets/74497663/e131a990-1a3f-4992-91be-ef41aaed733e)
