### PR TITLE
Implemented switch direction of graph in all 4 direction

### DIFF
--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -98,6 +98,7 @@ values:
       - (-t)
       - (-l)
       - (-x)
+      - (-y)
   - name: apcupsd_model
     desc: Prints the model of the UPS.
   - name: apcupsd_name
@@ -330,7 +331,7 @@ values:
       numbers) when you use the -l switch. Takes the switch '-t' to use a
       temperature gradient, which makes the gradient values change depending
       on the amplitude of a particular graph value (try it and see). The flag
-      '-x' inverts the x axis of the graph.
+      '-x' inverts the x axis and '-y' inverts the y axis of the graph.
     args:
       - (cpuN)
       - (height),(width)
@@ -340,6 +341,7 @@ values:
       - (-t)
       - (-l)
       - (-x)
+      - (-y)
   - name: curl
     desc: |-
       Download data from URI using Curl at the specified interval.
@@ -392,7 +394,8 @@ values:
       scale (to see small numbers) when you use -l switch. Takes the switch
       '-t' to use a temperature gradient, which makes the gradient values
       change depending on the amplitude of a particular graph value (try it
-      and see). The flag '-x' inverts the x axis of the graph.
+      and see). The flag '-x' inverts the x axis and '-y' inverts the y axis 
+      of the graph.
     args:
       - (device)
       - (height),(width)
@@ -402,6 +405,7 @@ values:
       - (-t)
       - (-l)
       - (-x)
+      - (-y)
   - name: diskiograph_read
     desc: |-
       Disk IO graph for reads, colours defined in hex, minus the
@@ -410,7 +414,7 @@ values:
       use -l switch. Takes the switch '-t' to use a temperature gradient,
       which makes the gradient values change depending on the amplitude of a
       particular graph value (try it and see). The flag '-x' inverts the x 
-      axis of the graph.
+      axis and '-y' inverts the y axis of the graph.
     args:
       - (device)
       - (height),(width)
@@ -420,6 +424,7 @@ values:
       - (-t)
       - (-l)
       - (-x)
+      - (-y)
   - name: diskiograph_write
     desc: |-
       Disk IO graph for writes, colours defined in hex, minus the
@@ -428,7 +433,7 @@ values:
       use -l switch. Takes the switch '-t' to use a temperature gradient,
       which makes the gradient values change depending on the amplitude of a
       particular graph value (try it and see). The flag '-x' inverts the x 
-      axis of the graph.
+      axis and '-y' inverts the y axis of the graph.
     args:
       - (device)
       - (height),(width)
@@ -438,6 +443,7 @@ values:
       - (-t)
       - (-l)
       - (-x)
+      - (-y)
   - name: distribution
     desc: |-
       The name of the distribution. It could be that some of the
@@ -464,7 +470,8 @@ values:
       per second). Uses a logarithmic scale (to see small numbers) when you use
       -l switch. Takes the switch '-t' to use a temperature gradient, which makes
       the gradient values change depending on the amplitude of a particular
-      graph value (try it and see). The flag '-x' inverts the x axis of the graph.
+      graph value (try it and see). The flag '-x' inverts the x axis and '-y' 
+      inverts the y axis of the graph.
     args:
       - (netdev)
       - (height),(width)
@@ -474,6 +481,7 @@ values:
       - (-t)
       - (-l)
       - (-x)
+      - (-y)
   - name: draft_mails
     desc: |-
       Number of mails marked as draft in the specified mailbox or
@@ -545,7 +553,7 @@ values:
       -l switch to enable a logarithmic scale, which helps to see small values.
       The default size for graphs can be controlled via the default_graph_height
       and default_graph_width config settings. The flag '-x' inverts the x axis 
-      of the graph.
+      and '-y' inverts the y axis of the graph.
 
       If you need to execute a command with spaces, you have a
       couple options:
@@ -573,6 +581,7 @@ values:
       - (-t)
       - (-l)
       - (-x)
+      - (-y)
   - name: execi
     desc: |-
       Same as exec, but with a specific interval in seconds. The
@@ -605,6 +614,7 @@ values:
       - (-t)
       - (-l)
       - (-x)
+      - (-y)
   - name: execp
     desc: |-
       Executes a shell command and displays the output in conky.
@@ -1124,7 +1134,7 @@ values:
       when you use the -l switch. Takes the switch '-t' to use a temperature
       gradient, which makes the gradient values change depending on the
       amplitude of a particular graph value (try it and see). The flag
-      '-x' inverts the x axis of the graph.
+      '-x' inverts the x axis and '-y' inverts the y axis of the graph.
     args:
       - (height),(width)
       - (gradient colour 1)
