### PR TITLE
Add BUILD_COLOUR_NAME_MAP build flag

### DIFF
--- a/cmake/Conky.cmake
+++ b/cmake/Conky.cmake
@@ -153,12 +153,6 @@ if(NOT APP_UNAME)
   message(FATAL_ERROR "Unable to find program 'uname'")
 endif(NOT APP_UNAME)
 
-find_program(APP_GPERF gperf)
-
-if(NOT APP_GPERF)
-  message(FATAL_ERROR "Unable to find program 'gperf' (required at build-time as of Conky v1.20.2)")
-endif(NOT APP_GPERF)
-
 if(NOT RELEASE)
   find_program(APP_GIT git)
 
@@ -169,7 +163,7 @@ if(NOT RELEASE)
   mark_as_advanced(APP_GIT)
 endif(NOT RELEASE)
 
-mark_as_advanced(APP_AWK APP_WC APP_UNAME APP_GPERF)
+mark_as_advanced(APP_AWK APP_WC APP_UNAME)
 
 execute_process(COMMAND ${APP_UNAME} -sm
   RESULT_VARIABLE RETVAL

--- a/cmake/ConkyBuildOptions.cmake
+++ b/cmake/ConkyBuildOptions.cmake
@@ -67,6 +67,8 @@ option(BUILD_EXTRAS "Build extras (includes syntax files for editors)" false)
 
 option(BUILD_I18N "Enable if you want internationalization support" true)
 
+option(BUILD_COLOUR_NAME_MAP "Include mappings of colour name -> RGB (i.e., red -> ff0000)" true)
+
 if(BUILD_I18N)
   set(LOCALE_DIR "${CMAKE_INSTALL_PREFIX}/share/locale"
     CACHE STRING "Directory containing the locales")

--- a/cmake/ConkyPlatformChecks.cmake
+++ b/cmake/ConkyPlatformChecks.cmake
@@ -510,7 +510,7 @@ if(BUILD_LUA_CAIRO)
     set(luacairo_libs ${CAIROXLIB_LIBRARIES} ${luacairo_libs})
     set(luacairo_includes ${CAIROXLIB_INCLUDE_DIRS} ${luacairo_includes})
   endif(BUILD_LUA_CAIRO_XLIB)
-  
+
   find_program(APP_PATCH patch)
 
   if(NOT APP_PATCH)
@@ -668,6 +668,16 @@ if(BUILD_DOCS OR BUILD_EXTRAS)
     )
   endif()
 endif(BUILD_DOCS OR BUILD_EXTRAS)
+
+if(BUILD_COLOUR_NAME_MAP)
+  find_program(APP_GPERF gperf)
+
+  if(NOT APP_GPERF)
+    message(FATAL_ERROR "Unable to find program 'gperf' (required at build-time as of Conky v1.20.2)")
+  endif(NOT APP_GPERF)
+
+  mark_as_advanced(APP_GPERF)
+endif(BUILD_COLOUR_NAME_MAP)
 
 if(CMAKE_BUILD_TYPE MATCHES "Debug")
   set(DEBUG true)

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -142,6 +142,8 @@
 
 #cmakedefine BUILD_HSV_GRADIENT 1
 
+#cmakedefine BUILD_COLOUR_NAME_MAP 1
+
 #cmakedefine HAVE_STATFS64 1
 #ifndef HAVE_STATFS64
 #define statfs64 statfs

--- a/src/colour-names-stub.hh
+++ b/src/colour-names-stub.hh
@@ -1,0 +1,28 @@
+/*
+ * To generate colour-names.hh, you must have gperf installed during build.
+ * This is a dummy implementation for builds without gperf.
+ * Color name matching will always return null (i.e. no match).
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#include "logging.h"
+
+struct rgb {
+  const char *name;
+  uint8_t red;
+  uint8_t green;
+  uint8_t blue;
+};
+
+class color_name_hash {
+ public:
+  static const struct rgb *in_word_set(const char *str, size_t len);
+};
+
+const struct rgb *color_name_hash::in_word_set(const char *str, size_t len) {
+  DBGP("color parsing not supported");
+  return nullptr;
+}

--- a/src/colours.cc
+++ b/src/colours.cc
@@ -42,6 +42,7 @@ Colour Colour::from_argb32(uint32_t argb) {
   return out;
 }
 
+#ifdef BUILD_COLOUR_NAME_MAP
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wregister"
 #pragma GCC diagnostic push
@@ -49,6 +50,9 @@ Colour Colour::from_argb32(uint32_t argb) {
 #include <colour-names.hh>
 #pragma clang diagnostic pop
 #pragma GCC diagnostic pop
+#else /* BUILD_COLOUR_NAME_MAP */
+#include "colour-names-stub.hh"
+#endif /* BUILD_COLOUR_NAME_MAP */
 
 std::optional<Colour> parse_color_name(const std::string &name) {
   const rgb *value = color_name_hash::in_word_set(name.c_str(), name.length());


### PR DESCRIPTION
You can now specify `BUILD_COLOUR_NAME_MAP=OFF` to disable building the gperf-based colour map, which also removes the requirement for gperf at build time.

This adds back the colour stub feature removed in #1870, however this time it retains backward compatibility with the previous colour name handling behaviour by default.