### PR TITLE
Implemented graph value clamping

### DIFF
--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -99,6 +99,7 @@ values:
       - (-l)
       - (-x)
       - (-y)
+      - (-m value)
   - name: apcupsd_model
     desc: Prints the model of the UPS.
   - name: apcupsd_name
@@ -331,7 +332,8 @@ values:
       numbers) when you use the -l switch. Takes the switch '-t' to use a
       temperature gradient, which makes the gradient values change depending
       on the amplitude of a particular graph value (try it and see). The flag
-      '-x' inverts the x axis and '-y' inverts the y axis of the graph.
+      '-x' inverts the x axis and '-y' inverts the y axis of the graph. The flag
+      '-m' clamps values below the specified value to the value (excluding 0) */
     args:
       - (cpuN)
       - (height),(width)
@@ -342,6 +344,7 @@ values:
       - (-l)
       - (-x)
       - (-y)
+      - (-m value)
   - name: curl
     desc: |-
       Download data from URI using Curl at the specified interval.
@@ -395,7 +398,8 @@ values:
       '-t' to use a temperature gradient, which makes the gradient values
       change depending on the amplitude of a particular graph value (try it
       and see). The flag '-x' inverts the x axis and '-y' inverts the y axis 
-      of the graph.
+      of the graph. The flag '-m' clamps values below the specified value 
+      to the value (excluding 0).
     args:
       - (device)
       - (height),(width)
@@ -406,6 +410,7 @@ values:
       - (-l)
       - (-x)
       - (-y)
+      - (-m value)
   - name: diskiograph_read
     desc: |-
       Disk IO graph for reads, colours defined in hex, minus the
@@ -414,7 +419,8 @@ values:
       use -l switch. Takes the switch '-t' to use a temperature gradient,
       which makes the gradient values change depending on the amplitude of a
       particular graph value (try it and see). The flag '-x' inverts the x 
-      axis and '-y' inverts the y axis of the graph.
+      axis and '-y' inverts the y axis of the graph. The flag '-m' clamps 
+      values below the specified value to the value (excluding 0).
     args:
       - (device)
       - (height),(width)
@@ -425,6 +431,7 @@ values:
       - (-l)
       - (-x)
       - (-y)
+      - (-m value)
   - name: diskiograph_write
     desc: |-
       Disk IO graph for writes, colours defined in hex, minus the
@@ -433,7 +440,8 @@ values:
       use -l switch. Takes the switch '-t' to use a temperature gradient,
       which makes the gradient values change depending on the amplitude of a
       particular graph value (try it and see). The flag '-x' inverts the x 
-      axis and '-y' inverts the y axis of the graph.
+      axis and '-y' inverts the y axis of the graph. The flag '-m' clamps 
+      values below the specified value to the value (excluding 0).
     args:
       - (device)
       - (height),(width)
@@ -444,6 +452,7 @@ values:
       - (-l)
       - (-x)
       - (-y)
+      - (-m value)
   - name: distribution
     desc: |-
       The name of the distribution. It could be that some of the
@@ -471,7 +480,8 @@ values:
       -l switch. Takes the switch '-t' to use a temperature gradient, which makes
       the gradient values change depending on the amplitude of a particular
       graph value (try it and see). The flag '-x' inverts the x axis and '-y' 
-      inverts the y axis of the graph.
+      inverts the y axis of the graph. The flag '-m' clamps values below the 
+      specified value to the value (excluding 0).
     args:
       - (netdev)
       - (height),(width)
@@ -482,6 +492,7 @@ values:
       - (-l)
       - (-x)
       - (-y)
+      - (-m)
   - name: draft_mails
     desc: |-
       Number of mails marked as draft in the specified mailbox or
@@ -553,7 +564,8 @@ values:
       -l switch to enable a logarithmic scale, which helps to see small values.
       The default size for graphs can be controlled via the default_graph_height
       and default_graph_width config settings. The flag '-x' inverts the x axis 
