### PR TITLE
Fix buffer overflow on X11 error bug

### DIFF
--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -411,15 +411,16 @@ bool display_output_x11::main_loop_wait(double t) {
             query_x11_window_at_pos(display, data->root_x, data->root_y);
 
         static bool cursor_inside = false;
-        if ((query_result != 0 && query_result == window.window) ||
-            ((query_result == window.desktop || query_result == window.root ||
-              query_result == 0) &&
-             data->root_x >= window.x &&
-             data->root_x < (window.x + window.width) &&
-             data->root_y >= window.y &&
-             data->root_y < (window.y + window.height))) {
-          // cursor is inside conky
 
+        // - over conky window
+        // - conky has now window, over desktop and within conky region
+        bool cursor_over_conky = query_result == window.window &&
+                                 (window.window != 0u ||
+                                  (data->root_x >= window.x &&
+                                   data->root_x < (window.x + window.width) &&
+                                   data->root_y >= window.y &&
+                                   data->root_y < (window.y + window.height)));
+        if (cursor_over_conky) {
           if (!cursor_inside) {
             llua_mouse_hook(mouse_crossing_event(
                 mouse_event_t::AREA_ENTER, data->root_x - window.x,

--- a/src/x11.cc
+++ b/src/x11.cc
@@ -258,7 +258,7 @@ static int x11_error_handler(Display *d, XErrorEvent *err) {
     const char *minor = xcb_errors_get_name_for_minor_code(
         xcb_errors_ctx, err->request_code, err->minor_code);
     if (minor != nullptr) {
-      const std::size_t size = strlen(base_name) + strlen(extension) + 4;
+      const std::size_t size = strlen(major) + strlen(minor) + 4;
       code_description = new char[size];
       snprintf(code_description, size, "%s - %s", major, minor);
       code_allocated = true;
@@ -1402,6 +1402,9 @@ Window query_x11_window_at_pos(Display *display, int x, int y) {
   Window last = None;
   XQueryPointer(display, window.root, &root_return, &last, &root_x_return,
                 &root_y_return, &win_x_return, &win_y_return, &mask_return);
+
+  // If root, last descendant will be wrong
+  if (last == 0) return 0;
 
   // X11 correctly returns a window which covers conky area, but returned
   // window is not window.window, but instead a parent node in some cases and


### PR DESCRIPTION
Closes #1739.

## Additional changes

- Skip descendant checking if cursor over desktop in query_x11_window_at_pos.
- Simplify check for whether cursor is over conky.
