### PR TITLE
Updated flake per https://github.com/NixOS/nix/issues/5532

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1709126324,
+        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708475490,
-        "narHash": "sha256-g1v0TsWBQPX97ziznfJdWhgMyMGtoBFs102xSYO4syU=",
+        "lastModified": 1709703039,
+        "narHash": "sha256-6hqgQ8OK6gsMu1VtcGKBxKQInRLHtzulDo9Z5jxHEFY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0e74ca98a74bc7270d28838369593635a5db3260",
+        "rev": "9df3e30ce24fd28c7b3e2de0d986769db5d6225d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -20,18 +20,18 @@
       system: let
         pkgs = import nixpkgs {
           inherit system;
-          overlays = [self.overlay];
+          overlays = [self.overlays.default];
         };
       in
         with pkgs; rec
         {
           packages = flake-utils.lib.flattenTree {
             conky = conky;
+            default = conky;
           };
 
-          defaultPackage = packages.conky;
           apps.conky = flake-utils.lib.mkApp {drv = packages.conky;};
-          defaultApp = apps.conky;
+          apps.default = apps.conky;
           devShells.default = mkShell {
             buildInputs =
               packages.conky.buildInputs
@@ -47,7 +47,7 @@
         }
     )
     // {
-      overlay = final: prev: {
+      overlays.default = final: prev: {
         conky = with final;
           stdenv.mkDerivation rec {
             name = "conky";


### PR DESCRIPTION
`nix flake check` no longer returns warnings.