### PR TITLE
Fix conky-cairo_imlib2_helper dependency conditions

### DIFF
--- a/cmake/ConkyBuildOptions.cmake
+++ b/cmake/ConkyBuildOptions.cmake
@@ -210,10 +210,10 @@ dependent_option(BUILD_MOUSE_EVENTS "Enable mouse event support" true
   "Mouse event support requires Wayland or X11 enabled")
 
 # Lua library options
-dependent_option(BUILD_LUA_CAIRO "Build cairo bindings for Lua" false
+dependent_option(BUILD_LUA_CAIRO "Build Cairo bindings for Lua" false
   "BUILD_GUI" false
   "Cairo Lua bindings depend on BUILD_GUI")
-dependent_option(BUILD_LUA_CAIRO_XLIB "Build Imlib2 bindings for Lua" true
+dependent_option(BUILD_LUA_CAIRO_XLIB "Build Cairo & Xlib interoperability for Lua" true
   "BUILD_X11;BUILD_LUA_CAIRO" false
   "Cairo Xlib Lua bindings require Cairo and X11")
 dependent_option(BUILD_LUA_IMLIB2 "Build Imlib2 bindings for Lua" false

--- a/lua/CMakeLists.txt
+++ b/lua/CMakeLists.txt
@@ -79,7 +79,7 @@ if(BUILD_LUA_IMLIB2)
   print_target_properties(conky-imlib2)
 endif(BUILD_LUA_IMLIB2)
 
-if(BUILD_LUA_IMLIB2)
+if(BUILD_LUA_CAIRO AND BUILD_LUA_IMLIB2)
   include_directories(${luacairo_includes} ${luaimlib2_includes}
     ${CMAKE_CURRENT_SOURCE_DIR})
   wrap_tolua(luacairo_imlib2_helper_src cairo_imlib2_helper.pkg)
@@ -93,7 +93,7 @@ if(BUILD_LUA_IMLIB2)
     ${luaimlib2_libs}
     toluapp_lib_static)
   set(lua_libs ${lua_libs} conky-cairo_imlib2_helper)
-endif(BUILD_LUA_IMLIB2)
+endif(BUILD_LUA_CAIRO AND BUILD_LUA_IMLIB2)
 
 if(BUILD_LUA_RSVG)
   include_directories(${luarsvg_includes} ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
Broke this while separating cairo from Lua in 45500b1439f8284e87aa715a0e1557133ddbd924.

Fixes #1873.