### PR TITLE
Separate cairo-xlib.h Lua bindings from cairo.h

### DIFF
--- a/.github/workflows/build-and-test-linux.yaml
+++ b/.github/workflows/build-and-test-linux.yaml
@@ -87,7 +87,7 @@ jobs:
             lcov \
             libaudclient-dev \
             libcairo2-dev \
-            libcurl4-gnutls-dev \
+            libpango1.0-dev \
             libcurl4-gnutls-dev \
             libdbus-glib-1-dev \
             libglib2.0-dev \
@@ -148,6 +148,7 @@ jobs:
             -DBUILD_IRC=ON                       \
             -DBUILD_JOURNAL=ON                   \
             -DBUILD_LUA_CAIRO=ON                 \
+            -DBUILD_LUA_CAIRO_XLIB=ON            \
             -DBUILD_LUA_IMLIB2=ON                \
             -DBUILD_LUA_RSVG=${RSVG_ENABLED}     \
             -DBUILD_MYSQL=ON                     \

--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,6 @@ CMakeCache.txt
 CMakeFiles
 data/convertconf.h
 data/defconfig.h
-lua/libcairo-orig.c
-lua/libcairo.c
-lua/libimlib2.c
 *.so
 *.a
 /config.h

--- a/cmake/ConkyBuildOptions.cmake
+++ b/cmake/ConkyBuildOptions.cmake
@@ -211,6 +211,9 @@ dependent_option(BUILD_MOUSE_EVENTS "Enable mouse event support" true
 
 # Lua library options
 option(BUILD_LUA_CAIRO "Build cairo bindings for Lua" false)
+dependent_option(BUILD_LUA_CAIRO_XLIB "Build Imlib2 bindings for Lua" true
+  "BUILD_X11;BUILD_LUA_CAIRO" false
+  "Lua support for Cairo Xlib requires Cairo and X11")
 dependent_option(BUILD_LUA_IMLIB2 "Build Imlib2 bindings for Lua" false
   "BUILD_X11;BUILD_IMLIB2" false
   "Imlib2 Lua bindings require X11 and Imlib2")

--- a/cmake/ConkyBuildOptions.cmake
+++ b/cmake/ConkyBuildOptions.cmake
@@ -210,14 +210,18 @@ dependent_option(BUILD_MOUSE_EVENTS "Enable mouse event support" true
   "Mouse event support requires Wayland or OWN_WINDOW enabled")
 
 # Lua library options
-option(BUILD_LUA_CAIRO "Build cairo bindings for Lua" false)
+dependent_option(BUILD_LUA_CAIRO "Build cairo bindings for Lua" false
+  "BUILD_GUI" false
+  "Cairo Lua bindings depend on BUILD_GUI")
 dependent_option(BUILD_LUA_CAIRO_XLIB "Build Imlib2 bindings for Lua" true
   "BUILD_X11;BUILD_LUA_CAIRO" false
-  "Lua support for Cairo Xlib requires Cairo and X11")
+  "Cairo Xlib Lua bindings require Cairo and X11")
 dependent_option(BUILD_LUA_IMLIB2 "Build Imlib2 bindings for Lua" false
   "BUILD_X11;BUILD_IMLIB2" false
   "Imlib2 Lua bindings require X11 and Imlib2")
-option(BUILD_LUA_RSVG "Build rsvg bindings for Lua" false)
+dependent_option(BUILD_LUA_RSVG "Build rsvg bindings for Lua" false
+  "BUILD_GUI" false
+  "RSVG Lua bindings depend on BUILD_GUI")
 
 option(BUILD_AUDACIOUS "Build audacious (music player) support" false)
 

--- a/cmake/ConkyPlatformChecks.cmake
+++ b/cmake/ConkyPlatformChecks.cmake
@@ -472,15 +472,19 @@ if(BUILD_WAYLAND)
     set(conky_includes ${conky_includes} ${EPOLL_INCLUDE_DIRS})
   endif(OS_DARWIN OR OS_DRAGONFLY OR OS_FREEBSD OR OS_NETBSD OR OS_OPENBSD)
 
