### PR TITLE
Don't call FcFini()

### DIFF
--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -701,9 +701,6 @@ void display_output_x11::cleanup() {
     XDestroyRegion(x11_stuff.region);
     x11_stuff.region = nullptr;
   }
-#ifdef BUILD_XFT
-  FcFini();
-#endif /* BUILD_XFT */
 }
 
 void display_output_x11::set_foreground_color(Colour c) {


### PR DESCRIPTION
Fontconfig has a bug in FcFini() where it calls assert when it probably shouldn't. This looks to be fixed in
https://gitlab.freedesktop.org/fontconfig/fontconfig/-/commit/6f6b39780215714386606ca1c5457a7106639ff4, which is in libfontconfig >=2.13.93.

Removing this seems to be safe, it will cause valgrind to show mem leaks, but it doesn't look to be a problem in practice.