### PR TITLE
set_struts improvements

### DIFF
--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -313,37 +313,8 @@ bool display_output_x11::main_loop_wait(double t) {
 
       /* update struts */
       if ((changed != 0) && own_window_type.get(*state) == window_type::PANEL) {
-        int sidenum = -1;
-
         NORM_ERR("defining struts");
-
-        alignment align = text_alignment.get(*state);
-        switch (align) {
-          case alignment::TOP_LEFT:
-          case alignment::TOP_RIGHT:
-          case alignment::TOP_MIDDLE: {
-            sidenum = 2;
-            break;
-          }
-          case alignment::BOTTOM_LEFT:
-          case alignment::BOTTOM_RIGHT:
-          case alignment::BOTTOM_MIDDLE: {
-            sidenum = 3;
-            break;
-          }
-          case alignment::MIDDLE_LEFT: {
-            sidenum = 0;
-            break;
-          }
-          case alignment::MIDDLE_RIGHT: {
-            sidenum = 1;
-            break;
-          }
-          default:
-            break;
-        }
-
-        if (sidenum != -1) set_struts(sidenum);
+        set_struts(text_alignment.get(*state));
       }
     }
 #endif

--- a/src/x11.cc
+++ b/src/x11.cc
@@ -1116,29 +1116,7 @@ void set_struts(alignment align) {
   Atom strut = ATOM(_NET_WM_STRUT);
   if (strut != None) {
     long sizes[STRUT_COUNT] = {0};
-    int i;
 
-    switch (vertical_alignment(align)) {
-      case axis_align::START:
-        sizes[*x11_strut::TOP] =
-            std::clamp(window.y + window.height, 0, display_height);
-        sizes[*x11_strut::TOP_START_X] = std::clamp(window.x, 0, display_width);
-        sizes[*x11_strut::TOP_END_X] =
-            std::clamp(window.x + window.width + 6, 0, display_width);
-        break;
-      case axis_align::END:
-        sizes[*x11_strut::BOTTOM] =
-            std::clamp(display_height - window.y, 0, display_height);
-        sizes[*x11_strut::BOTTOM_START_X] =
-            std::clamp(window.x, 0, display_width);
-        sizes[*x11_strut::BOTTOM_END_X] =
-            std::clamp(window.x + window.width, 0, display_width);
-        break;
-      case axis_align::MIDDLE:
-        // can't reserve space in middle of the screen
-      default:
-        break;
-    }
     switch (horizontal_alignment(align)) {
       case axis_align::START:
         sizes[*x11_strut::LEFT] =
@@ -1157,7 +1135,28 @@ void set_struts(alignment align) {
             std::clamp(window.y + window.height, 0, display_height);
         break;
       case axis_align::MIDDLE:
-        // can't reserve space in middle of the screen
+        switch (vertical_alignment(align)) {
+          case axis_align::START:
+            sizes[*x11_strut::TOP] =
+                std::clamp(window.y + window.height, 0, display_height);
+            sizes[*x11_strut::TOP_START_X] =
+                std::clamp(window.x, 0, display_width);
+            sizes[*x11_strut::TOP_END_X] =
+                std::clamp(window.x + window.width, 0, display_width);
+            break;
+          case axis_align::END:
+            sizes[*x11_strut::BOTTOM] =
+                std::clamp(display_height - window.y, 0, display_height);
+            sizes[*x11_strut::BOTTOM_START_X] =
+                std::clamp(window.x, 0, display_width);
+            sizes[*x11_strut::BOTTOM_END_X] =
+                std::clamp(window.x + window.width, 0, display_width);
+            break;
+          case axis_align::MIDDLE:
+            // can't reserve space in middle of the screen
+          default:
+            break;
+        }
       default:
         break;
     }

--- a/src/x11.cc
+++ b/src/x11.cc
@@ -1108,60 +1108,66 @@ constexpr size_t operator*(x11_strut index) {
 }
 
 /* reserve window manager space */
-void set_struts(int sidenum) {
-  Atom strut;
-  if ((strut = ATOM(_NET_WM_STRUT)) != None) {
-    /* reserve space at left, right, top, bottom */
-    signed long sizes[12] = {0};
+void set_struts(alignment align) {
+  // Middle and none align don't have least significant bit set.
+  // Ensures either vertical or horizontal axis are start/end
+  if ((*align & 0b0101) == 0) return;
+
+  Atom strut = ATOM(_NET_WM_STRUT);
+  if (strut != None) {
+    long sizes[STRUT_COUNT] = {0};
     int i;
 
-    /* define strut depth */
-    switch (sidenum) {
-      case 0:
-        /* left side */
-        sizes[0] = window.x + window.width;
+    switch (vertical_alignment(align)) {
+      case axis_align::START:
+        sizes[*x11_strut::TOP] =
+            std::clamp(window.y + window.height, 0, display_height);
+        sizes[*x11_strut::TOP_START_X] = std::clamp(window.x, 0, display_width);
+        sizes[*x11_strut::TOP_END_X] =
+            std::clamp(window.x + window.width + 6, 0, display_width);
         break;
-      case 1:
-        /* right side */
-        sizes[1] = display_width - window.x;
+      case axis_align::END:
+        sizes[*x11_strut::BOTTOM] =
+            std::clamp(display_height - window.y, 0, display_height);
+        sizes[*x11_strut::BOTTOM_START_X] =
+            std::clamp(window.x, 0, display_width);
+        sizes[*x11_strut::BOTTOM_END_X] =
+            std::clamp(window.x + window.width, 0, display_width);
         break;
-      case 2:
-        /* top side */
-        sizes[2] = window.y + window.height;
-        break;
-      case 3:
-        /* bottom side */
-        sizes[3] = display_height - window.y;
+      case axis_align::MIDDLE:
+        // can't reserve space in middle of the screen
+      default:
         break;
     }
-
-    /* define partial strut length */
-    if (sidenum <= 1) {
-      sizes[4 + (sidenum * 2)] = window.y;
-      sizes[5 + (sidenum * 2)] = window.y + window.height;
-    } else if (sidenum <= 3) {
-      sizes[4 + (sidenum * 2)] = window.x;
-      sizes[5 + (sidenum * 2)] = window.x + window.width;
-    }
-
-    /* check constraints */
-    for (i = 0; i < 12; i++) {
-      if (sizes[i] < 0) {
-        sizes[i] = 0;
-      } else {
-        if (i <= 1 || i >= 8) {
-          if (sizes[i] > display_width) { sizes[i] = display_width; }
-        } else {
-          if (sizes[i] > display_height) { sizes[i] = display_height; }
-        }
-      }
+    switch (horizontal_alignment(align)) {
+      case axis_align::START:
+        sizes[*x11_strut::LEFT] =
+            std::clamp(window.x + window.width, 0, display_width);
+        sizes[*x11_strut::LEFT_START_Y] =
+            std::clamp(window.y, 0, display_height);
+        sizes[*x11_strut::LEFT_END_Y] =
+            std::clamp(window.y + window.height, 0, display_height);
+        break;
+      case axis_align::END:
+        sizes[*x11_strut::RIGHT] =
+            std::clamp(display_width - window.x, 0, display_width);
+        sizes[*x11_strut::RIGHT_START_Y] =
+            std::clamp(window.y, 0, display_height);
+        sizes[*x11_strut::RIGHT_END_Y] =
+            std::clamp(window.y + window.height, 0, display_height);
+        break;
+      case axis_align::MIDDLE:
+        // can't reserve space in middle of the screen
+      default:
+        break;
     }
 
     XChangeProperty(display, window.window, strut, XA_CARDINAL, 32,
                     PropModeReplace, reinterpret_cast<unsigned char *>(&sizes),
                     4);
 
-    if ((strut = ATOM(_NET_WM_STRUT_PARTIAL)) != None) {
+    strut = ATOM(_NET_WM_STRUT_PARTIAL);
+    if (strut != None) {
       XChangeProperty(display, window.window, strut, XA_CARDINAL, 32,
                       PropModeReplace,
                       reinterpret_cast<unsigned char *>(&sizes), 12);

--- a/src/x11.h
+++ b/src/x11.h
@@ -103,7 +103,7 @@ void destroy_window(void);
 void create_gc(void);
 void set_transparent_background(Window win);
 void get_x11_desktop_info(Display *current_display, Atom atom);
-void set_struts(int);
+void set_struts(alignment alignment);
 void x11_init_window(lua::state &l, bool own);
 void deinit_x11();
 


### PR DESCRIPTION
This PR modifies `set_struts` function to accept `alignment` directly instead of using an intermediate value.

This commit makes code easier to follow and improves performance a tiny bit because it inlines a loop.

# Testing

- [x] bottom and middle alignment seem to not be working on Openbox. Need to be tested against `main`, it's possible this is a bug in Openbox because set values seem fine.
  - Used incorrect type for values.

