### PR TITLE
Fix AC/battery detection logic on FreeBSD.

### DIFF
--- a/src/freebsd.cc
+++ b/src/freebsd.cc
@@ -455,17 +455,17 @@ static void get_battery_stats(int *battime, int *batcapacity, int *batstate,
 
   if (battery_present) {
     if (battime && GETSYSCTL("hw.acpi.battery.time", *battime)) {
-      fprintf(stderr, "Cannot read sysctl \"hw.acpi.battery.time\"\n");
+      NORM_ERR("Cannot read sysctl \"hw.acpi.battery.time\"");
     }
     if (batcapacity && GETSYSCTL("hw.acpi.battery.life", *batcapacity)) {
-      fprintf(stderr, "Cannot read sysctl \"hw.acpi.battery.life\"\n");
+      NORM_ERR("Cannot read sysctl \"hw.acpi.battery.life\"");
     }
     if (batstate && GETSYSCTL("hw.acpi.battery.state", *batstate)) {
-      fprintf(stderr, "Cannot read sysctl \"hw.acpi.battery.state\"\n");
+      NORM_ERR("Cannot read sysctl \"hw.acpi.battery.state\"");
     }
   }
   if (ac_present && ac && GETSYSCTL("hw.acpi.acline", *ac)) {
-    fprintf(stderr, "Cannot read sysctl \"hw.acpi.acline\"\n");
+    NORM_ERR("Cannot read sysctl \"hw.acpi.acline\"");
   }
 }
 

--- a/src/freebsd.cc
+++ b/src/freebsd.cc
@@ -427,6 +427,10 @@ double get_acpi_temperature(int fd) {
   return 0.0;
 }
 
+// If a leaf MIB in the sysctl tree returns ENOENT, that means the entry does
+// not exist. On the contrary, if a non-leaf entry *does exist*, then EISDIR
+// errno is returned, meaning it exists, but it is an array/directory with
+// more elements hanging from it.
 static int sysctl_mib_exists(const char *mib)
 {
   size_t len;
@@ -437,10 +441,6 @@ static int sysctl_mib_exists(const char *mib)
 
 static void get_battery_stats(int *battime, int *batcapacity, int *batstate,
                               int *ac) {
-  // If a leaf MIB in the sysctl tree returns ENOENT, that means the entry does
-  // not exist. On the contrary, if a non-leaf entry *does exist*, then EISDIR
-  // errno is returned, meaning it exists, but it is an array/directory with
-  // more elements hanging from it.
   int battery_present = sysctl_mib_exists("hw.acpi.battery");
   int ac_present = sysctl_mib_exists("hw.acpi.acline");
 


### PR DESCRIPTION
The logic for the detection of the battery/AC line was not completely correct for FreeBSD. Launching conky on console shows the following:

Cannot read sysctl "hw.acpi.battery.time"
Cannot read sysctl "hw.acpi.battery.life"
Cannot read sysctl "hw.acpi.battery.state"
Cannot read sysctl "hw.acpi.acline"
Unknown battery state 8!

In a PC, the hw.acpi.battery MIB does not exist.
Also, the hw.acpi.acline is only present if supported by the hardware. In addition, some variables were used uninitialized and that causes strange behavior: in a PC it showed it worked on battery and the % of charge was an ridiculous big number.

![bad](https://github.com/brndnmtthws/conky/assets/2565871/d3bfb54e-7eca-4e3b-8fcc-72d61639291e)

This patch addresses the issue. It fixes the problem in the PC. It has also being tested in a laptop running FreeBSD current plugin and unplugging the AC line and also snatching the battery mercilessly to see if something breaks.

![good](https://github.com/brndnmtthws/conky/assets/2565871/b4d07447-6415-46c5-b190-38114dcf2c1e)

# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [x ] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

* Describe the changes, why they were necessary, etc
* Describe how the changes will affect existing behaviour.
* Describe how you tested and validated your changes.
* Include any relevant screenshots/evidence demonstrating that the changes work and have been tested.
