### PR TITLE
Handle external PropertyNotify events

### DIFF
--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -440,7 +440,7 @@ bool display_output_x11::main_loop_wait(double t) {
 #endif /* BUILD_MOUSE_EVENTS && BUILD_XINPUT */
 
     // Any of the remaining events apply to conky window
-    if (ev.xany.window != window.window) continue;
+    if (ev.xany.window != window.window && ev.type != PropertyNotify) continue;
     switch (ev.type) {
       case Expose: {
         XRectangle r;


### PR DESCRIPTION
I made conky ignore non cursor events for other windows in a4ac632db7c76bde63b8e50a0541bbd0cd6a192b, but `PropertyNotify` was reported from root window, which made conky ignore changes to properties on it (e.g. desktop number).

I checked whether any other "external" events should be handled, and it seems only `PropertyNotify` requires exclusion.
