### PR TITLE
Stop walking window tree if we get zero

### DIFF
--- a/src/x11.cc
+++ b/src/x11.cc
@@ -1384,8 +1384,13 @@ inline Window last_descendant(Display *display, Window parent) {
   while (
       XQueryTree(display, current, &_ignored, &_ignored, &children, &count) &&
       count != 0) {
-    current = children[count - 1];
+    auto next = children[count - 1];
     XFree(children);
+    if (next != 0) {
+      current = next;
+    } else {
+      break;
+    }
   }
 
   return current;


### PR DESCRIPTION
It looks like some of the child windows are zero, which causes the next call to XQueryTree to blow up.

cc @Caellian 