### PR TITLE
Stop trying to access filesystems that are no longer in dynamically generated conky text

### DIFF
--- a/src/fs.cc
+++ b/src/fs.cc
@@ -79,7 +79,7 @@ int update_fs_stats() {
   if (current_update_time - last_fs_update < 13) { return 0; }
 
   for (i = 0; i < MAX_FS_STATS; ++i) {
-    if (fs_stats[i].set != 0) { update_fs_stat(&fs_stats[i]); }
+    fs_stats[i].set = 0;
   }
   last_fs_update = current_update_time;
   return 0;


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [ ] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

Dynamically updated conky texts that use "fs" variables can leave their entries in fs_stats after they have been removed from the text dynamically.

Instead of having update_fs_stats() call update_fs_stat() for all entries that have the "set" flag, just clear the "set" flag.
This will "remove" the current fs_stats entries (including in particular, filesystems that no longer appear in the conky text).

On the next update cycle, prepare_fs_stat() will call update_fs_stat() for anything that requires it, and will retain the logic that prevents it from updating the same fs multiple times.

Note: Depending on how well update frequencies line up, it is still possible to get stat errors but they won't continue forever.

- fixes #208 hopefully properly
- also fixes the niche but possible issue of exhausting the total fs_stats entries if someone adds and removes many "fs" targets over time (eg. a long running system that has many USB drives plugged and unplugged)
- as far as I can tell this does not increase the frequency of attempted stat calls, and should have very minimal effect on overall load