### PR TITLE
Update DPI when changed in resource manager

### DIFF
--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -82,9 +82,7 @@ extern int need_to_update;
 int get_border_total();
 extern conky::range_config_setting<int> maximum_width;
 extern Colour current_color;
-#ifdef BUILD_XFT
-static float xft_dpi = -1;
-#endif /* BUILD_XFT */
+static float screen_dpi = -1;
 
 /* for x_fonts */
 struct x_font_list {
@@ -153,24 +151,24 @@ void update_dpi() {
   // See dunst PR: https://github.com/dunst-project/dunst/pull/608
 
 #ifdef BUILD_XFT
-  if (xft_dpi > 0) return;
+  if (screen_dpi > 0) return;
   if (use_xft.get(*state)) {
     XrmDatabase db = XrmGetDatabase(display);
     if (db != nullptr) {
       char *xrmType;
       XrmValue xrmValue;
       if (XrmGetResource(db, "Xft.dpi", "Xft.dpi", &xrmType, &xrmValue)) {
-        xft_dpi = strtof(xrmValue.addr, NULL);
+        screen_dpi = strtof(xrmValue.addr, NULL);
       }
     } else {
       auto dpi = XGetDefault(display, "Xft", "dpi");
-      if (dpi) { xft_dpi = strtof(dpi, nullptr); }
+      if (dpi) { screen_dpi = strtof(dpi, nullptr); }
     }
   }
 #endif /* BUILD_XFT */
-  if (xft_dpi > 0) return;
-  xft_dpi = static_cast<float>(DisplayWidth(display, screen)) * 25.4 /
-            static_cast<float>(DisplayWidthMM(display, screen));
+  if (screen_dpi > 0) return;
+  screen_dpi = static_cast<float>(DisplayWidth(display, screen)) * 25.4 /
+               static_cast<float>(DisplayWidthMM(display, screen));
 }
 
 static void X11_create_window() {
@@ -739,7 +737,7 @@ bool handle_event<x_event_handler::PROPERTY_NOTIFY>(
   if (ev.xproperty.atom == XA_RESOURCE_MANAGER) {
     update_x11_resource_db();
     update_x11_workarea();
-    xft_dpi = -1;
+    screen_dpi = -1;
     update_dpi();
     return true;
   }
@@ -980,11 +978,9 @@ void display_output_x11::move_win(int x, int y) {
 
 const float PIXELS_PER_INCH = 96.0;
 float display_output_x11::get_dpi_scale() {
-#ifdef BUILD_XFT
-  if (use_xft.get(*state) && xft_dpi > 0) {
-    return static_cast<float>(xft_dpi) / PIXELS_PER_INCH;
+  if (screen_dpi > 0) {
+    return static_cast<float>(screen_dpi) / PIXELS_PER_INCH;
   }
-#endif /* BUILD_XFT */
   return 1.0;
 }
 

--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -49,6 +49,7 @@
 #include <X11/extensions/XInput2.h>
 #undef COUNT
 #endif /* BUILD_XINPUT */
+#include <X11/Xresource.h>
 
 #include <cstdint>
 #include <iostream>
@@ -82,7 +83,7 @@ int get_border_total();
 extern conky::range_config_setting<int> maximum_width;
 extern Colour current_color;
 #ifdef BUILD_XFT
-static int xft_dpi = -1;
+static float xft_dpi = -1;
 #endif /* BUILD_XFT */
 
 /* for x_fonts */
@@ -147,16 +148,36 @@ struct _x11_stuff_s {
 #endif
 } x11_stuff;
 
+void update_dpi() {
+  // Add XRandR support if used
+  // See dunst PR: https://github.com/dunst-project/dunst/pull/608
+
+#ifdef BUILD_XFT
+  if (xft_dpi > 0) return;
+  if (use_xft.get(*state)) {
+    XrmDatabase db = XrmGetDatabase(display);
+    if (db != nullptr) {
+      char *xrmType;
+      XrmValue xrmValue;
+      if (XrmGetResource(db, "Xft.dpi", "Xft.dpi", &xrmType, &xrmValue)) {
+        xft_dpi = strtof(xrmValue.addr, NULL);
+      }
+    } else {
+      auto dpi = XGetDefault(display, "Xft", "dpi");
+      if (dpi) { xft_dpi = strtof(dpi, nullptr); }
+    }
+  }
+#endif /* BUILD_XFT */
+  if (xft_dpi > 0) return;
+  xft_dpi = static_cast<float>(display_width) * 25.4 /
+            static_cast<float>(DisplayWidthMM(display, screen));
+}
+
 static void X11_create_window() {
   if (!window.window) { return; }
   setup_fonts();
   load_fonts(utf8_mode.get(*state));
-#ifdef BUILD_XFT
-  if (use_xft.get(*state)) {
-    auto dpi = XGetDefault(display, "Xft", "dpi");
-    if (dpi) { xft_dpi = strtol(dpi, nullptr, 10); }
-  }
-#endif                /* BUILD_XFT */
+  update_dpi();
   update_text_area(); /* to position text/window on screen */
 
 #ifdef OWN_WINDOW
@@ -713,19 +734,31 @@ bool handle_event<x_event_handler::PROPERTY_NOTIFY>(
     get_x11_desktop_info(ev.xproperty.display, ev.xproperty.atom);
   }
 
-#ifdef USE_ARGB
-  if (have_argb_visual) return true;
-#endif
+  if (ev.xproperty.atom == 0) return false;
 
-  if (ev.xproperty.atom == ATOM(_XROOTPMAP_ID) ||
-      ev.xproperty.atom == ATOM(_XROOTMAP_ID)) {
-    if (forced_redraw.get(*state)) {
-      draw_stuff();
-      next_update_time = get_time();
-      need_to_update = 1;
+  if (ev.xproperty.atom == XA_RESOURCE_MANAGER) {
+    update_x11_resource_db();
+    update_x11_workarea();
+    xft_dpi = -1;
+    update_dpi();
+    return true;
+  }
+
+  if (!have_argb_visual) {
+    Atom _XROOTPMAP_ID = XInternAtom(display, "_XROOTPMAP_ID", True);
+    Atom _XROOTMAP_ID = XInternAtom(display, "_XROOTMAP_ID", True);
+    if (ev.xproperty.atom == _XROOTPMAP_ID ||
+        ev.xproperty.atom == _XROOTMAP_ID) {
+      if (forced_redraw.get(*state)) {
+        draw_stuff();
+        next_update_time = get_time();
+        need_to_update = 1;
+      }
+      return true;
     }
   }
-  return true;
+
+  return false;
 }
 
 template <>

--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -169,7 +169,7 @@ void update_dpi() {
   }
 #endif /* BUILD_XFT */
   if (xft_dpi > 0) return;
-  xft_dpi = static_cast<float>(display_width) * 25.4 /
+  xft_dpi = static_cast<float>(DisplayWidth(display, screen)) * 25.4 /
             static_cast<float>(DisplayWidthMM(display, screen));
 }
 

--- a/src/gui.cc
+++ b/src/gui.cc
@@ -45,8 +45,6 @@
 #endif
 
 /* basic display attributes */
-int display_width;
-int display_height;
 int screen;
 
 /* workarea where window / text is aligned (from _NET_WORKAREA on X11) */

--- a/src/gui.h
+++ b/src/gui.h
@@ -168,10 +168,10 @@ inline bool TEST_HINT(uint16_t mask, window_hints hint) {
 #ifdef BUILD_X11
 extern Display *display;
 #endif /* BUILD_X11 */
-extern int display_width;
-extern int display_height;
 extern int screen;
 extern int workarea[4];
+#define display_width workarea[2]
+#define display_height workarea[3]
 
 extern char window_created;
 

--- a/src/gui.h
+++ b/src/gui.h
@@ -170,8 +170,6 @@ extern Display *display;
 #endif /* BUILD_X11 */
 extern int screen;
 extern int workarea[4];
-#define display_width workarea[2]
-#define display_height workarea[3]
 
 extern char window_created;
 

--- a/src/x11.cc
+++ b/src/x11.cc
@@ -368,7 +368,9 @@ static Window find_desktop_window(Window root) {
   Window desktop = root;
 
   /* get subwindows from root */
-  desktop = find_subwindow(root, -1, -1);
+  int display_width = DisplayWidth(display, screen);
+  int display_height = DisplayHeight(display, screen);
+  desktop = find_subwindow(root, display_width, display_height);
   update_x11_workarea();
   desktop = find_subwindow(desktop, workarea[2], workarea[3]);
 
@@ -900,13 +902,11 @@ static Window find_subwindow(Window win, int w, int h) {
 
     for (j = 0; j < n; j++) {
       XWindowAttributes attrs;
-
       if (XGetWindowAttributes(display, children[j], &attrs) != 0) {
         /* Window must be mapped and same size as display or
          * work space */
-        if (attrs.map_state != 0 &&
-            ((attrs.width == display_width && attrs.height == display_height) ||
-             (attrs.width == w && attrs.height == h))) {
+        if (attrs.map_state == IsViewable &&
+            ((attrs.width == w && attrs.height == h))) {
           win = children[j];
           break;
         }
@@ -1135,6 +1135,9 @@ void set_struts(alignment align) {
   Atom strut = ATOM(_NET_WM_STRUT);
   if (strut != None) {
     long sizes[STRUT_COUNT] = {0};
+
+    int display_width = workarea[2] - workarea[0];
+    int display_height = workarea[3] - workarea[1];
 
     switch (horizontal_alignment(align)) {
       case axis_align::START:

--- a/src/x11.h
+++ b/src/x11.h
@@ -98,6 +98,8 @@ struct conky_x11_window {
 
 extern struct conky_x11_window window;
 
+void update_x11_resource_db(bool first_run = false);
+void update_x11_workarea();
 void init_x11();
 void destroy_window(void);
 void create_gc(void);


### PR DESCRIPTION
# Description

This PR makes Xft dpi code use resource manager database to get the value, and updates the value on change in resource database. This closes #407.

# Other changes

- Added fallback when Xft isn't enabled.
- Removed some guards which weren't needed anymore.
- Made `find_desktop_window`, that is `find_subwindow`, be more specific which fixes #1730.
- Removed display width and height
  - They were used from a few places and weren't needed, they were also not a good fit for `set_struts` because `workarea` handles display offset properly.

# Testing
- [x] Tested `Xft.dpi` listening and updates.
- [x] Tested changes to `find_desktop_window` don't break functionality (plasma, mate)