### PR TITLE
Fix build with specific option combination.

### DIFF
--- a/src/llua.h
+++ b/src/llua.h
@@ -31,6 +31,7 @@ extern "C" {
 }
 
 #include <config.h>
+#include "geometry.h"
 
 #ifdef BUILD_MOUSE_EVENTS
 #include "mouse-events.h"

--- a/src/x11-settings.cc
+++ b/src/x11-settings.cc
@@ -77,7 +77,7 @@ bool use_xpmdb_setting::set_up(lua::state &l) {
   if (!out_to_x.get(l)) return false;
 
   window.back_buffer =
-      XCreatePixmap(display, window.window, window.width + 1, window.height + 1,
+      XCreatePixmap(display, window.window, window.geometry.get_width() + 1, window.geometry.get_height() + 1,
                     DefaultDepth(display, screen));
   if (window.back_buffer != None) {
     window.drawable = window.back_buffer;

--- a/src/x11.cc
+++ b/src/x11.cc
@@ -1219,10 +1219,10 @@ void xdbe_swap_buffers() {
 void xpmdb_swap_buffers(void) {
   if (use_xpmdb.get(*state)) {
     XCopyArea(display, window.back_buffer, window.window, window.gc, 0, 0,
-              window.width, window.height, 0, 0);
+              window.geometry.get_width(), window.geometry.get_height(), 0, 0);
     XSetForeground(display, window.gc, 0);
-    XFillRectangle(display, window.drawable, window.gc, 0, 0, window.width,
-                   window.height);
+    XFillRectangle(display, window.drawable, window.gc, 0, 0, window.geometry.get_width(),
+                   window.geometry.get_height());
     XFlush(display);
   }
 }


### PR DESCRIPTION
With at least double buffer, mouse events, lua imlib2, xinerama and wayland support disabled, the #ifdef combination in the code fails to build:

```
[snip]

/wrkdirs/usr/ports/sysutils/conky-awesome/work/conky-1.21.0/src/llua.h:62:6: error: variable has incomplete type 'void' void llua_setup_window_table(conky::rect<int> text_rect);
     ^
/wrkdirs/usr/ports/sysutils/conky-awesome/work/conky-1.21.0/src/llua.h:62:37: error: no member named 'rect' in namespace 'conky' void llua_setup_window_table(conky::rect<int> text_rect);
                             ~~~~~~~^
[snip]

/wrkdirs/usr/ports/sysutils/conky-awesome/work/conky-1.21.0/src/x11-settings.cc:80:52: error: no member named 'width' in 'conky_x11_window'
      XCreatePixmap(display, window.window, window.width + 1, window.height + 1,
                                            ~~~~~~ ^
/wrkdirs/usr/ports/sysutils/conky-awesome/work/conky-1.21.0/src/x11-settings.cc:80:70: error: no member named 'height' in 'conky_x11_window'
      XCreatePixmap(display, window.window, window.width + 1, window.height + 1,
                                                              ~~~~~~ ^
```
This commit fixes the usage of the `geometry` field in `conky_x11_window`.

# Checklist
- [X] I have described the changes
- [X] I have linked to any relevant GitHub issues, if applicable
- [X] Documentation in `doc/` has been updated
- [X] All new code is licensed under GPLv3

## Description

* Describe the changes, why they were necessary, etc
* Describe how the changes will affect existing behaviour.
* Describe how you tested and validated your changes.
* Include any relevant screenshots/evidence demonstrating that the changes work and have been tested.
