### PR TITLE
X11: Fix infinite loops caused by propagated Expose events

### DIFF
--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -450,10 +450,7 @@ bool display_output_x11::main_loop_wait(double t) {
         XUnionRectWithRegion(&r, x11_stuff.region, x11_stuff.region);
         XSync(display, False);
 
-        // modify for propagation
-        ev.xexpose.x += window.x;
-        ev.xexpose.y += window.y;
-        break;
+        continue;
       }
 
       case PropertyNotify: {


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [not needed] Documentation in `doc/` has been updated 
- [x] All new code is licensed under GPLv3

## Description

Fixes two issues introduced with the X11 Expose event propagation in commit a4ac632d, as described in issue #1698:
* Propagating the event causes an infinite loop in some window managers (at least herbstluftwm and enlightenment) caused by the event being returned to the conky window after propagation.
* Propagating the event causes an infinite loop if `own_window` is off caused by conky propagating the event to itself.

I couldn't find any documentation saying Expose events should be propagated, so this fix simply stops propagation of the Expose event, just like it was handled by conky before the commit. There wasn't a specific issue that was fixed by this change in the original PR (propagation was added for input events, Expose events were being propagated alongside them), so I believe this will not introduce a regression.

I've tested this in both xfce and herbstluftwm, and both with picom running as compositor with `own_window yes`, and no compositor running with `own_window no`. No infinite loop occurs in any of these cases, and conky is drawn as expected.