### PR TITLE
Re-enable RSS in AppImage, also enable in Nix flake

### DIFF
--- a/.github/workflows/build-and-test-macos.yaml
+++ b/.github/workflows/build-and-test-macos.yaml
@@ -33,20 +33,22 @@ jobs:
       - name: Install dependencies
         run: |
           brew install --force \
-            cmake \
-            freetype \
-            gettext \
-            imlib2 \
-            gperf \
-            lcov \
-            librsvg \
-            libxft \
-            libxinerama \
-            libxfixes \
-            libxi \
-            lua \
-            ninja \
-            pkg-config \
+            cmake              \
+            curl               \
+            freetype           \
+            gettext            \
+            gperf              \
+            imlib2             \
+            lcov               \
+            librsvg            \
+            libxfixes          \
+            libxft             \
+            libxi              \
+            libxinerama        \
+            libxml2            \
+            lua                \
+            ninja              \
+            pkg-config         \
             || true # Ignore errors
       - name: Checkout
         uses: actions/checkout@v4
@@ -57,6 +59,8 @@ jobs:
           cmake .. -G Ninja                    \
           -DMAINTAINER_MODE=ON                 \
           -DBUILD_WAYLAND=OFF                  \
+          -DBUILD_RSS=ON                       \
+          -DBUILD_CURL=ON                      \
           -DBUILD_TESTS=ON
       - name: Compile
         run: cmake --build build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,8 +1,8 @@
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
   schedule:
-    - cron: "20 2 * * 0"
+    - cron: '20 2 * * 0'
 
 jobs:
   analyze:
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["cpp", "javascript", "python"]
+        language: ['cpp', 'javascript', 'python']
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Use only 'java' to analyze code written in Java, Kotlin or both
         # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
@@ -37,7 +37,6 @@ jobs:
             libc++-14-dev \
             libc++abi-14-dev \
             libcairo2-dev \
-            libcurl4-gnutls-dev \
             libcurl4-gnutls-dev \
             libdbus-glib-1-dev \
             libglib2.0-dev \
@@ -86,4 +85,4 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
         with:
-          category: "/language:${{matrix.language}}"
+          category: '/language:${{matrix.language}}'

--- a/.github/workflows/publish-appimage.yml
+++ b/.github/workflows/publish-appimage.yml
@@ -103,6 +103,8 @@ jobs:
           echo "CXX=clang++-${CLANG_VERSION}" | tee -a $GITHUB_ENV
       - name: Build AppImage
         run: ./appimage/build.sh
+        env:
+          RELEASE: "${{ startsWith(github.ref, 'refs/tags/') && 'ON' || 'OFF' }}"
       - run: ./conky-x86_64.AppImage --version # print version
       - run: mv conky-x86_64.AppImage conky-${{ matrix.os }}-${{ matrix.arch }}-${{ env.GIT_VERSION }}.AppImage
       - run: mv conky-x86_64.AppImage.sha256 conky-${{ matrix.os }}-${{ matrix.arch }}-${{ env.GIT_VERSION }}.AppImage.sha256

--- a/.github/workflows/publish-appimage.yml
+++ b/.github/workflows/publish-appimage.yml
@@ -103,6 +103,7 @@ jobs:
           echo "CXX=clang++-${CLANG_VERSION}" | tee -a $GITHUB_ENV
       - name: Build AppImage
         run: ./appimage/build.sh
+      - run: ./conky-x86_64.AppImage --version # print version
       - run: mv conky-x86_64.AppImage conky-${{ matrix.os }}-${{ matrix.arch }}-${{ env.GIT_VERSION }}.AppImage
       - run: mv conky-x86_64.AppImage.sha256 conky-${{ matrix.os }}-${{ matrix.arch }}-${{ env.GIT_VERSION }}.AppImage.sha256
       - name: Upload AppImage artifact

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -55,6 +55,7 @@ cmake -G Ninja                         \
   -DBUILD_NVIDIA=ON                    \
   -DBUILD_PULSEAUDIO=ON                \
   -DBUILD_RSS=ON                       \
+  -DBUILD_CURL=ON                      \
   -DBUILD_WAYLAND=ON                   \
   -DBUILD_WLAN=ON                      \
   -DBUILD_X11=ON                       \

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -39,7 +39,7 @@ pushd "$BUILD_DIR"
 # we need to explicitly set the install prefix, as CMake's default is /usr/local for some reason...
 cmake -G Ninja                         \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo    \
-  -DRELEASE=ON                         \
+  -DRELEASE=$RELEASE                   \
   -DBUILD_AUDACIOUS=ON                 \
   -DBUILD_DOCS=ON                      \
   -DBUILD_HTTP=ON                      \

--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,8 @@
               "-DBUILD_LUA_CAIRO=ON"
               "-DBUILD_LUA_IMLIB2=ON"
               "-DBUILD_LUA_RSVG=ON"
+              "-DBUILD_RSS=ON"
+              "-DBUILD_CURL=ON"
             ];
             nativeBuildInputs = [
               clang_16
@@ -69,10 +71,12 @@
             buildInputs =
               [
                 cairo
+                curl
                 freetype
                 gettext
                 imlib2
                 librsvg
+                libxml2
                 llvmPackages_16.libcxx
                 llvmPackages_16.libcxxabi
                 lua5_4


### PR DESCRIPTION
The behaviour of the RSS flag changed in 4936c74, previously it would enable cURL support when it was switched on, but now you must pass both BUILD_RSS=ON and BUILD_CURL=ON to CMake at configure time.

This fixes #1861.