-      and '-y' inverts the y axis of the graph.
+      and '-y' inverts the y axis of the graph. The flag '-m' clamps values below 
+      the specified value to the value (excluding 0).
 
       If you need to execute a command with spaces, you have a
       couple options:
@@ -582,6 +594,7 @@ values:
       - (-l)
       - (-x)
       - (-y)
+      - (-m value)
   - name: execi
     desc: |-
       Same as exec, but with a specific interval in seconds. The
@@ -615,6 +628,7 @@ values:
       - (-l)
       - (-x)
       - (-y)
+      - (-m value)
   - name: execp
     desc: |-
       Executes a shell command and displays the output in conky.
@@ -1135,6 +1149,8 @@ values:
       gradient, which makes the gradient values change depending on the
       amplitude of a particular graph value (try it and see). The flag
       '-x' inverts the x axis and '-y' inverts the y axis of the graph.
+      The flag '-m' clamps values below the specified value to the value 
+      (excluding 0).
     args:
       - (height),(width)
       - (gradient colour 1)
@@ -1144,6 +1160,7 @@ values:
       - (-l)
       - (-x)
       - (-y)
+      - (-m value)
   - name: lowercase
     desc: Converts all letters into lowercase.
     args:
@@ -1190,7 +1207,8 @@ values:
       (try it and see). Conky puts 'conky_' in front of function_name to
       prevent accidental calls to the wrong function unless you put you
       place 'conky_' in front of it yourself.  The flag '-x' inverts the 
-      x axis and '-y' inverts the y axis of the graph. 
+      x axis and '-y' inverts the y axis of the graph. The flag '-m' clamps 
+      values below the specified value to the value (excluding 0).
     args:
       - function_name
       - (height),(width)
@@ -1201,6 +1219,7 @@ values:
       - (-l)
       - (-x)
       - (-y)
+      - (-m value)
   - name: lua_parse
     desc: |-
       Executes a Lua function with given parameters as per $lua,
@@ -1261,7 +1280,8 @@ values:
       numbers) when you use the -l switch. Takes the switch '-t' to use a
       temperature gradient, which makes the gradient values change depending
       on the amplitude of a particular graph value (try it and see). The flag
-      '-x' inverts the x axis and '-y' inverts the y axis of the graph.
+      '-x' inverts the x axis and '-y' inverts the y axis of the graph. The 
+      flag '-m' clamps values below the specified value to the value (excluding 0).
     args:
       - (height),(width)
       - (gradient colour 1)
@@ -1271,6 +1291,7 @@ values:
       - (-l)
       - (-x)
       - (-y)
+      - (-m value)
   - name: meminactive
     desc: Amount of inactive memory. FreeBSD only.
   - name: memlaundry
@@ -1299,6 +1320,8 @@ values:
       gradient, which makes the gradient values change depending on the
       amplitude of a particular graph value (try it and see). The flag
       '-x' inverts the x axis and '-y' inverts the y axis of the graph.
+      The flag '-m' clamps values below the specified value to the value 
+      (excluding 0).
     args:
       - (height),(width)
       - (gradient colour 1)
@@ -1308,6 +1331,7 @@ values:
       - (-l)
       - (-x)
       - (-y)
+      - (-m value)
   - name: mixer
     desc: |-
       Prints the mixer value as reported by the OS. On Linux, this
@@ -1574,6 +1598,7 @@ values:
       - (-l)
       - (-x)
       - (-y)
+      - (-m)
       - GPU_ID
   - name: offset
     desc: Move text over by N pixels. See also $voffset.
@@ -2365,7 +2390,8 @@ values:
       use a temperature gradient, which makes the gradient values
       change depending on the amplitude of a particular graph value
       (try it and see). The flag '-x' inverts the x axis and '-y' 
-      inverts the y axis of the graph.
+      inverts the y axis of the graph. The flag '-m' clamps values
+      below the specified value to the value (excluding 0).
     args:
       - (netdev)
       - (height),(width)
