### PR TITLE
Docker: updated base image to Ubuntu 24.04 LTS

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -2,7 +2,13 @@ name: Docker
 
 on:
   push:
-    # Publish `main` as Docker `latest` image.
+    branches:
+      - main
+    paths-ignore:
+      - web/**
+      - doc/**
+
+  pull_request:
     branches:
       - main
     paths-ignore:

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,14 +108,14 @@ RUN apt-get update \
   libc++1 \
   libc++abi1 \
   libcairo2 \
-  libcurl4 \
+  libcurl4t64 \
   libdbus-glib-1-2 \
-  libical3 \
-  libimlib2 \
+  libical3t64 \
+  libimlib2t64 \
   libircclient1 \
-  libiw30 \
+  libiw30t64 \
   liblua5.3-0 \
-  libmicrohttpd12 \
+  libmicrohttpd12t64 \
   libmysqlclient21 \
   libncurses6 \
   libpulse0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy AS builder
+FROM ubuntu:noble AS builder
 
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive \
@@ -6,6 +6,7 @@ RUN apt-get update \
   audacious-dev \
   ca-certificates \
   clang \
+  cmake \
   curl \
   gfortran \
   git \
@@ -39,24 +40,10 @@ RUN apt-get update \
   libxml2-dev \
   libxmmsclient-dev \
   libxnvctrl-dev \
-  make \
   ninja-build \
   patch \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
-
-# Compile CMake, we need the latest because the bug here (for armv7 builds):
-# https://gitlab.kitware.com/cmake/cmake/-/issues/20568
-WORKDIR /cmake
-ENV CMAKE_VERSION 3.25.1
-RUN curl -Lq https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.tar.gz -o cmake-${CMAKE_VERSION}.tar.gz \
-  && tar xf cmake-${CMAKE_VERSION}.tar.gz \
-  && cd cmake-${CMAKE_VERSION} \
-  && CC=clang CXX=clang++ CFLAGS="-D_FILE_OFFSET_BITS=64" CXXFLAGS="-D_FILE_OFFSET_BITS=64" ./bootstrap --system-libs --parallel=5 \
-  && make -j5 \
-  && make -j5 install \
-  && cd \
-  && rm -rf /cmake
 
 COPY . /conky
 WORKDIR /conky/build
@@ -112,7 +99,7 @@ RUN sh -c 'if [ "$X11" = "yes" ] ; then \
   && cmake --build . \
   && cmake --install .
 
-FROM ubuntu:jammy
+FROM ubuntu:noble
 
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive \
@@ -140,6 +127,7 @@ RUN apt-get update \
   libxext6 \
   libxfixes3 \
   libxft2 \
+  libxi6 \
   libxinerama1 \
   libxml2 \
   libxmmsclient6 \


### PR DESCRIPTION
This allows us to drop the CMake compliation step, which should speed up image build times significantly.
