### PR TITLE
Remove dpi scaling of maximum width

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -864,7 +864,7 @@ void update_text_area() {
     if (text_height < dpi_scale(minimum_height.get(*state))) {
       text_height = dpi_scale(minimum_height.get(*state));
     }
-    int mw = dpi_scale(maximum_width.get(*state));
+    int mw = maximum_width.get(*state);
     if (text_width > mw && mw > 0) { text_width = mw; }
   }
 
@@ -987,7 +987,7 @@ static int text_size_updater(char *s, int special_index) {
   w += get_string_width(s);
 
   if (w > text_width) { text_width = w; }
-  int mw = dpi_scale(maximum_width.get(*state));
+  int mw = maximum_width.get(*state);
   if (text_width > mw && mw > 0) { text_width = mw; }
 
   text_height += last_font_height;

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1052,7 +1052,7 @@ static void draw_string(const char *s) {
   }
 #ifdef BUILD_GUI
   if (display_output() && display_output()->graphical()) {
-    int mw = display_output()->dpi_scale(maximum_width.get(*state));
+    int mw = maximum_width.get(*state);
     if (text_width == mw) {
       /* this means the text is probably pushing the limit,
        * so we'll chop it */
@@ -1122,7 +1122,7 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
 
 #ifdef BUILD_GUI
   if (display_output() && display_output()->graphical()) {
-    mw = display_output()->dpi_scale(maximum_width.get(*state));
+    mw = maximum_width.get(*state);
     font_h = font_height();
     cur_y += font_ascent();
   }

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -38,6 +38,7 @@
 #include <cmath>
 #include <cstdarg>
 #include <ctime>
+#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <sstream>
@@ -275,7 +276,7 @@ int text_width = 1,
 struct information info;
 
 /* path to config file */
-std::string current_config;
+std::filesystem::path current_config;
 
 /* set to 1 if you want all text to be in uppercase */
 static conky::simple_config_setting<bool> stuff_in_uppercase("uppercase", false,
@@ -1960,6 +1961,40 @@ void load_config_file() {
   lua::state &l = *state;
   lua::stack_sentry s(l);
   l.checkstack(2);
+
+  // Extend lua package.path so scripts can use relative paths
+  {
+    struct stat file_stat {};
+
+    std::string path_ext;
+
+    // add XDG directory to lua path
+    auto xdg_path =
+        std::filesystem::path(to_real_path(XDG_CONFIG_FILE)).parent_path();
+    if (stat(xdg_path.c_str(), &file_stat) == 0) {
+      path_ext.push_back(';');
+      path_ext.append(xdg_path);
+      path_ext.append("/?.lua");
+    }
+
+    auto parent_path = current_config.parent_path();
+    if (xdg_path != parent_path && stat(path_ext.c_str(), &file_stat) == 0) {
+      path_ext.push_back(';');
+      path_ext.append(parent_path);
+      path_ext.append("/?.lua");
+    }
+
+    l.getglobal("package");
+    l.getfield(-1, "path");
+
+    auto path = l.tostring(-1);
+    path.append(path_ext);
+    l.pop();
+    l.pushstring(path.c_str());
+
+    l.setfield(-2, "path");
+    l.pop();
+  }
 
   try {
 #ifdef BUILD_BUILTIN_CONFIG

--- a/src/conky.h
+++ b/src/conky.h
@@ -38,6 +38,7 @@
 #include <config.h>      /* defines */
 #include <sys/utsname.h> /* struct uname_s */
 #include <csignal>
+#include <filesystem>
 #include <memory>
 
 #include "colours.h"
@@ -346,7 +347,7 @@ extern conky::simple_config_setting<bool> utf8_mode;
 extern conky::range_config_setting<unsigned int> max_user_text;
 
 /* path to config file */
-extern std::string current_config;
+extern std::filesystem::path current_config;
 
 #define DEFAULT_TEXT_BUFFER_SIZE_S "##DEFAULT_TEXT_BUFFER_SIZE"
 

--- a/src/display-wayland.cc
+++ b/src/display-wayland.cc
@@ -300,7 +300,17 @@ static void output_geometry(void *data, struct wl_output *wl_output, int32_t x,
                             int32_t y, int32_t physical_width,
                             int32_t physical_height, int32_t subpixel,
                             const char *make, const char *model,
-                            int32_t transform) {}
+                            int32_t transform) {
+  // TODO: Add support for proper output management through:
+  // - xdg-output-unstable-v1
+  // Maybe also support (if XDG protocol not reported):
+  // - kde-output-management(-v2)
+  // - wlr-output-management-unstable-v1
+  workarea.x = x;  // TODO: use xdg_output.logical_position
+  workarea.y = y;
+  workarea.width = physical_width;
+  workarea.height = physical_height;
+}
 
 static void output_mode(void *data, struct wl_output *wl_output, uint32_t flags,
                         int32_t width, int32_t height, int32_t refresh) {}

--- a/src/display-wayland.cc
+++ b/src/display-wayland.cc
@@ -306,10 +306,10 @@ static void output_geometry(void *data, struct wl_output *wl_output, int32_t x,
   // Maybe also support (if XDG protocol not reported):
   // - kde-output-management(-v2)
   // - wlr-output-management-unstable-v1
-  workarea.x = x;  // TODO: use xdg_output.logical_position
-  workarea.y = y;
-  workarea.width = physical_width;
-  workarea.height = physical_height;
+  workarea[0] = x;  // TODO: use xdg_output.logical_position
+  workarea[1] = y;
+  workarea[2] = physical_width;
+  workarea[3] = physical_height;
 }
 
 static void output_mode(void *data, struct wl_output *wl_output, uint32_t flags,

--- a/src/display-wayland.cc
+++ b/src/display-wayland.cc
@@ -923,10 +923,7 @@ void display_output_wayland::move_win(int x, int y) {
   // window.y = y;
   // TODO
 }
-template <typename T, typename>
-T display_output_wayland::dpi_scale(T value) {
-  return value;
-}
+float display_output_wayland::get_dpi_scale() { return 1.0; }
 
 void display_output_wayland::end_draw_stuff() {
   window_commit_buffer(global_window);

--- a/src/display-wayland.hh
+++ b/src/display-wayland.hh
@@ -71,9 +71,7 @@ class display_output_wayland : public display_output_base {
   virtual void fill_rect(int, int, int, int);
   virtual void draw_arc(int, int, int, int, int, int);
   virtual void move_win(int, int);
-  template <typename T, typename = typename std::enable_if<
-                            std::is_arithmetic<T>::value, T>::type>
-  T dpi_scale(T value);
+  virtual float get_dpi_scale();
 
   virtual void end_draw_stuff();
   virtual void clear_text(int);

--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -657,7 +657,7 @@ bool handle_event<x_event_handler::CONFIGURE>(
 
       text_width = window.width - 2 * border_total;
       text_height = window.height - 2 * border_total;
-      int mw = surface->dpi_scale(maximum_width.get(*state));
+      int mw = maximum_width.get(*state);
       if (text_width > mw && mw > 0) { text_width = mw; }
     }
 

--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -945,14 +945,13 @@ void display_output_x11::move_win(int x, int y) {
 #endif /* OWN_WINDOW */
 }
 
-const size_t PIXELS_PER_INCH = 96;
-template <typename T, typename>
-T display_output_x11::dpi_scale(T value) {
+const float PIXELS_PER_INCH = 96.0;
+float display_output_x11::get_dpi_scale() {
 #if defined(BUILD_XFT)
   if (use_xft.get(*state) && xft_dpi > 0) {
-    return (value * xft_dpi + (value > 0 ? 48 : -48)) / PIXELS_PER_INCH;
+    return static_cast<float>(xft_dpi) / PIXELS_PER_INCH;
   } else {
-    return value;
+    return 1.0;
   }
 #else  /* defined(BUILD_XFT) */
   return value;

--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -947,15 +947,12 @@ void display_output_x11::move_win(int x, int y) {
 
 const float PIXELS_PER_INCH = 96.0;
 float display_output_x11::get_dpi_scale() {
-#if defined(BUILD_XFT)
+#ifdef BUILD_XFT
   if (use_xft.get(*state) && xft_dpi > 0) {
     return static_cast<float>(xft_dpi) / PIXELS_PER_INCH;
-  } else {
-    return 1.0;
   }
-#else  /* defined(BUILD_XFT) */
-  return value;
-#endif /* defined(BUILD_XFT) */
+#endif /* BUILD_XFT */
+  return 1.0;
 }
 
 void display_output_x11::end_draw_stuff() {

--- a/src/display-x11.hh
+++ b/src/display-x11.hh
@@ -69,9 +69,7 @@ class display_output_x11 : public display_output_base {
   virtual void fill_rect(int, int, int, int);
   virtual void draw_arc(int, int, int, int, int, int);
   virtual void move_win(int, int);
-  template <typename T, typename = typename std::enable_if<
-                            std::is_arithmetic<T>::value, T>::type>
-  T dpi_scale(T value);
+  virtual float get_dpi_scale();
 
   virtual void end_draw_stuff();
   virtual void clear_text(int);


### PR DESCRIPTION
This PR removes `dpi_scale`ing of maximum width setting.

This seems incorrect because I expect maximum width to use absolute pixel value, otherwise meaning of `maximum_width` setting changes with DPI:

![image](https://github.com/brndnmtthws/conky/assets/4082795/ff27308c-5137-47bc-bc5a-ad21cd194338)
<sub>NOTE: <em>Height difference is caused by font height, conky height can't be limited.</em></sub>

This fixes #1528.

This PR also fixes a regression introduced in #1841, where I incorrectly assumed templated base class function would be overriden by display outputs so DPI scaling was completely disabled.

# Other changes

This PR also:
- sets `workspace` dimensions from WL `output_geometry` because workspace is used for some calculations in `conky.cc`.
  - this requires more work for proper support as noted in comments, but it should make Wayland less broken.
- adds conky xdg dir and script parent directory to Lua path so that scripts don't have to update it manually.

# Testing

- [x] Use mock Xft dpi value and see whether example from #1528 works better with/without this PR.