-  pkg_check_modules(PANGOCAIRO pangocairo)
+  pkg_check_modules(CAIRO REQUIRED cairo)
+  set(conky_libs ${conky_libs} ${CAIRO_LIBRARIES})
+  set(conky_includes ${conky_includes} ${CAIRO_INCLUDE_DIR})
+
+  pkg_check_modules(PANGOCAIRO REQUIRED pangocairo)
   set(conky_libs ${conky_libs} ${PANGOCAIRO_LIBRARIES})
   set(conky_includes ${conky_includes} ${PANGOCAIRO_INCLUDE_DIRS})
 
-  pkg_check_modules(PANGOFC pangofc)
+  pkg_check_modules(PANGOFC REQUIRED pangofc)
   set(conky_libs ${conky_libs} ${PANGOFC_LIBRARIES})
   set(conky_includes ${conky_includes} ${PANGOFC_INCLUDE_DIRS})
 
-  pkg_check_modules(PANGOFT2 pangoft2)
+  pkg_check_modules(PANGOFT2 REQUIRED pangoft2)
   set(conky_libs ${conky_libs} ${PANGOFT2_LIBRARIES})
   set(conky_includes ${conky_includes} ${PANGOFT2_INCLUDE_DIRS})
 endif(BUILD_WAYLAND)
@@ -494,9 +498,16 @@ include_directories(3rdparty/toluapp/include)
 if(BUILD_GUI)
   # Check for libraries used by Lua bindings
   if(BUILD_LUA_CAIRO)
-    pkg_check_modules(CAIRO REQUIRED cairo>=1.14 cairo-xlib)
+    pkg_check_modules(CAIRO REQUIRED cairo>=1.14)
     set(luacairo_libs ${CAIRO_LIBRARIES} ${LUA_LIBRARIES})
     set(luacairo_includes ${CAIRO_INCLUDE_DIRS} ${LUA_INCLUDE_DIR})
+
+    if(BUILD_LUA_CAIRO_XLIB)
+      pkg_check_modules(CAIROXLIB REQUIRED cairo-xlib)
+      set(luacairo_libs ${CAIROXLIB_LIBRARIES} ${luacairo_libs})
+      set(luacairo_includes ${CAIROXLIB_INCLUDE_DIRS} ${luacairo_includes})
+    endif(BUILD_LUA_CAIRO_XLIB)
+    
     find_program(APP_PATCH patch)
 
     if(NOT APP_PATCH)

--- a/cmake/ConkyPlatformChecks.cmake
+++ b/cmake/ConkyPlatformChecks.cmake
@@ -476,15 +476,19 @@ if(BUILD_WAYLAND)
   set(conky_libs ${conky_libs} ${CAIRO_LIBRARIES})
   set(conky_includes ${conky_includes} ${CAIRO_INCLUDE_DIR})
 
-  pkg_check_modules(PANGOCAIRO REQUIRED pangocairo)
+  pkg_check_modules(PANGO REQUIRED pango)
+  set(conky_libs ${conky_libs} ${PANGO_LIBRARIES})
+  set(conky_includes ${conky_includes} ${PANGO_INCLUDE_DIRS})
+
+  pkg_check_modules(PANGOCAIRO pangocairo)
   set(conky_libs ${conky_libs} ${PANGOCAIRO_LIBRARIES})
   set(conky_includes ${conky_includes} ${PANGOCAIRO_INCLUDE_DIRS})
 
-  pkg_check_modules(PANGOFC REQUIRED pangofc)
+  pkg_check_modules(PANGOFC pangofc)
   set(conky_libs ${conky_libs} ${PANGOFC_LIBRARIES})
   set(conky_includes ${conky_includes} ${PANGOFC_INCLUDE_DIRS})
 
