### PR TITLE
src/fs.{cc,h}: Update fs_stats without error spam.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -179,6 +179,7 @@ K. Eugene Carlson <kvngncrlsn at gmail dot com>
   Additional Linux memory reporting variables
   Linux CPU frequency governor reporting
   Additional FreeBSD memory reporting variables
+  fs_stat patch
 
 Kapil Hari Paranjape <kapil@imsc.res.in>
   ibm_volume patch

--- a/src/fs.cc
+++ b/src/fs.cc
@@ -147,10 +147,10 @@ static void update_fs_stat(struct fs_stat *fs) {
     get_fs_type(fs->path, fs->type);
 #endif
   } else {
-  if (fs->errored == 0) {
-    NORM_ERR("statfs '%s': %s", fs->path, strerror(errno));
-    fs->errored = 1;
-  }
+    if (fs->errored == 0) {
+      NORM_ERR("statfs '%s': %s", fs->path, strerror(errno));
+      fs->errored = 1;
+    }
     fs->size = 0;
     fs->avail = 0;
     fs->free = 0;

--- a/src/fs.cc
+++ b/src/fs.cc
@@ -79,7 +79,7 @@ int update_fs_stats() {
   if (current_update_time - last_fs_update < 13) { return 0; }
 
   for (i = 0; i < MAX_FS_STATS; ++i) {
-    fs_stats[i].set = 0;
+    if (fs_stats[i].set != 0) { update_fs_stat(&fs_stats[i]); }
   }
   last_fs_update = current_update_time;
   return 0;
@@ -113,6 +113,7 @@ struct fs_stat *prepare_fs_stat(const char *s) {
   }
   strncpy(next->path, s, DEFAULT_TEXT_BUFFER_SIZE);
   next->set = 1;
+  next->errored = 0;
   update_fs_stat(next);
   return next;
 }
@@ -142,10 +143,14 @@ static void update_fs_stat(struct fs_stat *fs) {
     /* bfree (root) or bavail (non-roots) ? */
     fs->avail = static_cast<long long>(s.f_bavail) * s.f_bsize;
     fs->free = static_cast<long long>(s.f_bfree) * s.f_bsize;
+    fs->errored = 0;
     get_fs_type(fs->path, fs->type);
 #endif
   } else {
+  if (fs->errored == 0) {
     NORM_ERR("statfs '%s': %s", fs->path, strerror(errno));
+    fs->errored = 1;
+  }
     fs->size = 0;
     fs->avail = 0;
     fs->free = 0;

--- a/src/fs.h
+++ b/src/fs.h
@@ -40,6 +40,7 @@ struct fs_stat {
   long long avail;
   long long free;
   char set;
+  char errored;
 };
 
 /* forward declare to make gcc happy (fs.h <-> text_object.h include) */


### PR DESCRIPTION
# Checklist
◯　I have described the changes
◯　I have linked to any relevant GitHub issues, if applicable
Documentation in `doc/` has been updated (N/A)
◯　All new code is licensed under GPLv3

## Description

* Describe the changes, why they were necessary, etc
RE 788ac88, #208

`update_fs_stats` was recently altered to clear `set` for all file systems every thirteen seconds, and its `update_fs_stat` call was removed. This was done to mitigate a longstanding issue whereby repeated errors appeared when updates were attempted for a nonexistent mountpoint. However, before the change, `update_fs_stat` was only called from `prepare_fs_stat` and `update_fs_stats`. In consequence, `update_fs_stat` is now called for each filesystem only at init time, and no changes are displayed. 

Updating capabilities can be restored by reverting the change to `update_fs_stats`. In addition, repeated error messages can be suppressed in the following manner:

1. Add a flag called `errored` and initialize to zero.
2. If a mountpoint is not found, write an error only if `errored` is zero; once this has been done, set `errored`.
3. Once the mountpoint has been found again, clear `errored` so that a new message can appear.

* Describe how the changes will affect existing behaviour.

Filesystem information will be updated periodically as before. Nonexistent mountpoints now produce errors only once at init, and once more if an existing mountpoint is removed. That is, errors will no longer be produced at every update.

* Describe how you tested and validated your changes.

I ran patched `conky` from a terminal to monitor standard error using a config file that included a spurious mountpoint. I periodically made and deleted that directory, verifying that error messages appeared only once upon deletion. This worked both with and without `if_mounted`. Live updates to `fs_used` and `fs_free` occurred as expected.