### PR TITLE
Fix event propagation on Openbox

### DIFF
--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -410,6 +410,8 @@ bool display_output_x11::main_loop_wait(double t) {
       if (data->evtype == XI_Motion && is_cursor_move) {
         Window query_result =
             query_x11_window_at_pos(display, data->root_x, data->root_y);
+        // query_result is not window.window in some cases.
+        query_result = query_x11_last_descendant(display, query_result);
 
         static bool cursor_inside = false;
 

--- a/src/x11.cc
+++ b/src/x11.cc
@@ -1401,16 +1401,7 @@ void propagate_x11_event(XEvent &ev) {
   i_ev->common.y = i_ev->common.y_root;
   i_ev->common.time = CurrentTime;
 
-  XUngrabPointer(display, i_ev->common.time);
-
-  // int _revert_to;
-  // Window focused;
-  // XGetInputFocus(display, &focused, &_revert_to);
-  // if (focused == window.window) {
-  //   XSetInputFocus(display, i_ev->common.window, RevertToPointerRoot,
-  //                  i_ev->common.time);
-  // }
-
+  XUngrabPointer(display, CurrentTime);
   XSendEvent(display, i_ev->common.window, False, ev_to_mask(i_ev->type), &ev);
 }
 

--- a/src/x11.cc
+++ b/src/x11.cc
@@ -1399,6 +1399,7 @@ void propagate_x11_event(XEvent &ev) {
   /* forward the event to the window below conky (e.g. caja) or desktop */
   i_ev->common.x = i_ev->common.x_root;
   i_ev->common.y = i_ev->common.y_root;
+  i_ev->common.time = CurrentTime;
 
   XUngrabPointer(display, i_ev->common.time);
 
@@ -1406,9 +1407,8 @@ void propagate_x11_event(XEvent &ev) {
   // Window focused;
   // XGetInputFocus(display, &focused, &_revert_to);
   // if (focused == window.window) {
-  //   Time time = CurrentTime;
-  //   if (i_ev != nullptr) { time = i_ev->common.time; }
-  //   XSetInputFocus(display, i_ev->common.window, RevertToPointerRoot, time);
+  //   XSetInputFocus(display, i_ev->common.window, RevertToPointerRoot,
+  //                  i_ev->common.time);
   // }
 
   XSendEvent(display, i_ev->common.window, False, ev_to_mask(i_ev->type), &ev);

--- a/src/x11.h
+++ b/src/x11.h
@@ -159,6 +159,21 @@ union InputEvent {
 InputEvent *xev_as_input_event(XEvent &ev);
 void propagate_x11_event(XEvent &ev);
 
+/// @brief Tries getting a list of windows ordered from bottom to top.
+///
+/// Whether the list is correctly ordered depends on WM/DE providing the
+/// `_NET_CLIENT_LIST_STACKING` atom. If only `_NET_CLIENT_LIST` is defined,
+/// this function assumes the WM/DE is a tiling one without stacking order.
+///
+/// If neither of the atoms are provided, this function tries traversing the
+/// window graph in order to collect windows. In this case, map state of windows
+/// is ignored. This also produces a lot of noise for some WM/DEs due to
+/// inserted window decorations.
+///
+/// @param display which display to query for windows @return a (likely) ordered
+/// list of windows
+std::vector<Window> query_x11_windows(Display *display);
+
 /// @brief Finds the last descendant of a window (leaf) on the graph.
 ///
 /// This function assumes the window stack below `parent` is linear. If it


### PR DESCRIPTION
Events now get correctly propagated to a window (or desktop if none) _behind_ conky instead of always to desktop.

This PR addresses some of the issues raised in #1767, but it's mainly correcting event propagation/passing.

This was a necessary change to handle cases such as MATE+caja where caja is used between conky and background to show icons and desktop menu.