### PR TITLE
Define text_object.data.l as "long long"

### DIFF
--- a/src/text_object.h
+++ b/src/text_object.h
@@ -109,7 +109,7 @@ struct text_object {
     void *opaque; /* new style generic per object data */
     char *s;      /* some string */
     int i;        /* some integer */
-    long l;       /* some long integer */
+    long long l;  /* some long integer */
   } data;
 
   void *special_data;

--- a/src/text_object.h
+++ b/src/text_object.h
@@ -109,7 +109,7 @@ struct text_object {
     void *opaque; /* new style generic per object data */
     char *s;      /* some string */
     int i;        /* some integer */
-    long long l;  /* some long integer */
+    int64_t l;    /* some long integer */
   } data;
 
   void *special_data;


### PR DESCRIPTION
# Checklist
- [X] I have described the changes
- [X] I have linked to any relevant GitHub issues, if applicable
- [ ] Documentation in `doc/` has been updated
- [X] All new code is licensed under GPLv3

## Description

The definition of `text_object.data.l` is changed from `long` to `long long`. In 32-bit environments, `long` may be as short as 32 bits, and this can cause minor issues. Specifically, I was hitting #1477.

This change solved the issue for me, and it doesn't appear to cause new issues, even on a 64-bit platform. However, it may not be the best fix in the long run, as `int` and `long long` are still platform-specific and can hide similar bugs.

Fixed-size definitions (e.g. `uint64_t`) should be safer, but I'm not sure what the sizes should be (the defaults on x86_64 could be a good starting point). I can update the PR if this solutions turns out to be preferred.
