### PR TITLE
Annoyingly, the artifacts go into a subdir

### DIFF
--- a/.github/workflows/publish-appimage.yml
+++ b/.github/workflows/publish-appimage.yml
@@ -145,5 +145,6 @@ jobs:
           prerelease: false
           discussion_category_name: General
           generate_release_notes: true
+          fail_on_unmatched_files: true
           files: |
-            ${{ github.workspace }}/artifacts/*
+            ${{ github.workspace }}/artifacts/**/*


### PR DESCRIPTION
The artifact files are actually zip files, and when extracted, are in subdirs within the artifact path.