### PR TITLE
Disable -Wregister on gperf output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ data/defconfig.h
 *.a
 /config.h
 /build.h
-src/colour-names.cc
+src/colour-names.hh
 
 # Compiler cache
 .cache

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,7 +11,7 @@ pre-commit:
       run: |
         clang-format -i {staged_files} \
           && git add {staged_files}
-      glob: '*.{c,cc,cxx,h,cpp}'
+      glob: '*.{c,cc,cxx,h,hh,cpp}'
     misc-linter:
       run: |
         npx -y prettier --write {staged_files} \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,7 +47,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/defconfig.h)
   )
 endif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/defconfig.h)
 
-# Generate colour-names.cc with gperf
+# Generate colour-names.hh with gperf
 if(APP_GPERF)
   execute_process(
     INPUT_FILE "${CMAKE_SOURCE_DIR}/data/color-names.yml"
@@ -56,12 +56,13 @@ if(APP_GPERF)
   )
   execute_process(
     INPUT_FILE "${CMAKE_BINARY_DIR}/data/color-names.gperf"
-    OUTPUT_FILE "${CMAKE_BINARY_DIR}/colour-names.cc"
+    OUTPUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/colour-names.hh"
     COMMAND ${APP_GPERF} --ignore-case -LC++ -Zcolor_name_hash -t -7 -m1 -C -E
   )
+  include_directories(${CMAKE_CURRENT_BINARY_DIR})
 else(APP_GPERF)
-  message(WARNING "'gperf' program not found, using stub colour-names.cc; colors names will not be parsed")
-  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/colour-names-stub.cc" "${CMAKE_BINARY_DIR}/colour-names.cc" COPYONLY)
+  message(WARNING "'gperf' program not found, using stub colour-names.hh; colors names will not be parsed")
+  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/colour-names-stub.hh" "${CMAKE_CURRENT_BINARY_DIR}/colour-names.hh" COPYONLY)
 endif(APP_GPERF)
 
 set(conky_sources
@@ -253,7 +254,7 @@ endif(BUILD_HTTP)
 
 if(BUILD_X11)
   set(x11
-    display-x11.cc 
+    display-x11.cc
     display-x11.hh
     x11-settings.cc
     x11-settings.h
@@ -274,11 +275,10 @@ if(BUILD_GUI)
   endif(BUILD_MOUSE_EVENTS OR BUILD_XINPUT)
 endif(BUILD_GUI)
 
-
 if(BUILD_WAYLAND)
   set(wl_srcs
     wl.cc
-    wl.h 
+    wl.h
     display-wayland.cc
     display-wayland.hh
     xdg-shell-protocol.c
@@ -356,10 +356,10 @@ endif(BUILD_ICONV)
 
 if(BUILD_NCURSES)
   set(ncurses_srcs
-  nc.cc
-  nc.h
-  display-ncurses.cc
-  display-ncurses.hh
+    nc.cc
+    nc.h
+    display-ncurses.cc
+    display-ncurses.hh
   )
   set(optional_sources ${optional_sources} ${ncurses_srcs})
 endif(BUILD_NCURSES)

--- a/src/colour-names-stub.hh
+++ b/src/colour-names-stub.hh
@@ -1,5 +1,5 @@
 /*
- * To generate colour-names.cc, you must have gperf installed during build.
+ * To generate colour-names.hh, you must have gperf installed during build.
  * This is a dummy implementation for builds without gperf.
  * Color name matching will always return null (i.e. no match).
  */

--- a/src/colours.cc
+++ b/src/colours.cc
@@ -42,7 +42,13 @@ Colour Colour::from_argb32(uint32_t argb) {
   return out;
 }
 
-#include "colour-names.cc"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wregister"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wregister"
+#include <colour-names.hh>
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 
 std::optional<Colour> parse_color_name(const std::string &name) {
   const rgb *value = color_name_hash::in_word_set(name.c_str(), name.length());


### PR DESCRIPTION
Older versions of gperf use the `register` keyword which is deprecated in C++17, and warnings are treated as errors.

This disables the warning on gperf's output (colour-names.hh). I also renamed `colour-names.cc` -> `colour-names.hh` because we're including it as a header, not compiling it separately.

This resolves #1865.