### PR TITLE
Disable Vc_ENABLE_INSTALL by default

### DIFF
--- a/3rdparty/Vc/CMakeLists.txt
+++ b/3rdparty/Vc/CMakeLists.txt
@@ -187,61 +187,61 @@ target_include_directories(Vc
    $<INSTALL_INTERFACE:include>
    )
 
-option(Vc_ENABLE_INSTALL "Whether to install the library." OFF)
-if (Vc_ENABLE_INSTALL)
-   install(TARGETS Vc EXPORT VcTargets DESTINATION lib${LIB_SUFFIX})
-   install(DIRECTORY Vc/ DESTINATION include/Vc FILES_MATCHING REGEX "/*.(h|tcc|def)$")
-   install(FILES
-      Vc/Allocator
-      Vc/IO
-      Vc/Memory
-      Vc/SimdArray
-      Vc/Utils
-      Vc/Vc
-      Vc/algorithm
-      Vc/array
-      Vc/iterators
-      Vc/limits
-      Vc/simdize
-      Vc/span
-      Vc/type_traits
-      Vc/vector
-      DESTINATION include/Vc)
+# option(Vc_ENABLE_INSTALL "Whether to install the library." OFF)
+# if (Vc_ENABLE_INSTALL)
+#    install(TARGETS Vc EXPORT VcTargets DESTINATION lib${LIB_SUFFIX})
+#    install(DIRECTORY Vc/ DESTINATION include/Vc FILES_MATCHING REGEX "/*.(h|tcc|def)$")
+#    install(FILES
+#       Vc/Allocator
+#       Vc/IO
+#       Vc/Memory
+#       Vc/SimdArray
+#       Vc/Utils
+#       Vc/Vc
+#       Vc/algorithm
+#       Vc/array
+#       Vc/iterators
+#       Vc/limits
+#       Vc/simdize
+#       Vc/span
+#       Vc/type_traits
+#       Vc/vector
+#       DESTINATION include/Vc)
 
-   # Generate and install CMake package and modules
-   include(CMakePackageConfigHelpers)
-   set(PACKAGE_INSTALL_DESTINATION
-      lib${LIB_SUFFIX}/cmake/${PROJECT_NAME}
-      )
-   install(EXPORT ${PROJECT_NAME}Targets
-      NAMESPACE ${PROJECT_NAME}::
-      DESTINATION ${PACKAGE_INSTALL_DESTINATION}
-      EXPORT_LINK_INTERFACE_LIBRARIES
-      )
-   write_basic_package_version_file(
-      ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}ConfigVersion.cmake
-      VERSION ${PROJECT_VERSION}
-      COMPATIBILITY AnyNewerVersion
-      )
-   configure_package_config_file(
-      ${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in
-      ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Config.cmake
-      INSTALL_DESTINATION ${PACKAGE_INSTALL_DESTINATION}
-      PATH_VARS CMAKE_INSTALL_PREFIX
-      )
-   install(FILES
-      cmake/UserWarning.cmake
-      cmake/VcMacros.cmake
-      cmake/AddCompilerFlag.cmake
-      cmake/CheckCCompilerFlag.cmake
-      cmake/CheckCXXCompilerFlag.cmake
-      cmake/OptimizeForArchitecture.cmake
-      cmake/FindVc.cmake
-      ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Config.cmake
-      ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}ConfigVersion.cmake
-      DESTINATION ${PACKAGE_INSTALL_DESTINATION}
-      )
-endif()
+#    # Generate and install CMake package and modules
+#    include(CMakePackageConfigHelpers)
+#    set(PACKAGE_INSTALL_DESTINATION
+#       lib${LIB_SUFFIX}/cmake/${PROJECT_NAME}
+#       )
+#    install(EXPORT ${PROJECT_NAME}Targets
+#       NAMESPACE ${PROJECT_NAME}::
+#       DESTINATION ${PACKAGE_INSTALL_DESTINATION}
+#       EXPORT_LINK_INTERFACE_LIBRARIES
+#       )
+#    write_basic_package_version_file(
+#       ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}ConfigVersion.cmake
+#       VERSION ${PROJECT_VERSION}
+#       COMPATIBILITY AnyNewerVersion
+#       )
+#    configure_package_config_file(
+#       ${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in
+#       ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Config.cmake
+#       INSTALL_DESTINATION ${PACKAGE_INSTALL_DESTINATION}
+#       PATH_VARS CMAKE_INSTALL_PREFIX
+#       )
+#    install(FILES
+#       cmake/UserWarning.cmake
+#       cmake/VcMacros.cmake
+#       cmake/AddCompilerFlag.cmake
+#       cmake/CheckCCompilerFlag.cmake
+#       cmake/CheckCXXCompilerFlag.cmake
+#       cmake/OptimizeForArchitecture.cmake
+#       cmake/FindVc.cmake
+#       ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Config.cmake
+#       ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}ConfigVersion.cmake
+#       DESTINATION ${PACKAGE_INSTALL_DESTINATION}
+#       )
+# endif()
 
 # option(BUILD_TESTING "Build the testing tree." OFF)
 # include (CTest)

--- a/3rdparty/Vc/CMakeLists.txt
+++ b/3rdparty/Vc/CMakeLists.txt
@@ -187,7 +187,7 @@ target_include_directories(Vc
    $<INSTALL_INTERFACE:include>
    )
 
-option(Vc_ENABLE_INSTALL "Whether to install the library." ON)
+option(Vc_ENABLE_INSTALL "Whether to install the library." OFF)
 if (Vc_ENABLE_INSTALL)
    install(TARGETS Vc EXPORT VcTargets DESTINATION lib${LIB_SUFFIX})
    install(DIRECTORY Vc/ DESTINATION include/Vc FILES_MATCHING REGEX "/*.(h|tcc|def)$")


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [] I have linked to any relevant GitHub issues, if applicable
- [] Documentation in `doc/` has been updated
- [] All new code is licensed under GPLv3

## Description

Debian maintainer here, forwarded from [Debian BTS #1071006](https://bugs.debian.org/1071006)

By default, the newly vendored Vc library will be installed alongside conky itself, e.g. [all of the headers and the cmake files that ship with Vc](https://web.archive.org/web/20240513084923/https://packages.debian.org/sid/amd64/conky-all/filelist). This is unnecessary and even undesired if the user already had Vc installed from other sources, e.g. `libvc-dev` in Debian/Ubuntu. I can turn this off with `-DVc_ENABLE_INSTALL=OFF` but I think this would be a sane default option.