@@ -2376,6 +2402,7 @@ values:
       - (-l)
       - (-x)
       - (-y)
+      - (-m)
   - name: uptime
     desc: Uptime.
   - name: uptime_short

--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -333,7 +333,8 @@ values:
       temperature gradient, which makes the gradient values change depending
       on the amplitude of a particular graph value (try it and see). The flag
       '-x' inverts the x axis and '-y' inverts the y axis of the graph. The flag
-      '-m' clamps values below the specified value to the value (excluding 0) */
+      '-m' sets a nonzero minimum/lowerbound, ensuring that all values are at 
+      least the specified minimum (excluding zero).
     args:
       - (cpuN)
       - (height),(width)
@@ -398,8 +399,8 @@ values:
       '-t' to use a temperature gradient, which makes the gradient values
       change depending on the amplitude of a particular graph value (try it
       and see). The flag '-x' inverts the x axis and '-y' inverts the y axis 
-      of the graph. The flag '-m' clamps values below the specified value 
-      to the value (excluding 0).
+      of the graph. The flag '-m' sets a nonzero minimum/lowerbound, ensuring 
+      that all values are at least the specified minimum (excluding zero).
     args:
       - (device)
       - (height),(width)
@@ -419,8 +420,9 @@ values:
       use -l switch. Takes the switch '-t' to use a temperature gradient,
       which makes the gradient values change depending on the amplitude of a
       particular graph value (try it and see). The flag '-x' inverts the x 
-      axis and '-y' inverts the y axis of the graph. The flag '-m' clamps 
-      values below the specified value to the value (excluding 0).
+      axis and '-y' inverts the y axis of the graph. The flag '-m' sets a nonzero 
+      minimum/lowerbound, ensuring that all values are at least the specified 
+      minimum (excluding zero).
     args:
       - (device)
       - (height),(width)
@@ -440,8 +442,9 @@ values:
       use -l switch. Takes the switch '-t' to use a temperature gradient,
       which makes the gradient values change depending on the amplitude of a
       particular graph value (try it and see). The flag '-x' inverts the x 
-      axis and '-y' inverts the y axis of the graph. The flag '-m' clamps 
-      values below the specified value to the value (excluding 0).
+      axis and '-y' inverts the y axis of the graph. The flag '-m' sets a 
+      nonzero minimum/lowerbound, ensuring that all values are at 
+      least the specified minimum (excluding zero).
     args:
       - (device)
       - (height),(width)
@@ -480,8 +483,9 @@ values:
       -l switch. Takes the switch '-t' to use a temperature gradient, which makes
       the gradient values change depending on the amplitude of a particular
       graph value (try it and see). The flag '-x' inverts the x axis and '-y' 
-      inverts the y axis of the graph. The flag '-m' clamps values below the 
-      specified value to the value (excluding 0).
+      inverts the y axis of the graph. The flag '-m' sets a nonzero 
+      minimum/lowerbound, ensuring that all values are at least the specified 
+      minimum (excluding zero).
     args:
       - (netdev)
       - (height),(width)
@@ -564,8 +568,9 @@ values:
       -l switch to enable a logarithmic scale, which helps to see small values.
       The default size for graphs can be controlled via the default_graph_height
       and default_graph_width config settings. The flag '-x' inverts the x axis 
-      and '-y' inverts the y axis of the graph. The flag '-m' clamps values below 
-      the specified value to the value (excluding 0).
+      and '-y' inverts the y axis of the graph. The flag '-m' sets a nonzero 
+      minimum/lowerbound, ensuring that all values are at least the specified 
+      minimum (excluding zero).
 
       If you need to execute a command with spaces, you have a
       couple options:
@@ -1149,8 +1154,8 @@ values:
       gradient, which makes the gradient values change depending on the
       amplitude of a particular graph value (try it and see). The flag
       '-x' inverts the x axis and '-y' inverts the y axis of the graph.
