### PR TITLE
Implement `-U`.

### DIFF
--- a/doc/man.md.j2
+++ b/doc/man.md.j2
@@ -162,7 +162,8 @@ file.
 
 **-U \| \--unique**
 
-:   Conky won't start if another Conky process is already running.
+:   Conky won't start if another Conky process is already running. Implemented
+    only for Linux.
 
 **-v \| -V \| \--version** 
 

--- a/doc/man.md.j2
+++ b/doc/man.md.j2
@@ -160,6 +160,10 @@ file.
 
 :   Update interval.
 
+**-U \| \--unique**
+
+:   Conky won't start if another Conky process is already running.
+
 **-v \| -V \| \--version** 
 
 :   Prints version, build information and general info. Exits after

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -2106,7 +2106,10 @@ void set_current_config() {
 
 /* : means that character before that takes an argument */
 const char *getopt_string =
-    "vVqdDSs:t:u:i:hc:p:U"
+    "vVqdDSs:t:u:i:hc:p:"
+#if defined(__linux__)
+    "U"
+#endif
 #ifdef BUILD_X11
     "x:y:w:a:X:m:f:"
 #ifdef OWN_WINDOW
@@ -2136,8 +2139,12 @@ const struct option longopts[] = {
     {"double-buffer", 0, nullptr, 'b'}, {"window-id", 1, nullptr, 'w'},
 #endif /* BUILD_X11 */
     {"text", 1, nullptr, 't'},          {"interval", 1, nullptr, 'u'},
-    {"pause", 1, nullptr, 'p'},         {"unique", 0, nullptr, 'U'},
-    {nullptr, 0, nullptr, 0}};
+    {"pause", 1, nullptr, 'p'},
+#if defined(__linux__)
+    {"unique", 0, nullptr, 'U'},
+#endif /* Linux */
+    {nullptr, 0, nullptr, 0}
+};
 
 void setup_inotify() {
 #ifdef HAVE_SYS_INOTIFY_H

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -2106,7 +2106,7 @@ void set_current_config() {
 
 /* : means that character before that takes an argument */
 const char *getopt_string =
-    "vVqdDSs:t:u:i:hc:p:"
+    "vVqdDSs:t:u:i:hc:p:U"
 #ifdef BUILD_X11
     "x:y:w:a:X:m:f:"
 #ifdef OWN_WINDOW
@@ -2136,7 +2136,8 @@ const struct option longopts[] = {
     {"double-buffer", 0, nullptr, 'b'}, {"window-id", 1, nullptr, 'w'},
 #endif /* BUILD_X11 */
     {"text", 1, nullptr, 't'},          {"interval", 1, nullptr, 'u'},
-    {"pause", 1, nullptr, 'p'},         {nullptr, 0, nullptr, 0}};
+    {"pause", 1, nullptr, 'p'},         {"unique", 0, nullptr, 'U'},
+    {nullptr, 0, nullptr, 0}};
 
 void setup_inotify() {
 #ifdef HAVE_SYS_INOTIFY_H

--- a/src/linux.h
+++ b/src/linux.h
@@ -58,6 +58,8 @@ int update_stat(void);
 
 void print_distribution(struct text_object *, char *, unsigned int);
 
+bool is_conky_already_running(void);
+
 extern char e_iface[64];
 extern char interfaces_arr[MAX_NET_INTERFACES][64];
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -284,7 +284,7 @@ static bool is_conky_already_running() {
   }
 
   while (fgets(line, sizeof(line), fp)) {
-    if (!strncmp(line, "conky", 5)) {
+    if (!strncmp(line, "conky\n", 6)) {
       instances++;
     }
   }

--- a/src/main.cc
+++ b/src/main.cc
@@ -36,8 +36,6 @@
 #include "display-output.hh"
 #include "lua-config.hh"
 
-#include <dirent.h>
-
 #ifdef BUILD_X11
 #include "x11.h"
 #endif /* BUILD_X11 */
@@ -45,6 +43,10 @@
 #ifdef BUILD_CURL
 #include "ccurl_thread.h"
 #endif /* BUILD_CURL */
+
+#if defined(__linux__)
+#include "linux.h"
+#endif /* Linux */
 
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
 #include "freebsd.h"
@@ -271,49 +273,11 @@ static void print_help(const char *prog_name) {
          " (and quit)\n"
          "   -p, --pause=SECS          pause for SECS seconds at startup "
          "before doing anything\n"
-         "   -U, --unique              only one conky process can be created\n",
-         prog_name);
-}
-
 #if defined(__linux__)
-// NOTE: Only works on systems where there is a /proc/[pid]/stat file.
-static bool is_conky_already_running() {
-  DIR *dir;
-  struct dirent *ent;
-  char buf[512];
-  int instances = 0;
-
-  if (!(dir = opendir("/proc"))) {
-    NORM_ERR("can't open /proc: %s\n", strerror(errno));
-    return false;
-  }
-
-  while ((ent = readdir(dir)) != NULL) {
-    char *endptr = ent->d_name;
-    long lpid = strtol(ent->d_name, &endptr, 10);
-    if (*endptr != '\0') {
-      continue;
-    }
-
-    snprintf(buf, sizeof(buf), "/proc/%ld/stat", lpid);
-    FILE *fp = fopen(buf, "r");
-    if (!fp) {
-      continue;
-    }
-
-    if (fgets(buf, sizeof(buf), fp) != NULL) {
-      char *conky = strstr(buf, "(conky)");
-      if (conky) {
-        instances++;
-      }
-    }
-    fclose(fp);
-  }
-
-  closedir(dir);
-  return instances > 1;
-}
+         "   -U, --unique              only one conky process can be created\n"
 #endif /* Linux */
+         , prog_name);
+}
 
 inline void reset_optind() {
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || \

--- a/src/main.cc
+++ b/src/main.cc
@@ -275,6 +275,7 @@ static void print_help(const char *prog_name) {
          prog_name);
 }
 
+#if defined(__linux__)
 // NOTE: Only works on systems where there is a /proc/[pid]/stat file.
 static bool is_conky_already_running() {
   DIR *dir;
@@ -312,6 +313,7 @@ static bool is_conky_already_running() {
   closedir(dir);
   return instances > 1;
 }
+#endif /* Linux */
 
 inline void reset_optind() {
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || \
@@ -392,19 +394,22 @@ int main(int argc, char **argv) {
         window.window = strtol(optarg, nullptr, 0);
         break;
 #endif /* BUILD_X11 */
+#if defined(__linux__)
       case 'U':
         unique_process = true;
         break;
-
+#endif /* Linux */
       case '?':
         return EXIT_FAILURE;
     }
   }
 
+#if defined(__linux__)
   if (unique_process && is_conky_already_running()) {
     NORM_ERR("already running");
     return 0;
   }
+#endif /* Linux */
 
   try {
     set_current_config();


### PR DESCRIPTION
If this argument is provided Conky won't start if another Conky process is already running.

Conky starts multiple times on my system at startup, and it is bothering me. I'm too lazy to check all of my config files, so I added this mechanism to prevent this behavior.