-  pkg_check_modules(PANGOFT2 REQUIRED pangoft2)
+  pkg_check_modules(PANGOFT2 pangoft2)
   set(conky_libs ${conky_libs} ${PANGOFT2_LIBRARIES})
   set(conky_includes ${conky_includes} ${PANGOFT2_INCLUDE_DIRS})
 endif(BUILD_WAYLAND)

--- a/cmake/ConkyPlatformChecks.cmake
+++ b/cmake/ConkyPlatformChecks.cmake
@@ -499,41 +499,39 @@ set(conky_libs ${conky_libs} ${LUA_LIBRARIES})
 set(conky_includes ${conky_includes} ${LUA_INCLUDE_DIR})
 include_directories(3rdparty/toluapp/include)
 
-if(BUILD_GUI)
-  # Check for libraries used by Lua bindings
-  if(BUILD_LUA_CAIRO)
-    pkg_check_modules(CAIRO REQUIRED cairo>=1.14)
-    set(luacairo_libs ${CAIRO_LIBRARIES} ${LUA_LIBRARIES})
-    set(luacairo_includes ${CAIRO_INCLUDE_DIRS} ${LUA_INCLUDE_DIR})
+# Check for libraries used by Lua bindings
+if(BUILD_LUA_CAIRO)
+  pkg_check_modules(CAIRO REQUIRED cairo>=1.14)
+  set(luacairo_libs ${CAIRO_LIBRARIES} ${LUA_LIBRARIES})
+  set(luacairo_includes ${CAIRO_INCLUDE_DIRS} ${LUA_INCLUDE_DIR})
 
-    if(BUILD_LUA_CAIRO_XLIB)
-      pkg_check_modules(CAIROXLIB REQUIRED cairo-xlib)
-      set(luacairo_libs ${CAIROXLIB_LIBRARIES} ${luacairo_libs})
-      set(luacairo_includes ${CAIROXLIB_INCLUDE_DIRS} ${luacairo_includes})
-    endif(BUILD_LUA_CAIRO_XLIB)
-    
-    find_program(APP_PATCH patch)
+  if(BUILD_LUA_CAIRO_XLIB)
+    pkg_check_modules(CAIROXLIB REQUIRED cairo-xlib)
+    set(luacairo_libs ${CAIROXLIB_LIBRARIES} ${luacairo_libs})
+    set(luacairo_includes ${CAIROXLIB_INCLUDE_DIRS} ${luacairo_includes})
+  endif(BUILD_LUA_CAIRO_XLIB)
+  
+  find_program(APP_PATCH patch)
 
-    if(NOT APP_PATCH)
-      message(FATAL_ERROR "Unable to find program 'patch'")
-    endif(NOT APP_PATCH)
-  endif(BUILD_LUA_CAIRO)
+  if(NOT APP_PATCH)
+    message(FATAL_ERROR "Unable to find program 'patch'")
+  endif(NOT APP_PATCH)
+endif(BUILD_LUA_CAIRO)
 
-  if(BUILD_X11 AND BUILD_LUA_IMLIB2)
-    pkg_search_module(IMLIB2 REQUIRED imlib2 Imlib2)
-    set(luaimlib2_libs ${IMLIB2_LIBS} ${IMLIB2_LDFLAGS} ${LUA_LIBRARIES})
-    set(luaimlib2_includes
-      ${IMLIB2_INCLUDE_DIRS}
-      ${LUA_INCLUDE_DIR}
-      ${X11_INCLUDE_DIR})
-  endif(BUILD_X11 AND BUILD_LUA_IMLIB2)
+if(BUILD_LUA_IMLIB2)
+  pkg_search_module(IMLIB2 REQUIRED imlib2 Imlib2)
+  set(luaimlib2_libs ${IMLIB2_LIBS} ${IMLIB2_LDFLAGS} ${LUA_LIBRARIES})
+  set(luaimlib2_includes
+    ${IMLIB2_INCLUDE_DIRS}
+    ${LUA_INCLUDE_DIR}
+    ${X11_INCLUDE_DIR})
+endif(BUILD_LUA_IMLIB2)
 