@@ -1133,6 +1143,7 @@ values:
       - (-t)
       - (-l)
       - (-x)
+      - (-y)
   - name: lowercase
     desc: Converts all letters into lowercase.
     args:
@@ -1178,7 +1189,8 @@ values:
       values change depending on the amplitude of a particular graph value
       (try it and see). Conky puts 'conky_' in front of function_name to
       prevent accidental calls to the wrong function unless you put you
-      place 'conky_' in front of it yourself.
+      place 'conky_' in front of it yourself.  The flag '-x' inverts the 
+      x axis and '-y' inverts the y axis of the graph. 
     args:
       - function_name
       - (height),(width)
@@ -1188,6 +1200,7 @@ values:
       - (-t)
       - (-l)
       - (-x)
+      - (-y)
   - name: lua_parse
     desc: |-
       Executes a Lua function with given parameters as per $lua,
@@ -1248,7 +1261,7 @@ values:
       numbers) when you use the -l switch. Takes the switch '-t' to use a
       temperature gradient, which makes the gradient values change depending
       on the amplitude of a particular graph value (try it and see). The flag
-      '-x' inverts the x axis of the graph.
+      '-x' inverts the x axis and '-y' inverts the y axis of the graph.
     args:
       - (height),(width)
       - (gradient colour 1)
@@ -1257,6 +1270,7 @@ values:
       - (-t)
       - (-l)
       - (-x)
+      - (-y)
   - name: meminactive
     desc: Amount of inactive memory. FreeBSD only.
   - name: memlaundry
@@ -1284,7 +1298,7 @@ values:
       use the -l switch. Takes the switch '-t' to use a temperature
       gradient, which makes the gradient values change depending on the
       amplitude of a particular graph value (try it and see). The flag
-      '-x' inverts the x axis of the graph.
+      '-x' inverts the x axis and '-y' inverts the y axis of the graph.
     args:
       - (height),(width)
       - (gradient colour 1)
@@ -1293,6 +1307,7 @@ values:
       - (-t)
       - (-l)
       - (-x)
+      - (-y)
   - name: mixer
     desc: |-
       Prints the mixer value as reported by the OS. On Linux, this
@@ -1548,7 +1563,7 @@ values:
       used as 0,1,2,3,..
 
       For possible arguments see nvidia and nvidiabar. To learn more about the
-      -t -l -x and gradient color options, see execgraph.
+      -t -l -x -y and gradient color options, see execgraph.
     args:
       - argument
       - (height),(width)
@@ -1558,6 +1573,7 @@ values:
       - (-t)
       - (-l)
       - (-x)
+      - (-y)
       - GPU_ID
   - name: offset
     desc: Move text over by N pixels. See also $voffset.
@@ -2348,7 +2364,8 @@ values:
       numbers) when you use the -l switch. Takes the switch '-t' to
       use a temperature gradient, which makes the gradient values
       change depending on the amplitude of a particular graph value
-      (try it and see). The flag '-x' inverts the x axis of the graph.
+      (try it and see). The flag '-x' inverts the x axis and '-y' 
+      inverts the y axis of the graph.
     args:
       - (netdev)
       - (height),(width)
@@ -2358,6 +2375,7 @@ values:
       - (-t)
       - (-l)
       - (-x)
+      - (-y)
   - name: uptime
     desc: Uptime.
   - name: uptime_short

--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -97,6 +97,7 @@ values:
       - (scale)
       - (-t)
       - (-l)
+      - (-x)
   - name: apcupsd_model
     desc: Prints the model of the UPS.
   - name: apcupsd_name
@@ -328,7 +329,8 @@ values:
       See $cpu for more info on SMP. Uses a logarithmic scale (to see small
       numbers) when you use the -l switch. Takes the switch '-t' to use a
       temperature gradient, which makes the gradient values change depending
-      on the amplitude of a particular graph value (try it and see).
+      on the amplitude of a particular graph value (try it and see). The flag
+      '-x' inverts the x axis of the graph.
     args:
       - (cpuN)
       - (height),(width)
@@ -337,6 +339,7 @@ values:
       - (scale)
       - (-t)
       - (-l)
+      - (-x)
   - name: curl
     desc: |-
       Download data from URI using Curl at the specified interval.
@@ -389,7 +392,7 @@ values:
       scale (to see small numbers) when you use -l switch. Takes the switch
       '-t' to use a temperature gradient, which makes the gradient values
       change depending on the amplitude of a particular graph value (try it
-      and see).
+      and see). The flag '-x' inverts the x axis of the graph.
     args:
       - (device)
       - (height),(width)
