### PR TITLE
Remove build date and associated vars

### DIFF
--- a/cmake/Conky.cmake
+++ b/cmake/Conky.cmake
@@ -54,36 +54,36 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
 endif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
 
 if(NOT OS_LINUX
-   AND NOT OS_FREEBSD
-   AND NOT OS_OPENBSD
-   AND NOT OS_DRAGONFLY
-   AND NOT OS_SOLARIS
-   AND NOT OS_HAIKU
-   AND NOT OS_DARWIN)
+  AND NOT OS_FREEBSD
+  AND NOT OS_OPENBSD
+  AND NOT OS_DRAGONFLY
+  AND NOT OS_SOLARIS
+  AND NOT OS_HAIKU
+  AND NOT OS_DARWIN)
   message(
     FATAL_ERROR
-      "Your platform, '${CMAKE_SYSTEM_NAME}', is not currently supported.  Patches are welcome."
-    )
+    "Your platform, '${CMAKE_SYSTEM_NAME}', is not currently supported.  Patches are welcome."
+  )
 endif(NOT
-      OS_LINUX
-      AND
-      NOT
-      OS_FREEBSD
-      AND
-      NOT
-      OS_OPENBSD
-      AND
-      NOT
-      OS_DRAGONFLY
-      AND
-      NOT
-      OS_SOLARIS
-      AND
-      NOT
-      OS_HAIKU
-      AND
-      NOT
-      OS_DARWIN)
+  OS_LINUX
+  AND
+  NOT
+  OS_FREEBSD
+  AND
+  NOT
+  OS_OPENBSD
+  AND
+  NOT
+  OS_DRAGONFLY
+  AND
+  NOT
+  OS_SOLARIS
+  AND
+  NOT
+  OS_HAIKU
+  AND
+  NOT
+  OS_DARWIN)
 
 include(FindThreads)
 find_package(Threads)
@@ -97,12 +97,11 @@ set(conky_includes ${CMAKE_BINARY_DIR})
 # used on macOS.
 #
 if(NOT OS_DARWIN)
-  add_definitions(-D_LARGEFILE64_SOURCE -D_POSIX_C_SOURCE=200809L) # Standard
-                                                                   # definitions
+  add_definitions(-D_LARGEFILE64_SOURCE -D_POSIX_C_SOURCE=200809L) # Standard definitions
   set(
     CMAKE_REQUIRED_DEFINITIONS
     "${CMAKE_REQUIRED_DEFINITIONS} -D_LARGEFILE64_SOURCE -D_POSIX_C_SOURCE=200809L"
-    )
+  )
 endif(NOT OS_DARWIN)
 
 if(OS_FREEBSD)
@@ -110,7 +109,7 @@ if(OS_FREEBSD)
   set(
     CMAKE_REQUIRED_DEFINITIONS
     "${CMAKE_REQUIRED_DEFINITIONS} -D_LARGEFILE64_SOURCE -D_POSIX_C_SOURCE=200809L -D__BSD_VISIBLE=1 -D_XOPEN_SOURCE=700"
-    )
+  )
 endif(OS_FREEBSD)
 
 if(OS_DRAGONFLY)
@@ -128,7 +127,7 @@ if(OS_HAIKU)
   set(
     CMAKE_REQUIRED_DEFINITIONS
     "${CMAKE_REQUIRED_DEFINITIONS} -D_GNU_SOURCE"
-    )
+  )
 endif(OS_HAIKU)
 
 # Do version stuff
@@ -137,57 +136,54 @@ set(VERSION_MINOR "19")
 set(VERSION_PATCH "8")
 
 find_program(APP_AWK awk)
+
 if(NOT APP_AWK)
   message(FATAL_ERROR "Unable to find program 'awk'")
 endif(NOT APP_AWK)
 
 find_program(APP_WC wc)
+
 if(NOT APP_WC)
   message(FATAL_ERROR "Unable to find program 'wc'")
 endif(NOT APP_WC)
 
-find_program(APP_DATE date)
-if(NOT APP_DATE)
-  message(FATAL_ERROR "Unable to find program 'date'")
-endif(NOT APP_DATE)
-
 find_program(APP_UNAME uname)
+
 if(NOT APP_UNAME)
   message(FATAL_ERROR "Unable to find program 'uname'")
 endif(NOT APP_UNAME)
 
 if(NOT RELEASE)
   find_program(APP_GIT git)