-  if(BUILD_LUA_RSVG)
-    pkg_check_modules(RSVG REQUIRED librsvg-2.0>=2.52)
-    set(luarsvg_libs ${RSVG_LIBRARIES} ${LUA_LIBRARIES})
-    set(luarsvg_includes ${RSVG_INCLUDE_DIRS} ${LUA_INCLUDE_DIR})
-  endif(BUILD_LUA_RSVG)
-endif(BUILD_GUI)
+if(BUILD_LUA_RSVG)
+  pkg_check_modules(RSVG REQUIRED librsvg-2.0>=2.52)
+  set(luarsvg_libs ${RSVG_LIBRARIES} ${LUA_LIBRARIES})
+  set(luarsvg_includes ${RSVG_INCLUDE_DIRS} ${LUA_INCLUDE_DIR})
+endif(BUILD_LUA_RSVG)
 
 if(BUILD_AUDACIOUS)
   set(WANT_GLIB true)

--- a/lua/.gitignore
+++ b/lua/.gitignore
@@ -1,0 +1,2 @@
+*.cc
+cmake_install.cmake

--- a/lua/CMakeLists.txt
+++ b/lua/CMakeLists.txt
@@ -22,74 +22,91 @@ include(ToLua)
 
 add_definitions(-DTOLUA_RELEASE)
 
-if(BUILD_X11)
-  if(BUILD_LUA_CAIRO)
-    include_directories(${luacairo_includes} ${CMAKE_CURRENT_SOURCE_DIR})
+# NOTE: Don't chain options in IFs here, their dependency is already handled by
+# ConkyBuildOptions.cmake
 
-    # Need the directory for -lSM
-    get_filename_component(X11_SM_LIB_PATH ${X11_SM_LIB} DIRECTORY)
-    link_directories(${X11_SM_LIB_PATH})
+if(BUILD_LUA_CAIRO)
+  include_directories(${luacairo_includes} ${CMAKE_CURRENT_SOURCE_DIR})
 
-    # cairo_set_dash() needs this special hack to work properly if you have a
-    # better solution, please let me know
-    wrap_tolua(luacairo_src cairo.pkg libcairo.patch)
+  # cairo_set_dash() needs this special hack to work properly if you have a
+  # better solution, please let me know
+  wrap_tolua(luacairo_src cairo.pkg libcairo.patch)
 
-    add_library(conky-cairo SHARED ${luacairo_src})
-    set_target_properties(conky-cairo PROPERTIES OUTPUT_NAME "cairo")
+  add_library(conky-cairo SHARED ${luacairo_src})
+  set_target_properties(conky-cairo PROPERTIES OUTPUT_NAME "cairo")
 
-    target_link_libraries(conky-cairo ${luacairo_libs} toluapp_lib_static)
-    set(lua_libs ${lua_libs} conky-cairo)
+  target_link_libraries(conky-cairo ${luacairo_libs} toluapp_lib_static)
+  set(lua_libs ${lua_libs} conky-cairo)
 
-    print_target_properties(conky-cairo)
-  endif(BUILD_LUA_CAIRO)
+  print_target_properties(conky-cairo)
+endif(BUILD_LUA_CAIRO)
 
-  if(BUILD_LUA_IMLIB2)
-    include_directories(${luaimlib2_includes} ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/src)
+if(BUILD_LUA_CAIRO_XLIB)
+  include_directories(${luacairoxlib_includes} ${CMAKE_CURRENT_SOURCE_DIR})
 
