### PR TITLE
set display to null for race condition

### DIFF
--- a/src/x11.cc
+++ b/src/x11.cc
@@ -33,6 +33,9 @@
 #include "x11.h"
 
 #include <X11/X.h>
+#include <X11/Xlibint.h>
+#undef min
+#undef max
 #include <sys/types.h>
 
 #include "common.h"
@@ -314,6 +317,8 @@ void update_x11_resource_db(bool first_run) {
       XrmDestroyDatabase(db);
     }
 
+    // https://github.com/dunst-project/dunst/blob/master/src/x11/x.c#L499
+    display->db = NULL; // should be new or deleted
     db = XrmGetStringDatabase((const char *)prop.value);
     XrmSetDatabase(display, db);
   }


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [ ] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

Per #1939 there is some kind of race condition when starting X11 after conky 1.21 where it will not show up on desktop or in `ps aux`.

https://github.com/dunst-project/dunst/blob/master/src/x11/x.c#L499 looks to be the source of some code which now sets display to NULL for some type of race condition in X11. Xlibint.h allows for building on Void Linux but needs min/max undefined. closes #1939

Without Xlibint.h it errors out, though Caellian didn't need it to build I think.

```
/usr/bin/g++ -D_LARGEFILE64_SOURCE -D_POSIX_C_SOURCE=200809L -I/builddir/conky-1.21.4/3rdparty/toluapp/include -I/builddir/conky-1.21.4/build -I/usr/include/freetype2 -I/usr/include/lua5.3 -I/usr/include/libxml2 -I/builddir/conky-1.21.4/3rdparty/Vc -I/builddir/conky-1.21.4/build/src -I/builddir/conky-1.21.4/build/data -DNDEBUG -fstack-clash-protection -D_FORTIFY_SOURCE=2 -mtune=generic -O2    -ffile-prefix-map=/builddir/conky-1.21.4/build=. -std=c++17 -Werror -MD -MT src/CMakeFiles/conky_core.dir/x11.cc.o -MF src/CMakeFiles/conky_core.dir/x11.cc.o.d -o src/CMakeFiles/conky_core.dir/x11.cc.o -c /builddir/conky-1.21.4/src/x11.cc
/builddir/conky-1.21.4/src/x11.cc: In function 'void update_x11_resource_db(bool)':
/builddir/conky-1.21.4/src/x11.cc:317:12: error: invalid use of incomplete type 'Display'
  317 |     display->db = NULL; // should be new or deleted
      |            ^~
In file included from /builddir/conky-1.21.4/src/x11.h:37,
                 from /builddir/conky-1.21.4/src/x11.cc:33:
/usr/include/X11/Xlib.h:251:8: note: forward declaration of 'Display'
  251 | struct _XDisplay;               /* Forward declare before use for C++ */
      |        ^~~~~~~~~
```