-      The flag '-m' clamps values below the specified value to the value 
-      (excluding 0).
+      The flag '-m' sets a nonzero minimum/lowerbound, ensuring that all 
+      values are at least the specified minimum (excluding zero).
     args:
       - (height),(width)
       - (gradient colour 1)
@@ -1207,8 +1212,9 @@ values:
       (try it and see). Conky puts 'conky_' in front of function_name to
       prevent accidental calls to the wrong function unless you put you
       place 'conky_' in front of it yourself.  The flag '-x' inverts the 
-      x axis and '-y' inverts the y axis of the graph. The flag '-m' clamps 
-      values below the specified value to the value (excluding 0).
+      x axis and '-y' inverts the y axis of the graph. The flag '-m' sets 
+      a nonzero minimum/lowerbound, ensuring that all values are at least 
+      the specified minimum (excluding zero).
     args:
       - function_name
       - (height),(width)
@@ -1280,8 +1286,9 @@ values:
       numbers) when you use the -l switch. Takes the switch '-t' to use a
       temperature gradient, which makes the gradient values change depending
       on the amplitude of a particular graph value (try it and see). The flag
-      '-x' inverts the x axis and '-y' inverts the y axis of the graph. The 
-      flag '-m' clamps values below the specified value to the value (excluding 0).
+      '-x' inverts the x axis and '-y' inverts the y axis of the graph. The flag 
+      '-m' sets a nonzero minimum/lowerbound, ensuring that all values are at 
+      least the specified minimum (excluding zero).
     args:
       - (height),(width)
       - (gradient colour 1)
@@ -1320,8 +1327,8 @@ values:
       gradient, which makes the gradient values change depending on the
       amplitude of a particular graph value (try it and see). The flag
       '-x' inverts the x axis and '-y' inverts the y axis of the graph.
-      The flag '-m' clamps values below the specified value to the value 
-      (excluding 0).
+      The flag '-m' sets a nonzero minimum/lowerbound, ensuring that all 
+      values are at least the specified minimum (excluding zero).
     args:
       - (height),(width)
       - (gradient colour 1)

--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -2397,8 +2397,9 @@ values:
       use a temperature gradient, which makes the gradient values
       change depending on the amplitude of a particular graph value
       (try it and see). The flag '-x' inverts the x axis and '-y' 