-    if(IMLIB2_VERSION VERSION_GREATER_EQUAL "1.10.0")
-      wrap_tolua(luaimlib2_src imlib2.pkg)
-    else(IMLIB2_VERSION VERSION_GREATER_EQUAL "1.10.0")
-      wrap_tolua(luaimlib2_src imlib2_old.pkg)
-    endif(IMLIB2_VERSION VERSION_GREATER_EQUAL "1.10.0")
+  # Need the directory for -lSM
+  get_filename_component(X11_SM_LIB_PATH ${X11_SM_LIB} DIRECTORY)
+  link_directories(${X11_SM_LIB_PATH})
+  wrap_tolua(luacairoxlib_src cairo_xlib.pkg)
 
-    add_library(conky-imlib2 SHARED ${luaimlib2_src})
-    set_target_properties(conky-imlib2 PROPERTIES OUTPUT_NAME "imlib2")
+  add_library(conky-cairo_xlib SHARED ${luacairoxlib_src})
+  set_target_properties(conky-cairo_xlib PROPERTIES OUTPUT_NAME "cairo")
 
-    target_link_libraries(conky-imlib2 ${luaimlib2_libs} toluapp_lib_static)
-    set(lua_libs ${lua_libs} conky-imlib2)
+  target_link_libraries(conky-cairo_xlib
+    ${luacairoxlib_libs}
+    ${luacairo_libs}
+    toluapp_lib_static)
+  set(lua_libs ${lua_libs} conky-cairo_xlib)
 
-    print_target_properties(conky-imlib2)
-  endif(BUILD_LUA_IMLIB2)
+  print_target_properties(conky-cairo_xlib)
+endif(BUILD_LUA_CAIRO_XLIB)
 
-  if(BUILD_LUA_RSVG)
-    include_directories(${luarsvg_includes} ${CMAKE_CURRENT_SOURCE_DIR})
-    wrap_tolua(luarsvg_src rsvg.pkg)
+if(BUILD_LUA_IMLIB2)
+  include_directories(${luaimlib2_includes} ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/src)
 
-    add_library(conky-rsvg SHARED ${luarsvg_src})
-    set_target_properties(conky-rsvg PROPERTIES OUTPUT_NAME "rsvg")
+  if(IMLIB2_VERSION VERSION_GREATER_EQUAL "1.10.0")
+    wrap_tolua(luaimlib2_src imlib2.pkg)
+  else(IMLIB2_VERSION VERSION_GREATER_EQUAL "1.10.0")
+    wrap_tolua(luaimlib2_src imlib2_old.pkg)
+  endif(IMLIB2_VERSION VERSION_GREATER_EQUAL "1.10.0")
 
-    target_link_libraries(conky-rsvg ${luarsvg_libs} toluapp_lib_static)
-    set(lua_libs ${lua_libs} conky-rsvg)
+  add_library(conky-imlib2 SHARED ${luaimlib2_src})
+  set_target_properties(conky-imlib2 PROPERTIES OUTPUT_NAME "imlib2")
 
-    print_target_properties(conky-rsvg)
-  endif(BUILD_LUA_RSVG)
+  target_link_libraries(conky-imlib2 ${luaimlib2_libs} toluapp_lib_static)
+  set(lua_libs ${lua_libs} conky-imlib2)
 
-  if(BUILD_LUA_CAIRO AND BUILD_LUA_IMLIB2)
-    include_directories(${luacairo_includes} ${luaimlib2_includes}
-      ${CMAKE_CURRENT_SOURCE_DIR})
-    wrap_tolua(luacairo_imlib2_helper_src cairo_imlib2_helper.pkg)
+  print_target_properties(conky-imlib2)
+endif(BUILD_LUA_IMLIB2)
 
-    add_library(conky-cairo_imlib2_helper SHARED ${luacairo_imlib2_helper_src})
-    set_target_properties(conky-cairo_imlib2_helper
-      PROPERTIES OUTPUT_NAME "cairo_imlib2_helper")
+if(BUILD_LUA_IMLIB2)
+  include_directories(${luacairo_includes} ${luaimlib2_includes}
+    ${CMAKE_CURRENT_SOURCE_DIR})
+  wrap_tolua(luacairo_imlib2_helper_src cairo_imlib2_helper.pkg)
 
