### PR TITLE
audacious.cc: print_audacious_filename(): fix always empty $audacious_filename

### DIFF
--- a/src/audacious.cc
+++ b/src/audacious.cc
@@ -206,7 +206,7 @@ void print_audacious_title(struct text_object *obj, char *p,
 
 void print_audacious_filename(struct text_object *obj, char *p,
                               unsigned int p_max_size) {
-  snprintf(p, std::min((unsigned int)obj->data.i, p_max_size), "%s",
+  snprintf(p, p_max_size, "%s",
            get_res().filename.c_str());
 }
 


### PR DESCRIPTION
`print_audacious_filename()` always returns an empty (zero-length) `$audacious_filename`, due to one of the `std::min()` operands always being 0. Removing the `std::min()` construct fixes the problem. Fixes #1175.

# Checklist
- [ :heavy_check_mark: ] I have described the changes
- [ :heavy_check_mark: ] I have linked to any relevant GitHub issues, if applicable
- [ :x: ] Documentation in `doc/` has been updated (N/A, I think :man_shrugging:)
- [ :heavy_check_mark: ] All new code is licensed under GPLv3

## Description
In `print_audacious_filename()`, `obj->data.i` is _always_ `0` on my system (can't test anywhere else, I'm afraid), so `std::min((unsigned int)obj->data.i, p_max_size)` _also_ evaluates to `0`, resulting in a zero-length (ie. empty) string being returned for `$audacious_filename`, even though the correct, full filename is being received over `DBus`. Removing the `std::min()` construct fixes the problem, resulting in the correct value being assigned to `$audacious_filename`.

I first encountered this bug with `conky-1.12.2`, `audaciuos-4.1`, `libaudclient-3.5-rc2`, `gcc-/g++-9.2.0` on 32bit `Slackware-14.2` more then 2 years ago, and it's still present today with `conky-1.21.7`, `audacious-4.3`, `libaudclient-3.5-rc2`, `gcc-/g++-11.2.0` on 64bit `Slackware-15.0`, so I doubt it's some sort of one-time "freak accident". :slightly_smiling_face: 