@@ -398,6 +401,7 @@ values:
       - (scale)
       - (-t)
       - (-l)
+      - (-x)
   - name: diskiograph_read
     desc: |-
       Disk IO graph for reads, colours defined in hex, minus the
@@ -405,7 +409,8 @@ values:
       in diskio. Uses a logarithmic scale (to see small numbers) when you
       use -l switch. Takes the switch '-t' to use a temperature gradient,
       which makes the gradient values change depending on the amplitude of a
-      particular graph value (try it and see).
+      particular graph value (try it and see). The flag '-x' inverts the x 
+      axis of the graph.
     args:
       - (device)
       - (height),(width)
@@ -414,6 +419,7 @@ values:
       - (scale)
       - (-t)
       - (-l)
+      - (-x)
   - name: diskiograph_write
     desc: |-
       Disk IO graph for writes, colours defined in hex, minus the
@@ -421,7 +427,8 @@ values:
       in diskio. Uses a logarithmic scale (to see small numbers) when you
       use -l switch. Takes the switch '-t' to use a temperature gradient,
       which makes the gradient values change depending on the amplitude of a
-      particular graph value (try it and see).
+      particular graph value (try it and see). The flag '-x' inverts the x 
+      axis of the graph.
     args:
       - (device)
       - (height),(width)
@@ -430,6 +437,7 @@ values:
       - (scale)
       - (-t)
       - (-l)
+      - (-x)
   - name: distribution
     desc: |-
       The name of the distribution. It could be that some of the
@@ -456,7 +464,7 @@ values:
       per second). Uses a logarithmic scale (to see small numbers) when you use
       -l switch. Takes the switch '-t' to use a temperature gradient, which makes
       the gradient values change depending on the amplitude of a particular
-      graph value (try it and see).
+      graph value (try it and see). The flag '-x' inverts the x axis of the graph.
     args:
       - (netdev)
       - (height),(width)
@@ -465,6 +473,7 @@ values:
       - (scale)
       - (-t)
       - (-l)
+      - (-x)
   - name: draft_mails
     desc: |-
       Number of mails marked as draft in the specified mailbox or
@@ -535,7 +544,8 @@ values:
       graph. The scale parameter defines the maximum value of the graph.  Use the
       -l switch to enable a logarithmic scale, which helps to see small values.
       The default size for graphs can be controlled via the default_graph_height
-      and default_graph_width config settings.
+      and default_graph_width config settings. The flag '-x' inverts the x axis 
+      of the graph.
 
       If you need to execute a command with spaces, you have a
       couple options:
@@ -562,6 +572,7 @@ values:
       - (scale)
       - (-t)
       - (-l)
+      - (-x)
   - name: execi
     desc: |-
       Same as exec, but with a specific interval in seconds. The
@@ -593,6 +604,7 @@ values:
       - (scale)
       - (-t)
       - (-l)
+      - (-x)
   - name: execp
     desc: |-
       Executes a shell command and displays the output in conky.
@@ -1111,7 +1123,8 @@ values:
       in hex, minus the #. Uses a logarithmic scale (to see small numbers)
       when you use the -l switch. Takes the switch '-t' to use a temperature
       gradient, which makes the gradient values change depending on the
-      amplitude of a particular graph value (try it and see).
+      amplitude of a particular graph value (try it and see). The flag
+      '-x' inverts the x axis of the graph.
     args:
       - (height),(width)
       - (gradient colour 1)
@@ -1119,6 +1132,7 @@ values:
       - (scale)
       - (-t)
       - (-l)
+      - (-x)
   - name: lowercase
     desc: Converts all letters into lowercase.
     args:
@@ -1173,6 +1187,7 @@ values:
       - (scale)
       - (-t)
       - (-l)
+      - (-x)
   - name: lua_parse
     desc: |-
       Executes a Lua function with given parameters as per $lua,
@@ -1232,7 +1247,8 @@ values:
       Memory usage graph. Uses a logarithmic scale (to see small
       numbers) when you use the -l switch. Takes the switch '-t' to use a
       temperature gradient, which makes the gradient values change depending
-      on the amplitude of a particular graph value (try it and see).
+      on the amplitude of a particular graph value (try it and see). The flag
+      '-x' inverts the x axis of the graph.
     args:
       - (height),(width)
       - (gradient colour 1)
@@ -1240,6 +1256,7 @@ values:
       - (scale)
       - (-t)
       - (-l)
+      - (-x)
   - name: meminactive
     desc: Amount of inactive memory. FreeBSD only.
   - name: memlaundry