-    target_link_libraries(conky-cairo_imlib2_helper
-      ${luacairo_libs}
-      ${luaimlib2_libs}
-      toluapp_lib_static)
-    set(lua_libs ${lua_libs} conky-cairo_imlib2_helper)
-  endif(BUILD_LUA_CAIRO AND BUILD_LUA_IMLIB2)
-endif(BUILD_X11)
+  add_library(conky-cairo_imlib2_helper SHARED ${luacairo_imlib2_helper_src})
+  set_target_properties(conky-cairo_imlib2_helper
+    PROPERTIES OUTPUT_NAME "cairo_imlib2_helper")
+
+  target_link_libraries(conky-cairo_imlib2_helper
+    ${luacairo_libs}
+    ${luaimlib2_libs}
+    toluapp_lib_static)
+  set(lua_libs ${lua_libs} conky-cairo_imlib2_helper)
+endif(BUILD_LUA_IMLIB2)
+
+if(BUILD_LUA_RSVG)
+  include_directories(${luarsvg_includes} ${CMAKE_CURRENT_SOURCE_DIR})
+  wrap_tolua(luarsvg_src rsvg.pkg)
+
+  add_library(conky-rsvg SHARED ${luarsvg_src})
+  set_target_properties(conky-rsvg PROPERTIES OUTPUT_NAME "rsvg")
+
+  target_link_libraries(conky-rsvg ${luarsvg_libs} toluapp_lib_static)
+  set(lua_libs ${lua_libs} conky-rsvg)
+
+  print_target_properties(conky-rsvg)
+endif(BUILD_LUA_RSVG)
 
 install(TARGETS ${lua_libs}
   LIBRARY DESTINATION ${LIB_INSTALL_DIR}/conky

--- a/lua/CMakeLists.txt
+++ b/lua/CMakeLists.txt
@@ -50,7 +50,7 @@ if(BUILD_LUA_CAIRO_XLIB)
   wrap_tolua(luacairoxlib_src cairo_xlib.pkg)
 
   add_library(conky-cairo_xlib SHARED ${luacairoxlib_src})
-  set_target_properties(conky-cairo_xlib PROPERTIES OUTPUT_NAME "cairo")
+  set_target_properties(conky-cairo_xlib PROPERTIES OUTPUT_NAME "cairo_xlib")
 
   target_link_libraries(conky-cairo_xlib
     ${luacairoxlib_libs}

--- a/lua/cairo.pkg
+++ b/lua/cairo.pkg
@@ -1,12 +1,10 @@
 $#include <cairo-features.h>
 $#include <cairo-deprecated.h>
 $#include <cairo.h>
-$#include <cairo-xlib.h>
-$#include <X11/Xlib.h>
 $#include <libcairo-helper.h>
 /*
- * This code was mostly copied from cairo.h and cairo-xlib.h with comments
- * removed.  The licence noticed below is present for the sake of clarity.
+ * This code was mostly copied from cairo.h with comments removed.  The
+ * license notice below is present for the sake of clarity.
  */
 
 /* cairo - a vector graphics library with display and print output
@@ -190,33 +188,6 @@ typedef enum _cairo_filter {
 	CAIRO_FILTER_BILINEAR,
 	CAIRO_FILTER_GAUSSIAN
 } cairo_filter_t;
-
-cairo_surface_t *cairo_xlib_surface_create(Display * dpy,
-		Drawable drawable,
-		Visual * visual, int width, int height);
-
-cairo_surface_t *cairo_xlib_surface_create_for_bitmap(Display * dpy,
-		Pixmap bitmap,
-		Screen * screen, int width, int height);
-
-void cairo_xlib_surface_set_size(cairo_surface_t * surface, int width, int height);
-
-void cairo_xlib_surface_set_drawable(cairo_surface_t * surface, Drawable
-		drawable, int width, int height);
-
-Display *cairo_xlib_surface_get_display(cairo_surface_t * surface);
-
-Drawable cairo_xlib_surface_get_drawable(cairo_surface_t * surface);
-
-Screen *cairo_xlib_surface_get_screen(cairo_surface_t * surface);
-
-Visual *cairo_xlib_surface_get_visual(cairo_surface_t * surface);
-
-int cairo_xlib_surface_get_depth(cairo_surface_t * surface);
-
-int cairo_xlib_surface_get_width(cairo_surface_t * surface);
-
-int cairo_xlib_surface_get_height(cairo_surface_t * surface);
 
 int cairo_version(void);
 

--- a/lua/cairo_xlib.pkg
+++ b/lua/cairo_xlib.pkg
@@ -1,0 +1,71 @@
+$#include <cairo.h>
+$#include <cairo-xlib.h>
+$#include <X11/Xlib.h>
+/*
+ * This code was mostly copied from cairo-xlib.h with comments removed.  The
+ * license notice below is present for the sake of clarity.
+ */
+
+/* cairo - a vector graphics library with display and print output
+ *
+ * Copyright © 2002 University of Southern California
+ * Copyright © 2005 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it either under the terms of the GNU Lesser General Public
+ * License version 2.1 as published by the Free Software Foundation
+ * (the "LGPL") or, at your option, under the terms of the Mozilla
+ * Public License Version 1.1 (the "MPL"). If you do not alter this
+ * notice, a recipient may use your version of this file under either
+ * the MPL or the LGPL.
+ *
+ * You should have received a copy of the LGPL along with this library
+ * in the file COPYING-LGPL-2.1; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * You should have received a copy of the MPL along with this library
+ * in the file COPYING-MPL-1.1
+ *
+ * The contents of this file are subject to the Mozilla Public License
+ * Version 1.1 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY
+ * OF ANY KIND, either express or implied. See the LGPL or the MPL for
+ * the specific language governing rights and limitations.
+ *
+ * The Original Code is the cairo graphics library.
+ *
+ * The Initial Developer of the Original Code is University of Southern
+ * California.
+ *
+ * Contributor(s):
+ *	Carl D. Worth <cworth@cworth.org>
+ */
+
+cairo_surface_t *cairo_xlib_surface_create(Display * dpy,
+		Drawable drawable,
+		Visual * visual, int width, int height);
+
+cairo_surface_t *cairo_xlib_surface_create_for_bitmap(Display * dpy,
+		Pixmap bitmap,
+		Screen * screen, int width, int height);
+
+void cairo_xlib_surface_set_size(cairo_surface_t * surface, int width, int height);
+
+void cairo_xlib_surface_set_drawable(cairo_surface_t * surface, Drawable
+		drawable, int width, int height);
+
+Display *cairo_xlib_surface_get_display(cairo_surface_t * surface);
+
+Drawable cairo_xlib_surface_get_drawable(cairo_surface_t * surface);
+
+Screen *cairo_xlib_surface_get_screen(cairo_surface_t * surface);
+
+Visual *cairo_xlib_surface_get_visual(cairo_surface_t * surface);
+
+int cairo_xlib_surface_get_depth(cairo_surface_t * surface);
+
+int cairo_xlib_surface_get_width(cairo_surface_t * surface);
+
+int cairo_xlib_surface_get_height(cairo_surface_t * surface);


### PR DESCRIPTION
This allows cairo.h to be used from Lua on Wayland without X11 as requirement.

A way of creating surfaces in Lua that uses Shm allocated buffers should be added in future. This PR only cleans up build options to avoid weird errors.

Closes #1804 - `BUILD_LUA_CAIRO` didn't depend on X11 and `lua/CMakeLists.txt` doesn't provide warnings like `dependent_option`s do, so it wasn't clear why the build was failing with `BUILD_LUA_CAIRO && !BUILD_X11`.