+
   if(NOT APP_GIT)
     message(FATAL_ERROR "Unable to find program 'git'")
   endif(NOT APP_GIT)
+
   mark_as_advanced(APP_GIT)
 endif(NOT RELEASE)
 
-mark_as_advanced(APP_AWK APP_WC APP_DATE APP_UNAME)
+mark_as_advanced(APP_AWK APP_WC APP_UNAME)
 
-# BUILD_DATE=$(LANG=en_US LC_ALL=en_US LOCALE=en_US date --utc
-# --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%Y-%m-%d)
-# BUILD_ARCH="$(uname -sm)"
-STRING(TIMESTAMP BUILD_DATE "%Y-%m-%d" UTC)
 execute_process(COMMAND ${APP_UNAME} -sm
-                RESULT_VARIABLE RETVAL
-                OUTPUT_VARIABLE BUILD_ARCH
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
+  RESULT_VARIABLE RETVAL
+  OUTPUT_VARIABLE BUILD_ARCH
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 if(RELEASE)
   set(VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 else(RELEASE)
   set(VERSION
-      "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}_pre${COMMIT_COUNT}")
+    "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}_pre${COMMIT_COUNT}")
 endif(RELEASE)
 
-set(COPYRIGHT "Copyright Brenden Matthews, et al, 2005-2021")
+set(COPYRIGHT "Copyright Brenden Matthews, et al, 2005-2024")
 
 macro(AC_SEARCH_LIBS FUNCTION_NAME INCLUDES TARGET_VAR)
   if("${TARGET_VAR}" MATCHES "^${TARGET_VAR}$")
     unset(AC_SEARCH_LIBS_TMP CACHE)
     check_symbol_exists(${FUNCTION_NAME} ${INCLUDES} AC_SEARCH_LIBS_TMP)
+
     if(${AC_SEARCH_LIBS_TMP})
       set(${TARGET_VAR} "" CACHE INTERNAL "Library containing ${FUNCTION_NAME}")
     else(${AC_SEARCH_LIBS_TMP})
@@ -196,12 +192,13 @@ macro(AC_SEARCH_LIBS FUNCTION_NAME INCLUDES TARGET_VAR)
         unset(AC_SEARCH_LIBS_FOUND CACHE)
         find_library(AC_SEARCH_LIBS_TMP ${LIB})
         check_library_exists(${LIB}
-                             ${FUNCTION_NAME}
-                             ${AC_SEARCH_LIBS_TMP}
-                             AC_SEARCH_LIBS_FOUND)
+          ${FUNCTION_NAME}
+          ${AC_SEARCH_LIBS_TMP}
+          AC_SEARCH_LIBS_FOUND)
+
         if(${AC_SEARCH_LIBS_FOUND})
           set(${TARGET_VAR} ${AC_SEARCH_LIBS_TMP}
-              CACHE INTERNAL "Library containing ${FUNCTION_NAME}")
+            CACHE INTERNAL "Library containing ${FUNCTION_NAME}")
           break()
         endif(${AC_SEARCH_LIBS_FOUND})
       endforeach(LIB)
@@ -218,21 +215,21 @@ function(print_target_properties tgt)
 
   # this list of properties can be extended as needed
   set(CMAKE_PROPERTY_LIST
-      SOURCE_DIR
-      BINARY_DIR
-      COMPILE_DEFINITIONS
-      COMPILE_OPTIONS
-      INCLUDE_DIRECTORIES
-      LINK_LIBRARIES)
+    SOURCE_DIR
+    BINARY_DIR
+    COMPILE_DEFINITIONS
+    COMPILE_OPTIONS
+    INCLUDE_DIRECTORIES
+    LINK_LIBRARIES)
 
   message("Configuration for target ${tgt}")
 
   foreach(prop ${CMAKE_PROPERTY_LIST})
     get_property(propval TARGET ${tgt} PROPERTY ${prop} SET)
+
     if(propval)
       get_target_property(propval ${tgt} ${prop})
       message(STATUS "${prop} = ${propval}")
     endif()
   endforeach(prop)
-
 endfunction(print_target_properties)

--- a/cmake/build.h.in
+++ b/cmake/build.h.in
@@ -3,7 +3,6 @@
 
 /* Conky build info */
 
