### PR TITLE
Fixed Down and Up Speed graph scaling

### DIFF
--- a/src/specials.cc
+++ b/src/specials.cc
@@ -519,11 +519,21 @@ static void graph_append(struct special_node *graph, double f, char showaslog) {
   graph->graph[0] = f; /* add new data */
 
   if (graph->scaled != 0) {
-    graph->scale =
-        *std::max_element(graph->graph + 0, graph->graph + graph->graph_width);
+    /* Get the location of the currentmax in the graph */
+    double* currentmax =
+        std::max_element(graph->graph + 0, graph->graph + graph->graph_width);
+    graph->scale = *currentmax;
     if (graph->speedgraph) {
-        maxspeedval = graph->scale < maxspeedval ? maxspeedval : graph->scale;
+        if(maxspeedval < graph->scale){
+          maxspeedval = graph->scale;
+        }
         graph->scale = maxspeedval;
+        /* If the currentmax is the maxspeedval and 
+         * currentmax location is at the last position
+         * Then we reset our maxspeedval */
+        if(*currentmax == maxspeedval && currentmax == (graph->graph + graph->width - 1)){
+          maxspeedval = 1e-47;
+        }
     }
     if (graph->scale < 1e-47) {
       /* avoid NaN's when the graph is all-zero (e.g. before the first update)


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [x] Documentation in `doc/` has been updated

## Description
I have updated the scaling mechanism to dynamically adjust the maximum value based on the data points currently displayed in the graphs. This ensures that spikes in usage will roll off the graph as time progresses, providing a more accurate and consistent representation of the current data range.

Fixes #2001 
