### PR TITLE
Fix typo in config_settings.yaml

### DIFF
--- a/doc/config_settings.yaml
+++ b/doc/config_settings.yaml
@@ -459,7 +459,7 @@ values:
       Changes the color space used for interpolation. Arguments are hcl, hsv,
       and rgb (default).
     args:
-      - (rbg|hcl|hsv)
+      - (rgb|hcl|hsv)
     default: rgb
   - name: stippled_borders
     desc: Border stippling (dashing) in pixels.


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [x] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

Fix minor typo in config_settings.yaml (rbg -> rgb)
