### PR TITLE
Fix bad imlib2 typedefs for imlib<1.10

### DIFF
--- a/lua/imlib2_old.pkg
+++ b/lua/imlib2_old.pkg
@@ -10,7 +10,6 @@ typedef void *Imlib_Updates;
 typedef void *Imlib_Font;
 typedef void *Imlib_Color_Range;
 typedef void *Imlib_Filter;
-typedef struct _imlib_color Imlib_Color;
 typedef void *ImlibPolygon;
 
 enum _imlib_operation {

--- a/lua/imlib2_old.pkg
+++ b/lua/imlib2_old.pkg
@@ -59,13 +59,15 @@ typedef enum _imlib_load_error ImlibLoadError;
 typedef enum _imlib_text_direction Imlib_Text_Direction;
 typedef enum _imlib_TTF_encoding Imlib_TTF_Encoding;
 
-typedef struct {
+struct _imlib_border {
   int left, right, top, bottom;
-} Imlib_Border;
+};
+typedef struct _imlib_border Imlib_Border;
 
-typedef struct {
+struct _imlib_color {
   int alpha, red, green, blue;
-} Imlib_Color;
+};
+typedef struct _imlib_color Imlib_Color;
 
 Imlib_Context imlib_context_new(void);
 void imlib_context_free(Imlib_Context context);

--- a/lua/imlib2_old.pkg
+++ b/lua/imlib2_old.pkg
@@ -60,7 +60,13 @@ typedef enum _imlib_load_error ImlibLoadError;
 typedef enum _imlib_text_direction Imlib_Text_Direction;
 typedef enum _imlib_TTF_encoding Imlib_TTF_Encoding;
 
-typedef struct _imlib_border Imlib_Border;
+typedef struct {
+  int left, right, top, bottom;
+} Imlib_Border;
+
+typedef struct {
+  int alpha, red, green, blue;
+} Imlib_Color;
 
 Imlib_Context imlib_context_new(void);
 void imlib_context_free(Imlib_Context context);


### PR DESCRIPTION
This should (properly) resolve #1743.