@@ -1266,7 +1283,8 @@ values:
       and cache. Uses a logarithmic scale (to see small numbers) when you
       use the -l switch. Takes the switch '-t' to use a temperature
       gradient, which makes the gradient values change depending on the
-      amplitude of a particular graph value (try it and see).
+      amplitude of a particular graph value (try it and see). The flag
+      '-x' inverts the x axis of the graph.
     args:
       - (height),(width)
       - (gradient colour 1)
@@ -1274,6 +1292,7 @@ values:
       - (scale)
       - (-t)
       - (-l)
+      - (-x)
   - name: mixer
     desc: |-
       Prints the mixer value as reported by the OS. On Linux, this
@@ -1529,7 +1548,7 @@ values:
       used as 0,1,2,3,..
 
       For possible arguments see nvidia and nvidiabar. To learn more about the
-      -t -l and gradient color options, see execgraph.
+      -t -l -x and gradient color options, see execgraph.
     args:
       - argument
       - (height),(width)
@@ -1538,6 +1557,7 @@ values:
       - (scale)
       - (-t)
       - (-l)
+      - (-x)
       - GPU_ID
   - name: offset
     desc: Move text over by N pixels. See also $voffset.
@@ -2328,7 +2348,7 @@ values:
       numbers) when you use the -l switch. Takes the switch '-t' to
       use a temperature gradient, which makes the gradient values
       change depending on the amplitude of a particular graph value
-      (try it and see).
+      (try it and see). The flag '-x' inverts the x axis of the graph.
     args:
       - (netdev)
       - (height),(width)
@@ -2337,6 +2357,7 @@ values:
       - (scale)
       - (-t)
       - (-l)
+      - (-x)
   - name: uptime
     desc: Uptime.
   - name: uptime_short

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1009,15 +1009,17 @@ static inline void draw_graph_bars(special_node *current, std::unique_ptr<Colour
       set_foreground_color(tmpcolour[colour_idx++]);
     }
   }
+  /* Handle the case where y axis is to be inverted */
+  int offsety1 = current->inverty ? by : by + h;
+  int offsety2 = current->inverty ? by +  current->graph[j] * (h - 1) / current->scale
+                          : round_to_positive_int(static_cast<double>(by) + h -
+                          current->graph[j] * (h - 1) /
+                          current->scale);
   /* this is mugfugly, but it works */
   if (display_output()) {
     display_output()->draw_line(
-        text_offset.x() + cur_x + i + 1, text_offset.y() + by + h,
-        text_offset.x() + cur_x + i + 1,
-        text_offset.y() +
-            round_to_positive_int(static_cast<double>(by) + h -
-                                  current->graph[j] * (h - 1) /
-                                      current->scale));
+        text_offset.x() + cur_x + i + 1, text_offset.y() + offsety1,
+        text_offset.x() + cur_x + i + 1, text_offset.y() + offsety2);
   }
   ++j;
 }
