### PR TITLE
Add wlr layer shell check

### DIFF
--- a/src/display-wayland.cc
+++ b/src/display-wayland.cc
@@ -576,6 +576,9 @@ bool display_output_wayland::initialize() {
   wl_registry_add_listener(wl_globals.registry, &registry_listener, NULL);
 
   wl_display_roundtrip(global_display);
+  if (wl_globals.layer_shell == nullptr) {
+    CRIT_ERR("Compositor doesn't support wlr-layer-shell-unstable-v1. Can't run conky.");
+  }
 
   struct wl_surface *surface =
       wl_compositor_create_surface(wl_globals.compositor);


### PR DESCRIPTION
Closes: #1751

When a global is registered with `wl_registry_add_listener` it receives events for all supported extensions in bulk. `wl_display_roundtrip` call blocks until the initial events are exchanged so it's safe to check whether `wl_globals.layer_shell` is initialized right after that.
