### PR TITLE
Create missing atom for XIGetProperty request in fixed_valuator_relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Conky is licensed under the terms of the [GPLv3](LICENSE) license.
 
 Contributions are welcome from anyone.
 
-Please read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on contributing to Conky.
+Please read [Contributing](https://github.com/brndnmtthws/conky/wiki/Contributing) page on wiki for guidelines on contributing to Conky.
 
 [mpd]: https://musicpd.org/
 [xmms2]: https://github.com/xmms2/wiki/wiki

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1694,6 +1694,16 @@ bool is_on_battery() {  // checks if at least one battery specified in
 
 volatile sig_atomic_t g_sigterm_pending, g_sighup_pending, g_sigusr2_pending;
 
+void log_system_details() {
+  char *session_ty = getenv("XDG_SESSION_TYPE");
+  char *session = getenv("GDMSESSION");
+  char *desktop = getenv("XDG_CURRENT_DESKTOP");
+  if (desktop != nullptr || session != nullptr) {
+    NORM_ERR("'%s' %s session running '%s' destop", session, session_ty,
+             desktop);
+  }
+}
+
 void main_loop() {
   int terminate = 0;
 #ifdef SIGNAL_BLOCKING
@@ -1715,6 +1725,8 @@ void main_loop() {
   sigaddset(&newmask, SIGTERM);
   sigaddset(&newmask, SIGUSR1);
 #endif
+
+  log_system_details();
 
   last_update_time = 0.0;
   next_update_time = get_time() - fmod(get_time(), active_update_interval());

--- a/src/mouse-events.cc
+++ b/src/mouse-events.cc
@@ -34,10 +34,6 @@
 extern "C" {
 #include <lua.h>
 
-#ifdef BUILD_XINPUT
-#include <X11/extensions/XInput2.h>
-#endif
-
 #include <X11/Xatom.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
@@ -316,7 +312,7 @@ bool fixed_valuator_relative(Display *display, XIDeviceInfo *device,
       "ConkyValuatorScrollMode",
   };
 
-  Atom override_atom = XInternAtom(display, atom_names[valuator >> 1], True);
+  Atom override_atom = XInternAtom(display, atom_names[valuator >> 1], False);
   unsigned char *value_return;
   Atom type_return;
   int format_return;

--- a/src/mouse-events.h
+++ b/src/mouse-events.h
@@ -44,7 +44,7 @@ extern "C" {
 #ifdef BUILD_XINPUT
 #include <X11/extensions/XInput.h>
 #include <X11/extensions/XInput2.h>
-#undef COUNT  // define from X11/extendsions/Xi.h
+#undef COUNT  // define from X11/extensions/Xi.h
 
 #endif /* BUILD_XINPUT */
 #endif /* BUILD_X11 */

--- a/src/x11.cc
+++ b/src/x11.cc
@@ -169,8 +169,8 @@ void use_xdbe_setting::lua_setter(lua::state &l, bool init) {
       l.pushboolean(false);
     }
 
-    fprintf(stderr, PACKAGE_NAME ": drawing to %s buffer\n",
-            do_convert(l, -1).first ? "double" : "single");
+    NORM_ERR("drawing to %s buffer",
+             do_convert(l, -1).first ? "double" : "single");
   }
 
   ++s;
@@ -206,8 +206,8 @@ void use_xpmdb_setting::lua_setter(lua::state &l, bool init) {
       l.pushboolean(false);
     }
 
-    fprintf(stderr, PACKAGE_NAME ": drawing to %s buffer\n",
-            do_convert(l, -1).first ? "double" : "single");
+    NORM_ERR("drawing to %s buffer",
+             do_convert(l, -1).first ? "double" : "single");
   }
 
   ++s;
@@ -374,7 +374,7 @@ static void init_x11() {
       std::string err =
           std::string("can't open display: ") + XDisplayName(disp);
 #ifdef BUILD_WAYLAND
-      fprintf(stderr, "%s\n", err.c_str());
+      NORM_ERR(err.c_str());
       return;
 #else  /* BUILD_WAYLAND */
       throw std::runtime_error(err);
@@ -479,10 +479,10 @@ static Window find_desktop_window(Window root) {
   desktop = find_subwindow(desktop, workarea[2], workarea[3]);
 
   if (desktop != root) {
-    DBGP2("desktop window (0x%lx) is subwindow of root window (0x%lx)", desktop,
-          root);
+    NORM_ERR("desktop window (0x%lx) is subwindow of root window (0x%lx)",
+             desktop, root);
   } else {
-    DBGP2("desktop window (0x%lx) is root window", desktop);
+    NORM_ERR("desktop window (0x%lx) is root window", desktop);
   }
   return desktop;
 }
@@ -659,8 +659,7 @@ void x11_init_window(lua::state &l, bool own) {
       XLowerWindow(display, window.window);
       XSetClassHint(display, window.window, &classHint);
 
-      fprintf(stderr, PACKAGE_NAME ": window type - override\n");
-      fflush(stderr);
+      NORM_ERR("window type - override");
     } else { /* own_window_type.get(l) != TYPE_OVERRIDE */
 
       /* A window managed by the window manager.
@@ -754,29 +753,24 @@ void x11_init_window(lua::state &l, bool own) {
         switch (own_window_type.get(l)) {
           case TYPE_DESKTOP:
             prop = ATOM(_NET_WM_WINDOW_TYPE_DESKTOP);
-            fprintf(stderr, PACKAGE_NAME ": window type - desktop\n");
-            fflush(stderr);
+            NORM_ERR("window type - desktop");
             break;
           case TYPE_DOCK:
             prop = ATOM(_NET_WM_WINDOW_TYPE_DOCK);
-            fprintf(stderr, PACKAGE_NAME ": window type - dock\n");
-            fflush(stderr);
+            NORM_ERR("window type - dock");
             break;
           case TYPE_PANEL:
             prop = ATOM(_NET_WM_WINDOW_TYPE_DOCK);
-            fprintf(stderr, PACKAGE_NAME ": window type - panel\n");
-            fflush(stderr);
+            NORM_ERR("window type - panel");
             break;
           case TYPE_UTILITY:
             prop = ATOM(_NET_WM_WINDOW_TYPE_UTILITY);
-            fprintf(stderr, PACKAGE_NAME ": window type - utility\n");
-            fflush(stderr);
+            NORM_ERR("window type - utility");
             break;
           case TYPE_NORMAL:
           default:
             prop = ATOM(_NET_WM_WINDOW_TYPE_NORMAL);
-            fprintf(stderr, PACKAGE_NAME ": window type - normal\n");
-            fflush(stderr);
+            NORM_ERR("window type - normal");
             break;
         }
         XChangeProperty(display, window.window, xa, XA_ATOM, 32,
@@ -788,9 +782,7 @@ void x11_init_window(lua::state &l, bool own) {
 
       /* Window decorations */
       if (TEST_HINT(hints, HINT_UNDECORATED)) {
-        /* fprintf(stderr, PACKAGE_NAME": hint - undecorated\n");
-           fflush(stderr); */
-
+        DBGP("hint - undecorated");
         xa = ATOM(_MOTIF_WM_HINTS);
         if (xa != None) {
           long prop[5] = {2, 0, 0, 0, 0};
@@ -801,9 +793,7 @@ void x11_init_window(lua::state &l, bool own) {
 
       /* Below other windows */
       if (TEST_HINT(hints, HINT_BELOW)) {
-        /* fprintf(stderr, PACKAGE_NAME": hint - below\n");
-           fflush(stderr); */
-
+        DBGP("hint - below");
         xa = ATOM(_WIN_LAYER);
         if (xa != None) {
           long prop = 0;
@@ -825,9 +815,7 @@ void x11_init_window(lua::state &l, bool own) {
 
       /* Above other windows */
       if (TEST_HINT(hints, HINT_ABOVE)) {
-        /* fprintf(stderr, PACKAGE_NAME": hint - above\n");
-           fflush(stderr); */
-
+        DBGP("hint - above");
         xa = ATOM(_WIN_LAYER);
         if (xa != None) {
           long prop = 6;
@@ -849,9 +837,7 @@ void x11_init_window(lua::state &l, bool own) {
 
       /* Sticky */
       if (TEST_HINT(hints, HINT_STICKY)) {
-        /* fprintf(stderr, PACKAGE_NAME": hint - sticky\n");
-           fflush(stderr); */
-
+        DBGP("hint - sticky");
         xa = ATOM(_NET_WM_DESKTOP);
         if (xa != None) {
           CARD32 xa_prop = 0xFFFFFFFF;
@@ -873,9 +859,7 @@ void x11_init_window(lua::state &l, bool own) {
 
       /* Skip taskbar */
       if (TEST_HINT(hints, HINT_SKIP_TASKBAR)) {
-        /* fprintf(stderr, PACKAGE_NAME": hint - skip_taskbar\n");
-           fflush(stderr); */
-
+        DBGP("hint - skip taskbar");
         xa = ATOM(_NET_WM_STATE);
         if (xa != None) {
           Atom xa_prop = ATOM(_NET_WM_STATE_SKIP_TASKBAR);
@@ -888,9 +872,7 @@ void x11_init_window(lua::state &l, bool own) {
 
       /* Skip pager */
       if (TEST_HINT(hints, HINT_SKIP_PAGER)) {
-        /* fprintf(stderr, PACKAGE_NAME": hint - skip_pager\n");
-           fflush(stderr); */
-
+        DBGP("hint - skip pager");
         xa = ATOM(_NET_WM_STATE);
         if (xa != None) {
           Atom xa_prop = ATOM(_NET_WM_STATE_SKIP_PAGER);
@@ -902,10 +884,7 @@ void x11_init_window(lua::state &l, bool own) {
       }
     }
 
-    fprintf(stderr, PACKAGE_NAME ": drawing to created window (0x%lx)\n",
-            window.window);
-    fflush(stderr);
-
+    NORM_ERR("drawing to created window (0x%lx)", window.window);
     XMapWindow(display, window.window);
   } else
 #endif /* OWN_WINDOW */
@@ -919,7 +898,7 @@ void x11_init_window(lua::state &l, bool own) {
       window.height = attrs.height;
     }
 
-    fprintf(stderr, PACKAGE_NAME ": drawing to desktop window\n");
+    NORM_ERR("drawing to desktop window");
   }
 
   /* Drawable is same as window. This may be changed by double buffering. */


### PR DESCRIPTION
I'm assuming sending `None` Atom in the request will cause an error. I defined those properties on my platform so that's why the function didn't fail.

Should close #1833.

## Out of scope

- Updated contributing link in project `README.md`
- Added session and desktop printing to reduce back and forth in issues
  - GDM seems to be the only DM that defines session env variable.
- Replaced `fprintf(stderr,...` with `NORM_ERR` in x11.cc