@@ -1321,7 +1323,7 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
               }
               colour_idx = 0;
               if(current->invertx){
-                for (i = 0; i <= w- 2; i++) {
+                for (i = 0; i <= w - 2; i++) {
                   draw_graph_bars(current, tmpcolour, text_offset, 
                   i, j, w, colour_idx, cur_x, by, h);
                 }

--- a/src/specials.cc
+++ b/src/specials.cc
@@ -85,6 +85,7 @@ conky::simple_config_setting<std::string> console_graph_ticks(
 
 /* special flag for inverting axis */
 #define SF_INVERTX (1 << 0)
+#define SF_INVERTY (1 << 1)
 
 /*
  * Special data typedefs
@@ -250,6 +251,7 @@ std::pair<char *, size_t> scan_command(const char *s) {
  * -l will set the showlog flag, enabling logarithmic graph scales
  * -t will set the tempgrad member to true, enabling temperature gradient colors
  * -x will set the invertx flag to true, inverting the x axis
+ * -y will set the invertx flag to true, inverting the y axis
  *
  * @param[out] obj  struct in which to save width, height and other options
  * @param[in]  args argument string to parse
@@ -298,6 +300,12 @@ bool scan_graph(struct text_object *obj, const char *argstr, double defscale, ch
       strncmp(argstr, INVERTX, strlen(INVERTX)) == 0) {
     g->invertflag |= SF_INVERTX;
   }
+  /* set inverty to true if '-y' specified.
+   * It doesn't matter where the argument is exactly. */
+  if ((strstr(argstr, " " INVERTY) != nullptr) ||
+      strncmp(argstr, INVERTY, strlen(INVERTY)) == 0) {
+    g->invertflag |= SF_INVERTY;
+  }
 
   /* all the following functions try to interpret the beginning of a
    * a string with different format strings. If successful, they return from
@@ -322,9 +330,7 @@ bool scan_graph(struct text_object *obj, const char *argstr, double defscale, ch
    * therfore we ensure last_colour_name is not TEMPGRAD or LOGGRAPH */
   if (sscanf(argstr, "%d,%d %s %s", &g->height, &g->width, first_colour_name,
              last_colour_name) == 4 && 
-             strcmp(last_colour_name, TEMPGRAD) != 0 &&
-             strcmp(last_colour_name, LOGGRAPH) != 0 &&
-             strcmp(last_colour_name, INVERTX) != 0) {
+             strchr(last_colour_name,'-') == NULL) {
     apply_graph_colours(g, first_colour_name, last_colour_name);
     return true;
   }
@@ -365,9 +371,7 @@ bool scan_graph(struct text_object *obj, const char *argstr, double defscale, ch
    * This could match as [scale] [-l | -t], 
    * therfore we ensure last_colour_name is not TEMPGRAD or LOGGRAPH */
   if (sscanf(argstr, "%s %s", first_colour_name, last_colour_name) == 2 &&
-             strcmp(last_colour_name, TEMPGRAD) != 0 &&
-             strcmp(last_colour_name, LOGGRAPH) != 0 &&
-             strcmp(last_colour_name, INVERTX) != 0) { 
+             strchr(last_colour_name,'-') == NULL) { 
     apply_graph_colours(g, first_colour_name, last_colour_name);
     return true;
   }
@@ -646,6 +650,9 @@ void new_graph(struct text_object *obj, char *buf, int buf_max_size,
 #endif
   if ((g->invertflag & SF_INVERTX) != 0){
     s->invertx = 1;
+  }
+  if ((g->invertflag & SF_INVERTY) != 0){
+    s->inverty = 1;
   }
   if (g->speedgraph) {
     s->speedgraph = TRUE;

--- a/src/specials.h
+++ b/src/specials.h
@@ -39,6 +39,7 @@
 // don't use spaces in LOGGRAPH or NORMGRAPH if you change them
 #define LOGGRAPH "-l"
 #define TEMPGRAD "-t"
+#define INVERTX "-x"
 
 enum class text_node_t : uint32_t {
   NONSPECIAL = 0,
@@ -81,6 +82,7 @@ struct special_node {
   short font_added;
   char tempgrad;
   char speedgraph;
+  char invertx;
   struct special_node *next;
 };
 

--- a/src/specials.h
+++ b/src/specials.h
@@ -40,6 +40,7 @@
 #define LOGGRAPH "-l"
 #define TEMPGRAD "-t"
 #define INVERTX "-x"
+#define INVERTY "-y"
 
 enum class text_node_t : uint32_t {
   NONSPECIAL = 0,
@@ -83,6 +84,7 @@ struct special_node {
   char tempgrad;
   char speedgraph;
   char invertx;
+  char inverty;
   struct special_node *next;
 };
 


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [x] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

#### Before 
Only two directions were possible, which was from right to left and down to up for graph displaying.
<img width="397" alt="Screenshot 2024-07-23 at 8 35 12 PM" src="https://github.com/user-attachments/assets/41400c8a-90cb-4ad2-974d-eaaf26334def">

#### After 
The changes made now will allow for the following directions
1. Right to Left
2. Left to Right
3. Top to Down
4. Down to Top

To implement this, use the flags -x to invert along the x axis and -y to invert along the y axis.
#### Example
```downspeedgraph en0 50,280 ADFF2F 32CD32 -t -x -y```
```upspeedgraph en0 50,280 ADFF2F 32CD32 -t -y```

<img width="397" alt="Screenshot 2024-07-24 at 12 22 44 AM" src="https://github.com/user-attachments/assets/2bdcc55e-af40-456a-a8f8-1d11181e8bab">

#### More Outputs
<img width="397" alt="Screenshot 2024-07-23 at 8 48 29 PM" src="https://github.com/user-attachments/assets/88b0d59e-bae9-454f-b3d7-ae4819d4d64f">
<img width="397" alt="Screenshot 2024-07-23 at 8 53 10 PM" src="https://github.com/user-attachments/assets/033236ba-5c26-4ebf-a0cd-2b493bd55817">
<img width="397" alt="Screenshot 2024-07-23 at 9 13 34 PM" src="https://github.com/user-attachments/assets/d7068a6e-51e9-4c18-aad0-9aa508e0d82c">

Fixes #890 

