### PR TITLE
Fix for GCC 15 two-phase lookup

### DIFF
--- a/src/geometry.h
+++ b/src/geometry.h
@@ -486,9 +486,9 @@ struct rect {
 
   inline void set_width(T value) {
     if constexpr (Kind == rect_kind::SIZED) {
-      this->other.set_x(value);
+      this->m_other.set_x(value);
     } else {
-      this->other.set_x(this->m_pos.get_x() + value);
+      this->m_other.set_x(this->m_pos.get_x() + value);
     }
   }
   inline void set_height(T value) {
@@ -532,9 +532,9 @@ struct rect {
   std::array<vec2<T>, 4> corners() const {
     return std::array<vec2<T>, 4>{
         this->m_pos,
-        this->m_pos + vec2<T>(this->get_width(), 0),
-        this->get_end_pos(),
-        this->m_pos + vec2<T>(0, this->get_height()),
+        this->m_pos + vec2<T>(this->width(), 0),
+        this->end_pos(),
+        this->m_pos + vec2<T>(0, this->height()),
     };
   }
 


### PR DESCRIPTION
* GCC 15 is more aggressive about checking dependent names: https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=r15-2117-g313afcfdabeab3

Bug: https://bugs.gentoo.org/936522

# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [x] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3