### PR TITLE
Tweak XSendEvent arguments

### DIFF
--- a/src/x11.cc
+++ b/src/x11.cc
@@ -1410,7 +1410,7 @@ void propagate_x11_event(XEvent &ev) {
   }
 
   XUngrabPointer(display, CurrentTime);
-  XSendEvent(display, i_ev->common.window, False, ev_to_mask(i_ev->type), &ev);
+  XSendEvent(display, i_ev->common.window, True, ev_to_mask(i_ev->type), &ev);
 }
 
 /// @brief This function returns the last descendant of a window (leaf) on the


### PR DESCRIPTION
Set propagate to `True`, to not propagate by default, as discussed in #1767.

XSendEvent `propagate` argument actually means "don't force propagation", so True value means the event will only get propagated if it's not handled, and False means the event will _always_ get propagated.

This is a followup PR to #1802.
