### PR TITLE
Skip propagation of non-input events

### DIFF
--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -374,6 +374,7 @@ bool display_output_x11::main_loop_wait(double t) {
     }
   }
 
+  DBGP2("Processing %d X11 events...", XPending(display));
   /* handle X events */
   while (XPending(display) != 0) {
     XEvent ev;
@@ -630,6 +631,7 @@ bool display_output_x11::main_loop_wait(double t) {
       }
     }
   }
+  DBGP2("Done with events!");
 
 #ifdef BUILD_XDAMAGE
   if (x11_stuff.damage) {

--- a/src/x11.cc
+++ b/src/x11.cc
@@ -1359,7 +1359,12 @@ void propagate_x11_event(XEvent &ev) {
     i_ev->common.window = window.desktop;
     i_ev->common.x = i_ev->common.x_root;
     i_ev->common.y = i_ev->common.y_root;
+  } else {
+    // Not a known input event; blindly propagating them causes loops and all
+    // sorts of other evil.
+    return;
   }
+  DBGP2("Propagating event: { type: %d; serial: %d }", i_ev->type, i_ev->common.serial);
   XSendEvent(display, window.desktop, False, window.event_mask, &ev);
 
   int _revert_to;


### PR DESCRIPTION
Fixes #1771.

This PR makes `propagate_x11_event` function skip over non-input events. I'm not 100% sure we need/want to propagate damage events as in most cases, whatever is behind conky (feh, mpv, ...) will update without us doing so.
All other event types (FocusIn/FocusOut) don't make sense to propagate either.