-      inverts the y axis of the graph. The flag '-m' clamps values
-      below the specified value to the value (excluding 0).
+      inverts the y axis of the graph. The flag '-m' sets a nonzero 
+      minimum/lowerbound, ensuring that all values are at least the 
+      specified minimum (excluding zero).
     args:
       - (netdev)
       - (height),(width)

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -998,6 +998,11 @@ static inline void set_foreground_color(Colour c) {
 static inline void draw_graph_bars(special_node *current, std::unique_ptr<Colour[]>& tmpcolour, 
                             conky::vec2i& text_offset, int i, int &j, int w, 
                             int colour_idx, int cur_x, int by, int h) {
+  double graphheight = current->graph[j] * (h - 1) / current->scale;
+  /* Check if graphheight is less than the minheight threshold, if so we must change it to the threshold */
+  if(graphheight > 0 && current->minheight - graphheight > 0) {
+    current->graph[j] = current->minheight * current->scale / (h - 1);
+  }
   if (current->colours_set) {
     if (current->tempgrad != 0) {
       set_foreground_color(tmpcolour[static_cast<int>(

--- a/src/specials.cc
+++ b/src/specials.cc
@@ -113,6 +113,7 @@ struct graph {
   char tempgrad;
   char speedgraph;  /* If the current graph is a speed graph */
   char invertflag;  /* If the axis needs to be inverted */
+  int minheight;    /* Clamp values below this threshold to this threshold */
 };
 
 struct stippled_hr {
@@ -246,12 +247,13 @@ std::pair<char *, size_t> scan_command(const char *s) {
 }
 
 /**
- * parses for [height,width] [color1 color2] [scale] [-t] [-l]
+ * parses for [height,width] [color1 color2] [scale] [-t] [-l] [-m value]
  *
  * -l will set the showlog flag, enabling logarithmic graph scales
  * -t will set the tempgrad member to true, enabling temperature gradient colors
  * -x will set the invertx flag to true, inverting the x axis
  * -y will set the invertx flag to true, inverting the y axis
+ * -m will set the minheight to value, this will clamp values below the threshold to the threshold
  *
  * @param[out] obj  struct in which to save width, height and other options
  * @param[in]  args argument string to parse
@@ -277,6 +279,7 @@ bool scan_graph(struct text_object *obj, const char *argstr, double defscale, ch
   g->scale = defscale;
   g->tempgrad = FALSE;
   g->invertflag = FALSE;
+  g->minheight = 0;
   if (speedGraph) {
     g->speedgraph = TRUE;
   }
@@ -305,6 +308,34 @@ bool scan_graph(struct text_object *obj, const char *argstr, double defscale, ch
   if ((strstr(argstr, " " INVERTY) != nullptr) ||
       strncmp(argstr, INVERTY, strlen(INVERTY)) == 0) {
     g->invertflag |= SF_INVERTY;
+  }
+
+  /* set MINHEIGHT to specified value if '-m' specified.
+   * It doesn't matter where the argument is exactly. 
+   * Accepted values are from [0-5] */
+  const char *position = strstr(argstr, " " MINHEIGHT);
+  if ((position != nullptr) ||
+      strncmp(argstr, MINHEIGHT, strlen(MINHEIGHT)) == 0) {
+      int minheight = 0;
+      position += strlen(MINHEIGHT) + 1;
+      int size = strlen(argstr);
+      // Avoid whitespaces
+      while(*position == ' ' && position < argstr + size) {
+        position++;
+      }
+      // Get the numeric value start and end position
+      const char* numStart = position;
+      while (isdigit(*position)) {
+          position++;
+      }
+      // Convert the numeric value to an integer
+      std::string numStr(numStart, position);
+      if (!numStr.empty()) {
+          minheight = atoi(numStr.c_str());
+      }
+      // If specified value is greater than the max threshold
+      minheight = minheight > 5 ? 5 : minheight;
+      g->minheight = minheight;
   }
 
   /* all the following functions try to interpret the beginning of a
@@ -642,6 +673,7 @@ void new_graph(struct text_object *obj, char *buf, int buf_max_size,
     s->show_scale = 1;
   }
   s->tempgrad = g->tempgrad;
+  s->minheight = g->minheight;
 #ifdef BUILD_MATH
   if ((g->flags & SF_SHOWLOG) != 0) {
     s->scale_log = 1;

--- a/src/specials.h
+++ b/src/specials.h
@@ -41,6 +41,7 @@
 #define TEMPGRAD "-t"
 #define INVERTX "-x"
 #define INVERTY "-y"
+#define MINHEIGHT "-m"
 
 enum class text_node_t : uint32_t {
   NONSPECIAL = 0,
@@ -85,6 +86,7 @@ struct special_node {
   char speedgraph;
   char invertx;
   char inverty;
+  int minheight;
   struct special_node *next;
 };
 


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [x] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

### Before
Values that fall below the threshold of visibility in a given graph are not seen, leading to small values being omitted.

### After 
A new flag, '-m value', has been implemented, allowing the user to specify the threshold value between 0 and 5. This will enable values below the threshold to be displayed.

```downspeedgraph en0 50,280 ADFF2F 32CD32 -t -x -m 5```
<img width="401" alt="Screenshot 2024-07-27 at 1 03 35 AM" src="https://github.com/user-attachments/assets/72468cca-c485-4a8e-b478-3ce511a2ffaf">

Fixes #1060 

