### PR TITLE
Fix bad query_x11_windows early returns

### DIFF
--- a/src/x11.cc
+++ b/src/x11.cc
@@ -1432,14 +1432,19 @@ std::vector<Window> x11_atom_window_list(Display *display, Window window,
 std::vector<Window> query_x11_windows(Display *display) {
   Window root = DefaultRootWindow(display);
 
-  Atom clients_atom = ATOM(_NET_CLIENT_LIST_STACKING);
-  std::vector<Window> result =
-      x11_atom_window_list(display, root, clients_atom);
-  if (result.empty()) { return result; }
+  std::vector<Window> result;
 
-  clients_atom = ATOM(_NET_CLIENT_LIST);
-  result = x11_atom_window_list(display, root, clients_atom);
-  if (result.empty()) { return result; }
+  Atom clients_atom = XInternAtom(display, "_NET_CLIENT_LIST_STACKING", True);
+  if (clients_atom != 0) {
+    result = x11_atom_window_list(display, root, clients_atom);
+    if (!result.empty()) { return result; }
+  }
+
+  clients_atom = XInternAtom(display, "_NET_CLIENT_LIST", True);
+  if (clients_atom != 0) {
+    result = x11_atom_window_list(display, root, clients_atom);
+    if (!result.empty()) { return result; }
+  }
 
   // slowest method
 

--- a/src/x11.h
+++ b/src/x11.h
@@ -132,12 +132,13 @@ std::vector<Window> x11_atom_window_list(Display *display, Window window,
 ///
 /// If neither of the atoms are provided, this function tries traversing the
 /// window graph in order to collect windows. In this case, map state of windows
-/// is ignored. This also produces a lot of noise for some WM/DEs due to
-/// inserted window decorations.
+/// is ignored.
 ///
-/// @param display which display to query for windows @return a (likely) ordered
-/// list of windows
-std::vector<Window> query_x11_windows(Display *display);
+/// @param display which display to query for windows
+/// @param eager fallback to very slow tree traversal to ensure a list of
+/// windows is returned even if window list atoms aren't defined
+/// @return a (likely) ordered list of windows
+std::vector<Window> query_x11_windows(Display *display, bool eager = false);
 
 /// @brief Finds the last ascendant of a window (trunk) before root.
 ///
@@ -171,7 +172,8 @@ Window query_x11_window_at_pos(Display *display, int x, int y);
 std::vector<Window> query_x11_windows_at_pos(
     Display *display, int x, int y,
     std::function<bool(XWindowAttributes &)> predicate =
-        [](XWindowAttributes &a) { return true; });
+        [](XWindowAttributes &a) { return true; },
+    bool eager = false);
 
 #ifdef BUILD_XDBE
 void xdbe_swap_buffers(void);


### PR DESCRIPTION
Forgot to negate `vector.empty()` in `query_x11_windows`, this made it always do the most expensive check.

Also disabled full tree traversal from event propagation code as it's obviously too slow.

Fixes #1852.
