### PR TITLE
Build AppImage separately per OS

### DIFF
--- a/.github/workflows/publish-appimage.yml
+++ b/.github/workflows/publish-appimage.yml
@@ -77,8 +77,8 @@ jobs:
             pip3 install --upgrade pyyaml
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Get tags
-        run: git fetch --tags origin
+        with:
+          fetch-depth: 0
       - name: Get git version
         id: git-version
         run: echo "GIT_VERSION=$(git describe --tags --always --debug)" | tee -a $GITHUB_ENV

--- a/.github/workflows/publish-appimage.yml
+++ b/.github/workflows/publish-appimage.yml
@@ -81,7 +81,7 @@ jobs:
         run: git fetch --tags origin
       - name: Get git version
         id: git-version
-        run: echo "GIT_VERSION=$(git describe --tags --always)" | tee -a $GITHUB_ENV
+        run: echo "GIT_VERSION=$(git describe --tags --always --debug)" | tee -a $GITHUB_ENV
       - name: Import GPG Deploy Key
         # only run on main branch
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/publish-appimage.yml
+++ b/.github/workflows/publish-appimage.yml
@@ -8,6 +8,12 @@ on:
     paths-ignore:
       - web/**
       - doc/**
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - web/**
+      - doc/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/publish-appimage.yml
+++ b/.github/workflows/publish-appimage.yml
@@ -81,7 +81,7 @@ jobs:
         run: git fetch --tags origin
       - name: Get git version
         id: git-version
-        run: echo "GIT_VERSION=$(git describe --tags --always)" >> $GITHUB_ENV
+        run: echo "GIT_VERSION=$(git describe --tags --always)" | tee -a $GITHUB_ENV
       - name: Import GPG Deploy Key
         # only run on main branch
         if: github.ref == 'refs/heads/main'
@@ -91,18 +91,18 @@ jobs:
       - name: Set clang version to 12 for ubuntu-20.04
         if: matrix.os == 'ubuntu-20.04'
         run: |
-          echo "CLANG_VERSION=12" >> $GITHUB_ENV
+          echo "CLANG_VERSION=12" | tee -a $GITHUB_ENV
       - name: Set clang version to 14 for ubuntu-22.04
         if: matrix.os == 'ubuntu-22.04'
         run: |
-          echo "CLANG_VERSION=14" >> $GITHUB_ENV
+          echo "CLANG_VERSION=14" | tee -a $GITHUB_ENV
       - name: Install libc++, set CC and CXX env vars
         run: |
           sudo apt-get install -yqq --no-install-recommends \
             libc++-${CLANG_VERSION}-dev \
             libc++abi-${CLANG_VERSION}-dev
-          echo "CC=clang-${CLANG_VERSION}" >> $GITHUB_ENV
-          echo "CXX=clang++-${CLANG_VERSION}" >> $GITHUB_ENV
+          echo "CC=clang-${CLANG_VERSION}" | tee -a $GITHUB_ENV
+          echo "CXX=clang++-${CLANG_VERSION}" | tee -a $GITHUB_ENV
       - name: Build AppImage
         run: ./appimage/build.sh
       - name: Upload AppImage artifact

--- a/.github/workflows/publish-appimage.yml
+++ b/.github/workflows/publish-appimage.yml
@@ -78,6 +78,8 @@ jobs:
         id: git-version
         run: echo "GIT_VERSION=$(git describe --tags)" >> $GITHUB_ENV
       - name: Import GPG Deploy Key
+        # only run on main branch
+        if: github.ref == 'refs/heads/main')
         run: |
           echo "${{ secrets.GPG_DEPLOY_KEY }}" > appimage/secret.gpg
           gpg --import appimage/secret.gpg

--- a/.github/workflows/publish-appimage.yml
+++ b/.github/workflows/publish-appimage.yml
@@ -23,6 +23,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-20.04

--- a/.github/workflows/publish-appimage.yml
+++ b/.github/workflows/publish-appimage.yml
@@ -98,8 +98,8 @@ jobs:
         if: matrix.os == 'ubuntu-20.04'
         run: |
           sudo apt-get install -yqq --no-install-recommends \
-            libc++-14-dev \
-            libc++abi-14-dev
+            libc++-12-dev \
+            libc++abi-12-dev
           echo "CC=clang-12" >> $GITHUB_ENV
           echo "CXX=clang++-12" >> $GITHUB_ENV
       - name: Build AppImage

--- a/.github/workflows/publish-appimage.yml
+++ b/.github/workflows/publish-appimage.yml
@@ -99,22 +99,22 @@ jobs:
       - name: Install libc++, set CC and CXX env vars
         run: |
           sudo apt-get install -yqq --no-install-recommends \
-            libc++-${CLANG-VERSION}-dev \
-            libc++abi-${CLANG-VERSION}-dev
-          echo "CC=clang-${CLANG-VERSION}" >> $GITHUB_ENV
-          echo "CXX=clang++-${CLANG-VERSION}" >> $GITHUB_ENV
+            libc++-${CLANG_VERSION}-dev \
+            libc++abi-${CLANG_VERSION}-dev
+          echo "CC=clang-${CLANG_VERSION}" >> $GITHUB_ENV
+          echo "CXX=clang++-${CLANG_VERSION}" >> $GITHUB_ENV
       - name: Build AppImage
         run: ./appimage/build.sh
       - name: Upload AppImage artifact
         uses: actions/upload-artifact@v4
         with:
-          name: 'conky-${{ matrix.os }}-${{ matrix.arch }}-${{ env.GIT_VERSION }}.AppImage'
+          name: "conky-${{ matrix.os }}-${{ matrix.arch }}-${{ env.GIT_VERSION }}.AppImage"
           path: conky-x86_64.AppImage
           if-no-files-found: error
       - name: Upload AppImage checksum artifact
         uses: actions/upload-artifact@v4
         with:
-          name: 'conky-${{ matrix.os }}-${{ matrix.arch }}-${{ env.GIT_VERSION }}.AppImage.sha256'
+          name: "conky-${{ matrix.os }}-${{ matrix.arch }}-${{ env.GIT_VERSION }}.AppImage.sha256"
           path: conky-x86_64.AppImage.sha256
           if-no-files-found: error
       - name: Upload man page artifact

--- a/.github/workflows/publish-appimage.yml
+++ b/.github/workflows/publish-appimage.yml
@@ -83,8 +83,18 @@ jobs:
         run: |
           echo "${{ secrets.GPG_DEPLOY_KEY }}" > appimage/secret.gpg
           gpg --import appimage/secret.gpg
+      - name: Set CC and CXX env vars for ubuntu-22.04
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          echo "CC=clang-14" >> $GITHUB_ENV
+          echo "CXX=clang++-14" >> $GITHUB_ENV
+      - name: Set CC and CXX env vars for ubuntu-20.04
+        if: matrix.os == 'ubuntu-20.04'
+        run: |
+          echo "CC=clang-12" >> $GITHUB_ENV
+          echo "CXX=clang++-12" >> $GITHUB_ENV
       - name: Build AppImage
-        run: CC=clang-14 CXX=clang++-14 ./appimage/build.sh
+        run: ./appimage/build.sh
       - name: Upload AppImage artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish-appimage.yml
+++ b/.github/workflows/publish-appimage.yml
@@ -79,7 +79,7 @@ jobs:
         run: echo "GIT_VERSION=$(git describe --tags)" >> $GITHUB_ENV
       - name: Import GPG Deploy Key
         # only run on main branch
-        if: github.ref == 'refs/heads/main')
+        if: github.ref == 'refs/heads/main'
         run: |
           echo "${{ secrets.GPG_DEPLOY_KEY }}" > appimage/secret.gpg
           gpg --import appimage/secret.gpg

--- a/.github/workflows/publish-appimage.yml
+++ b/.github/workflows/publish-appimage.yml
@@ -86,14 +86,20 @@ jobs:
         run: |
           echo "${{ secrets.GPG_DEPLOY_KEY }}" > appimage/secret.gpg
           gpg --import appimage/secret.gpg
-      - name: Set CC and CXX env vars for ubuntu-22.04
+      - name: Install libc++, set CC and CXX env vars for ubuntu-22.04
         if: matrix.os == 'ubuntu-22.04'
         run: |
+          sudo apt-get install -yqq --no-install-recommends \
+            libc++-14-dev \
+            libc++abi-14-dev
           echo "CC=clang-14" >> $GITHUB_ENV
           echo "CXX=clang++-14" >> $GITHUB_ENV
-      - name: Set CC and CXX env vars for ubuntu-20.04
+      - name: Install libc++, set CC and CXX env vars for ubuntu-20.04
         if: matrix.os == 'ubuntu-20.04'
         run: |
+          sudo apt-get install -yqq --no-install-recommends \
+            libc++-14-dev \
+            libc++abi-14-dev
           echo "CC=clang-12" >> $GITHUB_ENV
           echo "CXX=clang++-12" >> $GITHUB_ENV
       - name: Build AppImage

--- a/.github/workflows/publish-appimage.yml
+++ b/.github/workflows/publish-appimage.yml
@@ -77,9 +77,11 @@ jobs:
             pip3 install --upgrade pyyaml
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Get tags
+        run: git fetch --tags origin
       - name: Get git version
         id: git-version
-        run: echo "GIT_VERSION=$(git describe --tags)" >> $GITHUB_ENV
+        run: echo "GIT_VERSION=$(git describe --tags --always)" >> $GITHUB_ENV
       - name: Import GPG Deploy Key
         # only run on main branch
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/publish-appimage.yml
+++ b/.github/workflows/publish-appimage.yml
@@ -86,34 +86,33 @@ jobs:
         run: |
           echo "${{ secrets.GPG_DEPLOY_KEY }}" > appimage/secret.gpg
           gpg --import appimage/secret.gpg
-      - name: Install libc++, set CC and CXX env vars for ubuntu-22.04
-        if: matrix.os == 'ubuntu-22.04'
-        run: |
-          sudo apt-get install -yqq --no-install-recommends \
-            libc++-14-dev \
-            libc++abi-14-dev
-          echo "CC=clang-14" >> $GITHUB_ENV
-          echo "CXX=clang++-14" >> $GITHUB_ENV
-      - name: Install libc++, set CC and CXX env vars for ubuntu-20.04
+      - name: Set clang version to 12 for ubuntu-20.04
         if: matrix.os == 'ubuntu-20.04'
         run: |
+          echo "CLANG_VERSION=12" >> $GITHUB_ENV
+      - name: Set clang version to 14 for ubuntu-22.04
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          echo "CLANG_VERSION=14" >> $GITHUB_ENV
+      - name: Install libc++, set CC and CXX env vars
+        run: |
           sudo apt-get install -yqq --no-install-recommends \
-            libc++-12-dev \
-            libc++abi-12-dev
-          echo "CC=clang-12" >> $GITHUB_ENV
-          echo "CXX=clang++-12" >> $GITHUB_ENV
+            libc++-${CLANG-VERSION}-dev \
+            libc++abi-${CLANG-VERSION}-dev
+          echo "CC=clang-${CLANG-VERSION}" >> $GITHUB_ENV
+          echo "CXX=clang++-${CLANG-VERSION}" >> $GITHUB_ENV
       - name: Build AppImage
         run: ./appimage/build.sh
       - name: Upload AppImage artifact
         uses: actions/upload-artifact@v4
         with:
-          name: "conky-${{ matrix.os }}-${{ matrix.arch }}-${{ env.GIT_VERSION }}.AppImage"
+          name: 'conky-${{ matrix.os }}-${{ matrix.arch }}-${{ env.GIT_VERSION }}.AppImage'
           path: conky-x86_64.AppImage
           if-no-files-found: error
       - name: Upload AppImage checksum artifact
         uses: actions/upload-artifact@v4
         with:
-          name: "conky-${{ matrix.os }}-${{ matrix.arch }}-${{ env.GIT_VERSION }}.AppImage.sha256"
+          name: 'conky-${{ matrix.os }}-${{ matrix.arch }}-${{ env.GIT_VERSION }}.AppImage.sha256'
           path: conky-x86_64.AppImage.sha256
           if-no-files-found: error
       - name: Upload man page artifact

--- a/.github/workflows/publish-appimage.yml
+++ b/.github/workflows/publish-appimage.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Upload AppImage checksum artifact
         uses: actions/upload-artifact@v4
         with:
-          name: "conky-${{ matrix.os }}-${{ matrix.arch }}-${{ env.GIT_VERSION }}.AppImage"
+          name: "conky-${{ matrix.os }}-${{ matrix.arch }}-${{ env.GIT_VERSION }}.AppImage.sha256"
           path: conky-x86_64.AppImage.sha256
           if-no-files-found: error
       - name: Upload man page artifact

--- a/.github/workflows/publish-appimage.yml
+++ b/.github/workflows/publish-appimage.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
-          path: ${{ github.workspace }}/artifacts
+          path: ${{ github.workspace }}
 
       - name: Create Conky Release
         id: create_release

--- a/.github/workflows/publish-appimage.yml
+++ b/.github/workflows/publish-appimage.yml
@@ -122,6 +122,8 @@ jobs:
         with:
           name: conky.1.gz
           path: conky.1.gz
+          # conky.1.gz is created by all jobs!
+          overwrite: true
 
   release:
     runs-on: ubuntu-latest
@@ -130,8 +132,6 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
-          # conky.1.gz is created by all jobs!
-          merge-multiple: true
           path: ${{ github.workspace }}/artifacts
 
       - name: Create Conky Release

--- a/.github/workflows/publish-appimage.yml
+++ b/.github/workflows/publish-appimage.yml
@@ -15,7 +15,12 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-20.04
+          - ubuntu-22.04
     permissions:
       contents: write
       discussions: write
@@ -63,6 +68,9 @@ jobs:
             pip3 install --upgrade pyyaml
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Get git version
+        id: git-version
+        run: echo "GIT_VERSION=$(git describe --tags)" >> $GITHUB_ENV
       - name: Import GPG Deploy Key
         run: |
           echo "${{ secrets.GPG_DEPLOY_KEY }}" > appimage/secret.gpg
@@ -72,18 +80,32 @@ jobs:
       - name: Upload AppImage artifact
         uses: actions/upload-artifact@v4
         with:
-          name: conky-x86_64.AppImage
+          name: "conky-${{ matrix.os }}-${{ env.GIT_VERSION }}.AppImage"
           path: conky-x86_64.AppImage
+          if-no-files-found: error
       - name: Upload AppImage checksum artifact
         uses: actions/upload-artifact@v4
         with:
-          name: conky-x86_64.AppImage.sha256
+          name: "conky-${{ matrix.os }}-${{ env.GIT_VERSION }}.AppImage"
           path: conky-x86_64.AppImage.sha256
+          if-no-files-found: error
       - name: Upload man page artifact
         uses: actions/upload-artifact@v4
         with:
           name: conky.1.gz
           path: conky.1.gz
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          # conky.1.gz is created by all jobs!
+          merge-multiple: true
+          path: ${{ github.workspace }}/artifacts
+
       - name: Create Conky Release
         id: create_release
         uses: softprops/action-gh-release@v1
@@ -94,6 +116,5 @@ jobs:
           discussion_category_name: General
           generate_release_notes: true
           files: |
-            conky-x86_64.AppImage
-            conky-x86_64.AppImage.sha256
+            conky-*.AppImage*
             conky.1.gz

--- a/.github/workflows/publish-appimage.yml
+++ b/.github/workflows/publish-appimage.yml
@@ -27,6 +27,8 @@ jobs:
         os:
           - ubuntu-20.04
           - ubuntu-22.04
+        arch:
+          - x86_64
     permissions:
       contents: write
       discussions: write
@@ -98,13 +100,13 @@ jobs:
       - name: Upload AppImage artifact
         uses: actions/upload-artifact@v4
         with:
-          name: "conky-${{ matrix.os }}-${{ env.GIT_VERSION }}.AppImage"
+          name: "conky-${{ matrix.os }}-${{ matrix.arch }}-${{ env.GIT_VERSION }}.AppImage"
           path: conky-x86_64.AppImage
           if-no-files-found: error
       - name: Upload AppImage checksum artifact
         uses: actions/upload-artifact@v4
         with:
-          name: "conky-${{ matrix.os }}-${{ env.GIT_VERSION }}.AppImage"
+          name: "conky-${{ matrix.os }}-${{ matrix.arch }}-${{ env.GIT_VERSION }}.AppImage"
           path: conky-x86_64.AppImage.sha256
           if-no-files-found: error
       - name: Upload man page artifact

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -74,7 +74,12 @@ wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appima
 
 chmod +x appimagetool-x86_64.AppImage
 
-./appimagetool-x86_64.AppImage AppDir --sign --sign-key E3034071
+GPG_KEY=E3034072
+if gpg --list-keys ${GPG_KEY}; then
+  ./appimagetool-x86_64.AppImage AppDir --sign --sign-key ${GPG_KEY}
+else
+  ./appimagetool-x86_64.AppImage AppDir
+fi
 
 for f in conky*.AppImage
 do

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -25,6 +25,13 @@ trap cleanup EXIT
 REPO_ROOT=$(readlink -f $(dirname $(dirname $0)))
 OLD_CWD=$(readlink -f .)
 
+# check if we have a recent enough version of librsvg
+if pkg-config --atleast-version 2.60 librsvg-2.0; then
+  ENABLE_RSVG=ON
+else
+  ENABLE_RSVG=OFF
+fi
+
 # switch to build dir
 pushd "$BUILD_DIR"
 
@@ -43,7 +50,7 @@ cmake -G Ninja                         \
   -DBUILD_JOURNAL=ON                   \
   -DBUILD_LUA_CAIRO=ON                 \
   -DBUILD_LUA_IMLIB2=ON                \
-  -DBUILD_LUA_RSVG=ON                  \
+  -DBUILD_LUA_RSVG=${ENABLE_RSVG}      \
   -DBUILD_MYSQL=ON                     \
   -DBUILD_NVIDIA=ON                    \
   -DBUILD_PULSEAUDIO=ON                \


### PR DESCRIPTION
Different OS'es have different `GLIBC_X.XX` versions.

While installing extra libraries is of course maybe necessary, it is next-to-impossible (AFAIU) to install/compliment a diffent `GLIBC_X.XX` on non-flexible OSes such as Debian, Ubuntu, etc.

If AppImage is unable to hide those differences,
then we must diversify if we want to support a wider base.

Fixes: https://github.com/brndnmtthws/conky/issues/1142
Fixes: https://github.com/brndnmtthws/conky/issues/1717

... and probably others.

# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [ ] ~Documentation in `doc/` has been updated~
- [x] All new code is licensed under GPLv3

## Description

* Describe the changes, why they were necessary, etc
* Describe how the changes will affect existing behaviour.
* Describe how you tested and validated your changes.
* Include any relevant screenshots/evidence demonstrating that the changes work and have been tested.
