### PR TITLE
Fix minimum height not being applied

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -863,9 +863,9 @@ void update_text_area() {
     for_each_line(text_buffer, text_size_updater);
     text_size += conky::vec2i::UnitX();
 
-    text_size.max(conky::vec2i(text_size.x(), minimum_height.get(*state)));
+    text_size = text_size.max(conky::vec2i(text_size.x(), minimum_height.get(*state)));
     int mw = maximum_width.get(*state);
-    if (mw > 0) text_size.min(conky::vec2i(mw, text_size.y()));
+    if (mw > 0) text_size = text_size.min(conky::vec2i(mw, text_size.y()));
   }
 
   alignment align = text_alignment.get(*state);


### PR DESCRIPTION
# Checklist
- [X] I have described the changes
- ~~I have linked to any relevant GitHub issues, if applicable~~
- ~~Documentation in `doc/` has been updated~~
- [X] All new code is licensed under GPLv3

## Description

Small commit to fix a regression introduced in 2d507672. The `min`/`max` methods of `vec` return the result as a new vector, but the return value is never assigned.

## Output

Test config:
```lua
conky.config = {
	own_window = true,
	minimum_width = 100,
	minimum_height = 100,
	
	lua_load = "/home/chris/.config/conky/test.lua",
	lua_draw_hook_post = "main"
}
conky.text = [[]];
```
```lua
require 'cairo'
require 'cairo_xlib'

function conky_main()
	if conky_window==nil then return end
	print("window size: ", conky_window.width, "x", conky_window.height)
end
```

Running in `HEAD`:
```
> conky -D -c ~/.config/conky/test.conf
DEBUG(0) [/home/chris/software/conky/src/conky.cc:1955]: reading contents from config file '/home/chris/.config/conky/test.conf'
DEBUG(0) [/home/chris/software/conky/src/x11.cc:244]: enter init_x11()
DEBUG(0) [/home/chris/software/conky/src/x11.cc:363]: Fixed xinerama area to: 0 0 1920 1080
DEBUG(0) [/home/chris/software/conky/src/x11.cc:288]: leave init_x11()
DEBUG(0) [/home/chris/software/conky/src/x11.cc:481]: enter x11_init_window()
DEBUG(0) [/home/chris/software/conky/src/x11.cc:363]: Fixed xinerama area to: 0 0 1920 1080
conky: desktop window (0x1e3) is root window
conky: window type - normal
conky: drawing to created window (0x5000001)
DEBUG(0) [/home/chris/software/conky/src/x11.cc:895]: leave x11_init_window()
DEBUG(0) [/home/chris/software/conky/src/display-output.cc:39]: HTTP display output disabled. Enable by recompiling with 'BUILD_HTTP' flag enabled.
DEBUG(0) [/home/chris/software/conky/src/display-output.cc:39]: Wayland display output disabled. Enable by recompiling with 'BUILD_WAYLAND' flag enabled.
conky: FOUND: console
conky: FOUND: ncurses
conky: FOUND: file
conky: FOUND: x11
DEBUG(0) [/home/chris/software/conky/src/display-output.cc:109]: Initialized display output 'x11'... 
conky: 'herbstluftwm' x11 session running '(null)' desktop
window size: 	0.0	x	0.0
window size: 	0.0	x	0.0
DEBUG(0) [/home/chris/software/conky/src/x11.cc:176]: X window Error:
Display: 5601bf6c6e30, XID: 0, Serial: 530
error code: [major: 12, minor: 0]
window size: 	113.0	x	0.0
window size: 	113.0	x	0.0
window size: 	113.0	x	0.0
...
```

Running in this commit:
```
> conky -D -c ~/.config/conky/test.conf
DEBUG(0) [/home/chris/software/conky/src/conky.cc:1955]: reading contents from config file '.config/conky/test.conf'
DEBUG(0) [/home/chris/software/conky/src/x11.cc:244]: enter init_x11()
DEBUG(0) [/home/chris/software/conky/src/x11.cc:363]: Fixed xinerama area to: 0 0 1920 1080
DEBUG(0) [/home/chris/software/conky/src/x11.cc:288]: leave init_x11()
DEBUG(0) [/home/chris/software/conky/src/x11.cc:481]: enter x11_init_window()
DEBUG(0) [/home/chris/software/conky/src/x11.cc:363]: Fixed xinerama area to: 1920 0 3280 768
conky: desktop window (0x1e3) is root window
conky: window type - normal
conky: drawing to created window (0x5000001)
DEBUG(0) [/home/chris/software/conky/src/x11.cc:895]: leave x11_init_window()
DEBUG(0) [/home/chris/software/conky/src/display-output.cc:39]: HTTP display output disabled. Enable by recompiling with 'BUILD_HTTP' flag enabled.
DEBUG(0) [/home/chris/software/conky/src/display-output.cc:39]: Wayland display output disabled. Enable by recompiling with 'BUILD_WAYLAND' flag enabled.
conky: FOUND: console
conky: FOUND: ncurses
conky: FOUND: file
conky: FOUND: x11
DEBUG(0) [/home/chris/software/conky/src/display-output.cc:109]: Initialized display output 'x11'... 
conky: 'herbstluftwm' x11 session running '(null)' desktop
window size: 	0.0	x	0.0
window size: 	113.0	x	100.0
window size: 	113.0	x	100.0
window size: 	113.0	x	100.0
...
```