### PR TITLE
Exclusive XInput event handling

### DIFF
--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -488,8 +488,8 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
   // query_result is not window.window in some cases.
   modifier_state_t mods = x11_modifier_state(data->mods.effective);
 
-  bool same_window = query_x11_top_level(display, event_window) ==
-                     query_x11_top_level(display, window.window);
+  bool same_window = query_x11_top_parent(display, event_window) ==
+                     query_x11_top_parent(display, window.window);
   bool cursor_over_conky = same_window && data->root_x >= window.x &&
                            data->root_x < (window.x + window.width) &&
                            data->root_y >= window.y &&

--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -53,7 +53,9 @@
 
 #include <cstdint>
 #include <iostream>
+#include <map>
 #include <sstream>
+#include <tuple>
 #include <unordered_map>
 #include <vector>
 
@@ -442,72 +444,163 @@ bool handle_event(conky::display_output_x11 *surface, Display *display,
 }
 
 #ifdef OWN_WINDOW
-#ifdef BUILD_XINPUT
-template <>
-bool handle_event<x_event_handler::XINPUT_MOTION>(
-    conky::display_output_x11 *surface, Display *display, XEvent &ev,
-    bool *consumed, void **cookie) {
-  if (ev.type != GenericEvent || ev.xcookie.extension != window.xi_opcode)
-    return false;
-
-  if (!XGetEventData(display, &ev.xcookie)) {
-    NORM_ERR("unable to get XInput event data");
-    return false;
-  }
-
-  auto *data = reinterpret_cast<XIDeviceEvent *>(ev.xcookie.data);
-
-  // the only way to differentiate between a scroll and move event is
-  // though valuators - move has first 2 set, other axis movements have
-  // other.
-  bool is_cursor_move =
-      data->valuators.mask_len >= 1 &&
-      (data->valuators.mask[0] & 3) == data->valuators.mask[0];
-  for (std::size_t i = 1; i < data->valuators.mask_len; i++) {
-    if (data->valuators.mask[i] != 0) {
-      is_cursor_move = false;
-      break;
-    }
-  }
-
-  if (data->evtype == XI_Motion && is_cursor_move) {
-    Window query_result =
-        query_x11_window_at_pos(display, data->root_x, data->root_y);
-    // query_result is not window.window in some cases.
-    query_result = query_x11_last_descendant(display, query_result);
-
-    static bool cursor_inside = false;
-
-    // - over conky window
-    // - conky has now window, over desktop and within conky region
-    bool cursor_over_conky =
-        query_result == window.window &&
-        (window.window != 0u || (data->root_x >= window.x &&
-                                 data->root_x < (window.x + window.width) &&
-                                 data->root_y >= window.y &&
-                                 data->root_y < (window.y + window.height)));
-    if (cursor_over_conky) {
-      if (!cursor_inside) {
-        llua_mouse_hook(mouse_crossing_event(
-            mouse_event_t::AREA_ENTER, data->root_x - window.x,
-            data->root_y - window.x, data->root_x, data->root_y));
-      }
-      cursor_inside = true;
-    } else if (cursor_inside) {
-      llua_mouse_hook(mouse_crossing_event(
-          mouse_event_t::AREA_LEAVE, data->root_x - window.x,
-          data->root_y - window.x, data->root_x, data->root_y));
-      cursor_inside = false;
-    }
-  }
-  XFreeEventData(display, &ev.xcookie);
-  return true;
-}
-#endif /* BUILD_XINPUT */
 template <>
 bool handle_event<x_event_handler::MOUSE_INPUT>(
     conky::display_output_x11 *surface, Display *display, XEvent &ev,
     bool *consumed, void **cookie) {
+#ifdef BUILD_XINPUT
+  if (ev.type == ButtonPress || ev.type == ButtonRelease ||
+      ev.type == MotionNotify) {
+    // destroy basic X11 events; and manufacture them later when trying to
+    // propagate XInput ones - this is required because there's no (simple) way
+    // of making sure the lua hook controls both when it only handles XInput
+    // ones.
+    *consumed = true;
+    return true;
+  }
+
+  if (ev.type != GenericEvent || ev.xgeneric.extension != window.xi_opcode)
+    return false;
+
+  auto *data = xi_event_data::read_cookie(display, &ev.xcookie);
+  if (data == nullptr) {
+    NORM_ERR("unable to get XInput event data");
+    return false;
+  }
+  *cookie = data;
+
+  if (data->evtype == XI_DeviceChanged) {
+    int device_id = data->sourceid;
+
+    // update cached device info
+    if (xi_device_info_cache.count(device_id)) {
+      xi_device_info_cache.erase(device_id);
+      conky_device_info::from_xi_id(display, device_id);
+    }
+    return true;
+  }
+
+  Window event_window;
+  modifier_state_t mods;
+  if (data->evtype == XI_Motion || data->evtype == XI_ButtonPress ||
+      data->evtype == XI_ButtonRelease) {
+    event_window = query_x11_window_at_pos(display, data->root_x, data->root_y);
+    // query_result is not window.window in some cases.
+    event_window = query_x11_last_descendant(display, event_window);
+    mods = x11_modifier_state(data->mods.effective);
+  }
+
+  bool cursor_over_conky =
+      (event_window == window.window ||
+       window.window == 0L &&
+           (event_window == window.root || event_window == window.desktop)) &&
+      (data->root_x >= window.x && data->root_x < (window.x + window.width) &&
+       data->root_y >= window.y && data->root_y < (window.y + window.height));
+
+  // XInput reports events twice on some hardware (even by 'xinput --test-xi2')
+  auto hash = std::make_tuple(data->serial, data->evtype, data->event);
+  typedef std::map<decltype(hash), Time> MouseEventDebounceMap;
+  static MouseEventDebounceMap debounce{};
+
+  Time now = data->time;
+  bool already_handled = debounce.count(hash) > 0;
+  debounce[hash] = now;
+
+  // clear stale entries
+  for (auto iter = debounce.begin(); iter != debounce.end();) {
+    if (data->time - iter->second > 1000) {
+      iter = debounce.erase(iter);
+    } else {
+      ++iter;
+    }
+  }
+
+  if (already_handled) {
+    *consumed = true;
+    return true;
+  }
+
+  if (data->evtype == XI_Motion) {
+    auto device_info = conky_device_info::from_xi_id(display, data->deviceid);
+    // TODO: Make valuator_index names configurable?
+
+    // Note that these are absolute (not relative) values in some cases
+    int hor_move_v = device_info->valuators["Rel X"].index;   // Almost always 0
+    int vert_move_v = device_info->valuators["Rel Y"].index;  // Almost always 1
+    int hor_scroll_v =
+        device_info->valuators["Rel Horiz Scroll"].index;  // Almost always 2
+    int vert_scroll_v =
+        device_info->valuators["Rel Vert Scroll"].index;  // Almost always 3
+
+    bool is_move =
+        data->test_valuator(hor_move_v) || data->test_valuator(vert_move_v);
+    bool is_scroll =
+        data->test_valuator(hor_scroll_v) || data->test_valuator(vert_scroll_v);
+
+    if (is_move) {
+      static bool cursor_inside = false;
+
+      // generate crossing events
+      if (cursor_over_conky) {
+        if (!cursor_inside) {
+          *consumed = llua_mouse_hook(mouse_crossing_event(
+              mouse_event_t::AREA_ENTER, data->root_x - window.x,
+              data->root_y - window.x, data->root_x, data->root_y));
+        }
+        cursor_inside = true;
+      } else if (cursor_inside) {
+        *consumed = llua_mouse_hook(mouse_crossing_event(
+            mouse_event_t::AREA_LEAVE, data->root_x - window.x,
+            data->root_y - window.x, data->root_x, data->root_y));
+        cursor_inside = false;
+      }
+
+      // generate movement events
+      if (cursor_over_conky) {
+        *consumed = llua_mouse_hook(mouse_move_event(
+            data->event_x, data->event_y, data->root_x, data->root_y, mods));
+      }
+    }
+    if (is_scroll && cursor_over_conky) {
+      // FIXME: Turn into relative values so direction works
+      auto horizontal = data->valuator_value(hor_scroll_v);
+      if (horizontal.value_or(0.0) != 0.0) {
+        scroll_direction_t direction = horizontal.value() > 0.0
+                                           ? scroll_direction_t::SCROLL_LEFT
+                                           : scroll_direction_t::SCROLL_RIGHT;
+        *consumed = llua_mouse_hook(
+            mouse_scroll_event(data->event_x, data->event_y, data->root_x,
+                               data->root_y, direction, mods));
+      }
+      auto vertical = data->valuator_value(vert_scroll_v);
+      if (vertical.value_or(0.0) != 0.0) {
+        scroll_direction_t direction = vertical.value() > 0.0
+                                           ? scroll_direction_t::SCROLL_DOWN
+                                           : scroll_direction_t::SCROLL_UP;
+        *consumed = llua_mouse_hook(
+            mouse_scroll_event(data->event_x, data->event_y, data->root_x,
+                               data->root_y, direction, mods));
+      }
+    }
+  } else if (cursor_over_conky && (data->evtype == XI_ButtonPress ||
+                                   data->evtype == XI_ButtonRelease)) {
+    if (data->detail >= 4 && data->detail <= 7) {
+      // Handled via motion event valuators, ignoring "backward compatibility"
+      // ones.
+      return true;
+    }
+
+    mouse_event_t type = mouse_event_t::MOUSE_PRESS;
+    if (data->evtype == XI_ButtonRelease) {
+      type = mouse_event_t::MOUSE_RELEASE;
+    }
+
+    mouse_button_t button = x11_mouse_button_code(data->detail);
+    *consumed = llua_mouse_hook(mouse_button_event(type, data->event_x,
+                                                   data->event_y, data->root_x,
+                                                   data->root_y, button, mods));
+  }
+#else /* BUILD_XINPUT */
   if (ev.type != ButtonPress && ev.type != ButtonRelease &&
       ev.type != MotionNotify)
     return false;
@@ -551,7 +644,7 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
   // always propagate mouse input if not handling mouse events
   *consumed = false;
 #endif /* BUILD_MOUSE_EVENTS */
-
+#endif /* BUILD_XINPUT */
   if (!own_window.get(*state)) return true;
   switch (own_window_type.get(*state)) {
     case window_type::TYPE_NORMAL:
@@ -751,9 +844,9 @@ void process_surface_events(conky::display_output_x11 *surface,
     XNextEvent(display, &ev);
 
     /*
-    indicates whether processed event was consumed; true by default so we don't
-    propagate handled events unless they explicitly state they haven't been
-    consumed.
+    indicates whether processed event was consumed; true by default so we
+    don't propagate handled events unless they explicitly state they haven't
+    been consumed.
     */
     bool consumed = true;
     void *cookie = nullptr;

--- a/src/mouse-events.cc
+++ b/src/mouse-events.cc
@@ -543,7 +543,6 @@ std::vector<std::tuple<int, XEvent *>> xi_event_data::generate_events(
       uint scroll_direction = 4;
       auto vertical = this->valuator_relative_value(valuator_t::SCROLL_Y);
       double vertical_value = vertical.value_or(0.0);
-      DBGP2("Vert Scroll: %d", vertical_value);
 
       if (vertical_value != 0.0) {
         scroll_direction = vertical_value < 0.0 ? Button4 : Button5;

--- a/src/mouse-events.cc
+++ b/src/mouse-events.cc
@@ -27,8 +27,19 @@
 
 #include "logging.h"
 
+#ifdef BUILD_XINPUT
+#include <cstring>
+#endif
+
 extern "C" {
 #include <lua.h>
+
+#ifdef BUILD_XINPUT
+#include <X11/extensions/XInput2.h>
+#endif
+
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
 }
 
 namespace conky {
@@ -205,5 +216,238 @@ void mouse_button_event::push_lua_data(lua_State *L) const {
   push_table_value(L, "button", this->button);
   push_mods(L, this->mods);
 }
+
+#ifdef BUILD_XINPUT
+XIDeviceInfoMap xi_device_info_cache{};
+
+conky_device_info *conky_device_info::from_xi_id(Display *display,
+                                                 int device_id) {
+  if (xi_device_info_cache.count(device_id)) {
+    return &xi_device_info_cache[device_id];
+  }
+
+  int num_devices;
+  XIDeviceInfo *device = XIQueryDevice(display, device_id, &num_devices);
+  if (num_devices == 0) { return nullptr; }
+
+  std::map<std::string, xi_valuator_info> valuators;
+  for (int i = 0; i < device->num_classes; i++) {
+    if (device->classes[i]->type != XIValuatorClass) continue;
+
+    XIValuatorClassInfo *class_info = (XIValuatorClassInfo *)device->classes[i];
+    char *label = XGetAtomName(display, class_info->label);
+    if (label == nullptr) {
+      XFree(label);
+      continue;
+    }
+
+    valuators[std::string(label)] =
+        xi_valuator_info{.index = static_cast<size_t>(class_info->number),
+                         .min = class_info->min,
+                         .max = class_info->max};
+    DBGP2("%s - %f %f %f", label, class_info->value, class_info->min,
+          class_info->max);
+    XFree(label);
+  }
+
+  xi_device_info_cache[device_id] =
+      conky_device_info{.device_id = device_id,
+                        .name = std::string(device->name),
+                        .valuators = valuators};
+  XIFreeDeviceInfo(device);
+
+  return &xi_device_info_cache[device_id];
+}
+
+bool xi_event_data::test_valuator(size_t index) const {
+  return this->valuators.count(index) > 0;
+}
+
+std::optional<double> xi_event_data::valuator_value(size_t index) const {
+  if (this->valuators.count(index) == 0) return std::nullopt;
+  return std::optional(this->valuators.at(index));
+}
+
+xi_event_data *xi_event_data::read_cookie(Display *display,
+                                          XGenericEventCookie *cookie) {
+  if (!XGetEventData(display, cookie)) {
+    // already consumed
+    return nullptr;
+  }
+  auto *source = reinterpret_cast<XIDeviceEvent *>(cookie->data);
+
+  uint32_t buttons = 0;
+  for (size_t bi = 1; bi <= source->buttons.mask_len; bi++) {
+    buttons |= source->buttons.mask[bi] << (source->buttons.mask_len - bi) * 8;
+  }
+
+  std::map<size_t, double> valuators{};
+  size_t valuator_index = 0;
+  for (size_t vi = 0; vi < source->valuators.mask_len * 8; vi++) {
+    if (XIMaskIsSet(source->valuators.mask, vi)) {
+      valuators[vi] = source->valuators.values[valuator_index++];
+    }
+  }
+
+  auto result = new xi_event_data{
+      .evtype = static_cast<xi_event_type>(source->evtype),
+      .serial = source->serial,
+      .send_event = source->send_event,
+      .display = source->display,
+      .extension = source->extension,
+      .time = source->time,
+      .deviceid = source->deviceid,
+      .sourceid = source->sourceid,
+      .detail = source->detail,
+      .root = source->root,
+      .event = source->event,
+      .child = source->child,
+      .root_x = source->root_x,
+      .root_y = source->root_y,
+      .event_x = source->event_x,
+      .event_y = source->event_y,
+      .flags = source->flags,
+      .buttons = std::bitset<32>(buttons),
+      .valuators = valuators,
+      .mods = source->mods,
+      .group = source->group,
+  };
+  XFreeEventData(display, cookie);
+
+  return result;
+}
+
+std::vector<std::tuple<int, XEvent *>> xi_event_data::generate_events(
+    Window target, Window child, double target_x, double target_y) const {
+  std::vector<std::tuple<int, XEvent *>> result{};
+
+  if (this->evtype == XI_Motion) {
+    auto device_info = conky_device_info::from_xi_id(display, this->deviceid);
+
+    // Note that these are absolute (not relative) values in some cases
+    int hor_move_v = device_info->valuators["Rel X"].index;   // Almost always 0
+    int vert_move_v = device_info->valuators["Rel Y"].index;  // Almost always 1
+    int hor_scroll_v =
+        device_info->valuators["Rel Horiz Scroll"].index;  // Almost always 2
+    int vert_scroll_v =
+        device_info->valuators["Rel Vert Scroll"].index;  // Almost always 3
+
+    bool is_move =
+        this->test_valuator(hor_move_v) || this->test_valuator(vert_move_v);
+    bool is_scroll =
+        this->test_valuator(hor_scroll_v) || this->test_valuator(vert_scroll_v);
+
+    if (is_move) {
+      XEvent *produced = new XEvent;
+      std::memset(produced, 0, sizeof(XEvent));
+
+      XMotionEvent *e = &produced->xmotion;
+      e->type = MotionNotify;
+      e->display = this->display;
+      e->root = this->root;
+      e->window = target;
+      e->subwindow = child;
+      e->time = CurrentTime;
+      e->x = static_cast<int>(target_x);
+      e->y = static_cast<int>(target_y);
+      e->x_root = static_cast<int>(this->root_x);
+      e->y_root = static_cast<int>(this->root_y);
+      e->state = this->mods.effective;
+      e->is_hint = NotifyNormal;
+      e->same_screen = True;
+      result.emplace_back(std::make_tuple(PointerMotionMask, produced));
+    }
+    if (is_scroll) {
+      XEvent *produced = new XEvent;
+      std::memset(produced, 0, sizeof(XEvent));
+
+      uint scroll_direction = 4;
+      auto vertical = this->valuator_value(vert_scroll_v);
+
+      // FIXME: Turn into relative values so direction works
+      if (vertical.value_or(0.0) != 0.0) {
+        scroll_direction = vertical.value() < 0.0 ? Button4 : Button5;
+      } else {
+        auto horizontal = this->valuator_value(hor_scroll_v);
+        if (horizontal.value_or(0.0) != 0.0) {
+          scroll_direction = horizontal.value() < 0.0 ? 6 : 7;
+        }
+      }
+
+      XButtonEvent *e = &produced->xbutton;
+      e->display = display;
+      e->root = this->root;
+      e->window = target;
+      e->subwindow = child;
+      e->time = CurrentTime;
+      e->x = static_cast<int>(target_x);
+      e->y = static_cast<int>(target_y);
+      e->x_root = static_cast<int>(this->root_x);
+      e->y_root = static_cast<int>(this->root_y);
+      e->state = this->mods.effective;
+      e->button = scroll_direction;
+      e->same_screen = True;
+
+      XEvent *press = new XEvent;
+      e->type = ButtonPress;
+      std::memcpy(press, produced, sizeof(XEvent));
+      result.emplace_back(std::make_tuple(ButtonPressMask, press));
+
+      e->type = ButtonRelease;
+      result.emplace_back(std::make_tuple(ButtonReleaseMask, produced));
+    }
+  } else {
+    XEvent *produced = new XEvent;
+    std::memset(produced, 0, sizeof(XEvent));
+
+    XButtonEvent *e = &produced->xbutton;
+    e->display = display;
+    e->root = this->root;
+    e->window = target;
+    e->subwindow = child;
+    e->time = CurrentTime;
+    e->x = static_cast<int>(target_x);
+    e->y = static_cast<int>(target_y);
+    e->x_root = static_cast<int>(this->root_x);
+    e->y_root = static_cast<int>(this->root_y);
+    e->state = this->mods.effective;
+    e->button = this->detail;
+    e->same_screen = True;
+
+    long event_mask = NoEventMask;
+    switch (this->evtype) {
+      case XI_ButtonPress:
+        e->type = ButtonPress;
+        event_mask = ButtonPressMask;
+        break;
+      case XI_ButtonRelease:
+        e->type = ButtonRelease;
+        event_mask = ButtonReleaseMask;
+        switch (this->detail) {
+          case 1:
+            event_mask |= Button1MotionMask;
+            break;
+          case 2:
+            event_mask |= Button2MotionMask;
+            break;
+          case 3:
+            event_mask |= Button3MotionMask;
+            break;
+          case 4:
+            event_mask |= Button4MotionMask;
+            break;
+          case 5:
+            event_mask |= Button5MotionMask;
+            break;
+        }
+        break;
+    }
+
+    result.emplace_back(std::make_tuple(event_mask, produced));
+  }
+
+  return result;
+}
+#endif /* BUILD_XINPUT */
 
 }  // namespace conky

--- a/src/mouse-events.cc
+++ b/src/mouse-events.cc
@@ -422,11 +422,9 @@ xi_event_data *xi_event_data::read_cookie(Display *display,
   }
 
   std::map<size_t, double> valuators{};
-  size_t valuator_index = 0;
+  double *values = source->valuators.values;
   for (size_t vi = 0; vi < source->valuators.mask_len * 8; vi++) {
-    if (XIMaskIsSet(source->valuators.mask, vi)) {
-      valuators[vi] = source->valuators.values[valuator_index++];
-    }
+    if (XIMaskIsSet(source->valuators.mask, vi)) { valuators[vi] = *values++; }
   }
 
   auto result = new xi_event_data{
@@ -460,7 +458,7 @@ xi_event_data *xi_event_data::read_cookie(Display *display,
   if (device == nullptr) return result;  // shouldn't happen
   for (size_t v = 0; v < valuator_t::VALUATOR_COUNT; v++) {
     valuator_t valuator = static_cast<valuator_t>(v);
-    auto valuator_info = device->valuator(valuator);
+    auto &valuator_info = device->valuator(valuator);
 
     if (result->valuators.count(valuator_info.index) == 0) { continue; }
     auto current = result->valuators[valuator_info.index];

--- a/src/mouse-events.cc
+++ b/src/mouse-events.cc
@@ -251,13 +251,21 @@ void handle_xi_device_change(const XIHierarchyEvent *event) {
   if ((event->flags & XISlaveRemoved) != 0) {
     for (int i = 0; i < event->num_info; i++) {
       auto info = event->info[i];
-      if ((info.flags & XISlaveRemoved) != 0 &&
-          xi_id_mapping.count(info.deviceid) > 0) {
-        size_t id = xi_id_mapping[info.deviceid];
-        xi_id_mapping.erase(info.deviceid);
-        device_info_cache.erase(id);
-        return;
-      }
+      if ((info.flags & XISlaveRemoved) == 0) continue;
+      if (xi_id_mapping.count(info.deviceid) == 0) continue;
+
+      size_t id = xi_id_mapping[info.deviceid];
+      xi_id_mapping.erase(info.deviceid);
+      device_info_cache.erase(id);
+    }
+  }
+
+  if ((event->flags & XISlaveAdded) != 0) {
+    for (int i = 0; i < event->num_info; i++) {
+      auto info = event->info[i];
+      if ((info.flags & XISlaveAdded) == 0) continue;
+      if (info.use == IsXPointer || info.use == IsXExtensionPointer)
+        conky::device_info::from_xi_id(info.deviceid, event->display);
     }
   }
 }

--- a/src/mouse-events.h
+++ b/src/mouse-events.h
@@ -42,7 +42,10 @@ extern "C" {
 #include <X11/X.h>
 
 #ifdef BUILD_XINPUT
+#include <X11/extensions/XInput.h>
 #include <X11/extensions/XInput2.h>
+#undef COUNT  // define from X11/extendsions/Xi.h
+
 #endif /* BUILD_XINPUT */
 #endif /* BUILD_X11 */
 
@@ -54,7 +57,7 @@ extern "C" {
 #include <dev/evdev/input-event-codes.h>
 #elif __DragonFly__
 #include <dev/misc/evdev/input-event-codes.h>
-#else
+#else /* platform */
 // Probably incorrect for some platforms, feel free to add your platform to the
 // above list if it has other event codes or a standard file containing them.
 
@@ -69,7 +72,7 @@ extern "C" {
 #define BTN_BACK 0x116
 // Forward mouse button event code
 #define BTN_FORWARD 0x115
-#endif
+#endif /* platform */
 }
 
 namespace conky {
@@ -260,10 +263,12 @@ struct device_info {
   std::array<conky_valuator_info, valuator_t::VALUATOR_COUNT> valuators{};
 
   static device_info *from_xi_id(xi_device_id id, Display *display = nullptr);
-  void init_xi_device(Display *display,
-                      std::variant<xi_device_id, XIDeviceInfo *> device);
 
   conky_valuator_info &valuator(valuator_t valuator);
+
+ private:
+  void init_xi_device(Display *display,
+                      std::variant<xi_device_id, XIDeviceInfo *> device);
 };
 
 void handle_xi_device_change(const XIHierarchyEvent *event);

--- a/src/mouse-events.h
+++ b/src/mouse-events.h
@@ -259,6 +259,7 @@ struct conky_valuator_info {
 
 struct device_info {
   /// @brief Device name.
+  xi_device_id id;
   std::string name;
   std::array<conky_valuator_info, valuator_t::VALUATOR_COUNT> valuators{};
 
@@ -284,7 +285,7 @@ struct xi_event_data {
   // printing.
   int extension;
   Time time;
-  xi_device_id deviceid;
+  device_info *device;
   int sourceid;
   int detail;
   Window root;
@@ -306,8 +307,7 @@ struct xi_event_data {
   /// Precomputed relative values
   std::array<double, valuator_t::VALUATOR_COUNT> valuators_relative;
 
-  static xi_event_data *read_cookie(Display *display,
-                                    XGenericEventCookie *cookie);
+  static xi_event_data *read_cookie(Display *display, const void *data);
 
   bool test_valuator(valuator_t id) const;
   conky_valuator_info *valuator_info(valuator_t id) const;

--- a/src/mouse-events.h
+++ b/src/mouse-events.h
@@ -241,7 +241,6 @@ struct mouse_crossing_event : public mouse_positioned_event {
 };
 
 #ifdef BUILD_XINPUT
-
 typedef int xi_device_id;
 typedef int xi_event_type;
 
@@ -282,8 +281,6 @@ struct xi_event_data {
   Time time;
   xi_device_id deviceid;
   int sourceid;
-  /// Primary event detail. Meaning depends on `evtype` value:
-  /// XI_ButtonPress - Mouse button
   int detail;
   Window root;
   Window event;
@@ -298,6 +295,11 @@ struct xi_event_data {
   std::map<size_t, double> valuators;
   XIModifierState mods;
   XIGroupState group;
+
+  // Extra data
+
+  /// Precomputed relative values
+  std::array<double, valuator_t::VALUATOR_COUNT> valuators_relative;
 
   static xi_event_data *read_cookie(Display *display,
                                     XGenericEventCookie *cookie);

--- a/src/x11.cc
+++ b/src/x11.cc
@@ -969,6 +969,7 @@ void x11_init_window(lua::state &l, bool own) {
 
     const std::size_t mask_size = (XI_LASTEVENT + 7) / 8;
     unsigned char mask_bytes[mask_size] = {0}; /* must be zeroed! */
+    XISetMask(mask_bytes, XI_HierarchyChanged);
     XISetMask(mask_bytes, XI_Motion);
     // Capture click events for "override" window type
     if (!own) {

--- a/src/x11.cc
+++ b/src/x11.cc
@@ -1499,8 +1499,9 @@ void propagate_x11_event(XEvent &ev, const void *cookie) {
 }
 
 Window query_x11_top_level(Display *display, Window child) {
-  if (child == None) return child;
   Window root = DefaultVRootWindow(display);
+
+  if (child == None || child == root) return child;
 
   Window ret_root, parent, *children;
   std::uint32_t child_count;

--- a/src/x11.cc
+++ b/src/x11.cc
@@ -1434,7 +1434,7 @@ void propagate_xinput_event(const conky::xi_event_data *ev) {
       target = below.back();
 
       // Update event x and y coordinates to be target window relative
-      XTranslateCoordinates(display, window.root, ev->event, ev->root_x,
+      XTranslateCoordinates(display, window.desktop, ev->event, ev->root_x,
                             ev->root_y, &target_x, &target_y, &child);
     }
   }

--- a/src/x11.cc
+++ b/src/x11.cc
@@ -1498,7 +1498,7 @@ void propagate_x11_event(XEvent &ev, const void *cookie) {
   }
 }
 
-Window query_x11_top_level(Display *display, Window child) {
+Window query_x11_top_parent(Display *display, Window child) {
   Window root = DefaultVRootWindow(display);
 
   if (child == None || child == root) return child;

--- a/src/x11.h
+++ b/src/x11.h
@@ -41,6 +41,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <optional>
 #include <vector>
 
 #ifdef BUILD_ARGB
@@ -158,6 +159,14 @@ union InputEvent {
 // otherwise.
 InputEvent *xev_as_input_event(XEvent &ev);
 void propagate_x11_event(XEvent &ev, const void *cookie);
+
+/// @brief Returns a list of window values for the given atom.
+/// @param display display with which the atom is associated
+/// @param window window to query for the atom value
+/// @param atom atom to query for
+/// @return a list of window values for the given atom
+std::vector<Window> x11_atom_window_list(Display *display, Window window,
+                                         Atom atom);
 
 /// @brief Tries getting a list of windows ordered from bottom to top.
 ///

--- a/src/x11.h
+++ b/src/x11.h
@@ -163,7 +163,7 @@ std::vector<Window> query_x11_windows(Display *display);
 /// @param display display of parent
 /// @param child window whose parents to query
 /// @return the top level ascendant window
-Window query_x11_top_level(Display *display, Window child);
+Window query_x11_top_parent(Display *display, Window child);
 
 /// @brief Returns the top-most window overlapping provided screen coordinates.
 ///


### PR DESCRIPTION
This commit builds upon #1819 and makes conky use _only_ XInput for mouse events if `BUILD_MOUSE_EVENTS` is enabled.

This PR makes conky only propagate basic X11 mouse events, because constructing XInput events is a bit tricky (or impossible):
- We can't just forward the event we've received because XInput stores event details in a cookie which can't be claimed multiple times.
- We can't pass them through and ignore them.
- I'm still looking into ways of constructing XInput events.