### PR TITLE
Use private mapping from provided shm_pool buffer

### DIFF
--- a/src/display-wayland.cc
+++ b/src/display-wayland.cc
@@ -1065,7 +1065,7 @@ static struct wl_shm_pool *make_shm_pool(struct wl_shm *shm, int size,
     return NULL;
   }
 
-  *data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  *data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
   if (*data == MAP_FAILED) {
     fprintf(stderr, "mmap failed: %m\n");
     close(fd);


### PR DESCRIPTION
Using `MAP_SHARED` causes a crash on some compositors/systems as shown by #1824. According to WL docs:
> From version 7 onwards, the fd must be mapped with MAP_PRIVATE by the recipient, as MAP_SHARED may fail.

We don't need a `MAP_SHARED` as the provided buffer will be used exclusively by conky and not shared with other processes.

This PR addresses that and closes #1824.

# Testing
- Tested private mapping in another Wayland client and it worked with hyprland.