### PR TITLE
Made upspeedgraph and downspeed graph scale on a common axis 

### DIFF
--- a/src/common.cc
+++ b/src/common.cc
@@ -352,7 +352,7 @@ void print_no_update(struct text_object *obj, char *p,
 
 #ifdef BUILD_GUI
 void scan_loadgraph_arg(struct text_object *obj, const char *arg) {
-  scan_graph(obj, arg, 0);
+  scan_graph(obj, arg, 0, FALSE);
 }
 
 double loadgraphval(struct text_object *obj) {

--- a/src/core.cc
+++ b/src/core.cc
@@ -729,7 +729,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
 #ifdef BUILD_GUI
   END OBJ(cpugraph, &update_cpu_usage) get_cpu_count();
   SCAN_CPU(arg, obj->data.i);
-  scan_graph(obj, arg, 1);
+  scan_graph(obj, arg, 1, FALSE);
   DBGP2("Adding $cpugraph for CPU %d", obj->data.i);
   obj->callbacks.graphval = &cpu_barval;
   obj->callbacks.free = &free_cpu;
@@ -1241,9 +1241,9 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ(memwithbuffersbar, &update_meminfo) scan_bar(obj, arg, 1);
   obj->callbacks.barval = &mem_with_buffers_barval;
 #ifdef BUILD_GUI
-  END OBJ(memgraph, &update_meminfo) scan_graph(obj, arg, 1);
+  END OBJ(memgraph, &update_meminfo) scan_graph(obj, arg, 1, FALSE);
   obj->callbacks.graphval = &mem_barval;
-  END OBJ(memwithbuffersgraph, &update_meminfo) scan_graph(obj, arg, 1);
+  END OBJ(memwithbuffersgraph, &update_meminfo) scan_graph(obj, arg, 1, FALSE);
   obj->callbacks.graphval = &mem_with_buffers_barval;
 #endif /* BUILD_GUI*/
 #ifdef HAVE_SOME_SOUNDCARD_H
@@ -1825,7 +1825,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
       "lua_graph needs arguments: <function name> [height],[width] [gradient "
       "colour 1] [gradient colour 2] [scale] [-t] [-l]") auto [buf, skip] =
       scan_command(arg);
-  scan_graph(obj, arg + skip, 100);
+  scan_graph(obj, arg + skip, 100, FALSE);
   if (buf != nullptr) {
     obj->data.s = buf;
   } else {
@@ -1968,7 +1968,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ(apcupsd_loadbar, &update_apcupsd) scan_bar(obj, arg, 100);
   obj->callbacks.barval = &apcupsd_loadbarval;
 #ifdef BUILD_GUI
-  END OBJ(apcupsd_loadgraph, &update_apcupsd) scan_graph(obj, arg, 100);
+  END OBJ(apcupsd_loadgraph, &update_apcupsd) scan_graph(obj, arg, 100, FALSE);
   obj->callbacks.graphval = &apcupsd_loadbarval;
   END OBJ(apcupsd_loadgauge, &update_apcupsd) scan_gauge(obj, arg, 100);
   obj->callbacks.gaugeval = &apcupsd_loadbarval;

--- a/src/diskio.cc
+++ b/src/diskio.cc
@@ -173,7 +173,7 @@ void print_diskio_write(struct text_object *obj, char *p,
 #ifdef BUILD_GUI
 void parse_diskiograph_arg(struct text_object *obj, const char *arg) {
   auto [buf, skip] = scan_command(arg);
-  scan_graph(obj, arg + skip, 0);
+  scan_graph(obj, arg + skip, 0, FALSE);
 
   obj->data.opaque = prepare_diskio_stat(dev_name(buf));
   free_and_zero(buf);

--- a/src/exec.cc
+++ b/src/exec.cc
@@ -275,7 +275,7 @@ void scan_exec_arg(struct text_object *obj, const char *arg,
     cmd = scan_gauge(obj, cmd, 100);
   } else if ((execflag & EF_GRAPH) != 0u) {
     auto [buf, skip] = scan_command(cmd);
-    scan_graph(obj, cmd + skip, 100);
+    scan_graph(obj, cmd + skip, 100, FALSE);
     cmd = buf;
     if (cmd == nullptr) {
       NORM_ERR("error parsing arguments to execgraph object");

--- a/src/net_stat.cc
+++ b/src/net_stat.cc
@@ -334,7 +334,7 @@ void parse_net_stat_graph_arg(struct text_object *obj, const char *arg,
                               void *free_at_crash) {
   /* scan arguments and get interface name back */
   auto [buf, skip] = scan_command(arg);
-  scan_graph(obj, arg + skip, 0);
+  scan_graph(obj, arg + skip, 0, TRUE);
 
   // default to DEFAULTNETDEV
   if (buf != nullptr) {

--- a/src/nvidia.cc
+++ b/src/nvidia.cc
@@ -458,7 +458,7 @@ int set_nvidia_query(struct text_object *obj, const char *arg,
       break;
     case text_node_t::GRAPH: {
       auto [buf, skip] = scan_command(arg);
-      scan_graph(obj, arg + skip, 100);
+      scan_graph(obj, arg + skip, 100, FALSE);
       arg = buf;
     } break;
     case text_node_t::GAUGE:

--- a/src/specials.h
+++ b/src/specials.h
@@ -80,6 +80,7 @@ struct special_node {
   Colour last_colour;
   short font_added;
   char tempgrad;
+  char speedgraph;
   struct special_node *next;
 };
 
@@ -97,7 +98,7 @@ const char *scan_gauge(struct text_object *, const char *, double);
 #ifdef BUILD_GUI
 void scan_font(struct text_object *, const char *);
 std::pair<char *, size_t> scan_command(const char *);
-bool scan_graph(struct text_object *, const char *, double);
+bool scan_graph(struct text_object *, const char *, double, char);
 void scan_tab(struct text_object *, const char *);
 void scan_stippled_hr(struct text_object *, const char *);
 

--- a/tests/test-graph.cc
+++ b/tests/test-graph.cc
@@ -54,7 +54,7 @@ struct graph {
 
 static std::pair<struct graph, bool> test_parse(const char *s) {
   struct text_object obj;
-  bool result = scan_graph(&obj, s, default_scale);
+  bool result = scan_graph(&obj, s, default_scale,FALSE);
   auto g = static_cast<struct graph *>(obj.special_data);
   struct graph graph = *g;
   free(g);


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] All new code is licensed under GPLv3

## Description
#### Before
In the current latest code of conky, downspeedgraph and upspeedgraph look the same because they're both individually scaled with respect to max value.

<img width="329" alt="Screenshot 2024-07-20 at 10 59 35 PM" src="https://github.com/user-attachments/assets/495cbe9e-e759-4937-aed1-ba2ea3e6c34c">

#### After
<img width="298" alt="Screenshot 2024-07-21 at 3 15 48 AM" src="https://github.com/user-attachments/assets/d4dd9690-95cc-4158-b9d7-8083f038083f">
<img width="298" alt="Screenshot 2024-07-21 at 3 15 59 AM" src="https://github.com/user-attachments/assets/cdeb196c-1137-4496-8a12-52491ca6f0a6">

This has now been fixed and both of them are scaled on a common axis. I have tested the code, and it does not influence any other graphs.

The changes made include 
1. Adding ```char speedgraph``` flag to the ```struct graph``` and ```struct special_node```.
2. Declaring a global ```double maxval``` to keep track of the current max value across the two graphs.
3.  Adding parameter ```char speedgraph``` to scan_graph method.
4.  And finally checking if the current value getting added is bigger than maxval, if so we make our scale = maxval, in the graph_append method.

Fixes #1820 