-#define BUILD_DATE "@BUILD_DATE@"
 #define BUILD_ARCH "@BUILD_ARCH@"
 
 #endif /* __BUILD_H */

--- a/doc/lua.yaml
+++ b/doc/lua.yaml
@@ -85,10 +85,6 @@ values:
     desc: |-
       A string containing the build architecture for this
       particular instance of Conky.
-  - name: conky_build_date
-    desc: |-
-      A string containing the build date for this particular
-      instance of Conky.
   - name: conky_build_info
     desc: |-
       A string containing the build info for this particular

--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -293,8 +293,6 @@ values:
       - var2
   - name: conky_build_arch
     desc: CPU architecture Conky was built for.
-  - name: conky_build_date
-    desc: Date Conky was built.
   - name: conky_version
     desc: Conky version.
   - name: cpu
@@ -1058,7 +1056,7 @@ values:
       'max_msg_lines' entries if specified.
     args:
       - server(:port)
-      - "#channel"
+      - '#channel'
       - (max_msg_lines)
   - name: journal
     desc: |-

--- a/src/build.h.in
+++ b/src/build.h.in
@@ -3,7 +3,6 @@
 
 /* Conky build info */
 
-#define BUILD_DATE "@BUILD_DATE@"
 #define BUILD_ARCH "@BUILD_ARCH@"
 
 #endif /* __BUILD_H */

--- a/src/core.cc
+++ b/src/core.cc
@@ -660,8 +660,12 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
                                                                      EQUAL) {
     obj->data.i = PB_BATT_STATUS;
   }
-  else if (strcmp(arg, "percent") == EQUAL) { obj->data.i = PB_BATT_PERCENT; }
-  else if (strcmp(arg, "time") == EQUAL) { obj->data.i = PB_BATT_TIME; }
+  else if (strcmp(arg, "percent") == EQUAL) {
+    obj->data.i = PB_BATT_PERCENT;
+  }
+  else if (strcmp(arg, "time") == EQUAL) {
+    obj->data.i = PB_BATT_TIME;
+  }
   else {
     NORM_ERR("pb_battery: illegal argument '%s', defaulting to status", arg);
     obj->data.i = PB_BATT_STATUS;
@@ -836,7 +840,6 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   obj->callbacks.free = &gen_free_opaque;
 #endif /* BUILD_GUI */
   END OBJ(conky_version, nullptr) obj_be_plain_text(obj, VERSION);
-  END OBJ(conky_build_date, nullptr) obj_be_plain_text(obj, BUILD_DATE);
   END OBJ(conky_build_arch, nullptr) obj_be_plain_text(obj, BUILD_ARCH);
   END OBJ(downspeed, &update_net_stats)
       parse_net_stat_arg(obj, arg, free_at_crash);

--- a/src/llua.cc
+++ b/src/llua.cc
@@ -179,15 +179,11 @@ void llua_init() {
   lua_setfield(lua_L, -3, "cpath");
   lua_pop(lua_L, 2);
 
-  lua_pushstring(lua_L, PACKAGE_NAME " " VERSION " compiled " BUILD_DATE
-                                     " for " BUILD_ARCH);
+  lua_pushstring(lua_L, PACKAGE_NAME " " VERSION " compiled for " BUILD_ARCH);
   lua_setglobal(lua_L, "conky_build_info");
 
   lua_pushstring(lua_L, VERSION);
   lua_setglobal(lua_L, "conky_version");
-
-  lua_pushstring(lua_L, BUILD_DATE);
-  lua_setglobal(lua_L, "conky_build_date");
 
   lua_pushstring(lua_L, BUILD_ARCH);
   lua_setglobal(lua_L, "conky_build_arch");

--- a/src/main.cc
+++ b/src/main.cc
@@ -57,8 +57,7 @@
 #endif /* BUILD_BUILTIN_CONFIG */
 
 static void print_version() {
-  std::cout << _(PACKAGE_NAME " " VERSION " compiled " BUILD_DATE
-                              " for " BUILD_ARCH
+  std::cout << _(PACKAGE_NAME " " VERSION " compiled for " BUILD_ARCH
                               "\n"
                               "\nCompiled in features:\n\n"
                               "System config file: " SYSTEM_CONFIG_FILE


### PR DESCRIPTION
For reproducible builds, the build date messes things up, and some distros just set it to 1980 now anyway. Thus, it's better to remove the date altogether.