### PR TITLE
Fix for the graph scale text colour changing depending on graph position

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1374,6 +1374,7 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
             }
 #ifdef BUILD_MATH
             if (show_graph_scale.get(*state) && (current->show_scale == 1)) {
+              set_foreground_color(current->first_colour);
               int tmp_x = cur_x;
               int tmp_y = cur_y;
               cur_x += font_ascent() / 2;

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1374,6 +1374,7 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
             }
 #ifdef BUILD_MATH
             if (show_graph_scale.get(*state) && (current->show_scale == 1)) {
+              // Set the foreground colour to the first colour, ensures the scale text is always drawn in the same colour
               set_foreground_color(current->first_colour);
               int tmp_x = cur_x;
               int tmp_y = cur_y;


### PR DESCRIPTION
# Checklist
- [X] I have described the changes
- [X] All new code is licensed under GPLv3

## Description

In the current latest code of conky, when you have a graph scale enabled, the text will change colour whenever a "high point" on the graph reached the "end" of the graph. It's difficult to describe so I took some screenshots:

### Before
![before-normal](https://github.com/brndnmtthws/conky/assets/135234789/7aaa8f2a-06d6-4dcb-884c-b406c3022a45)
![before-error](https://github.com/brndnmtthws/conky/assets/135234789/b1f662d6-1118-4463-9428-b0943e46c06e)

The scale text changes colour to whatever the colour of the leftmost "bar" of the graph is.

### After
![after-normal](https://github.com/brndnmtthws/conky/assets/135234789/198dbcbb-6dbd-4052-8c40-09600a44a97d)
![after-error](https://github.com/brndnmtthws/conky/assets/135234789/f40669c3-fe83-4d4b-8029-7a700db56474)

No longer does this

I'm not sure if this was an intended feature, if it was, feel free to close this. imo it shouldn't change colour because it makes the text very hard to read when the whole graph is full of red. 
It's a simple fix, just adding one extra line to change the colour back to the "first" graph colour (i.e. the colour of the lowest values)

There shouldn't be any unintended side effects of the change, because looking at the code, this is the last if statement in a block, and right after the if statements, the colour gets changed anyway (`set_foreground_color(last_colour);`)
