### PR TITLE
fix: set initial state withdrawn wm hint (fixes #2046)

### DIFF
--- a/src/x11.cc
+++ b/src/x11.cc
@@ -640,7 +640,7 @@ void x11_init_window(lua::state &l, bool own) {
 #endif /* BUILD_XSHAPE */
       if (own_window_type.get(l) == window_type::DOCK ||
           own_window_type.get(l) == window_type::PANEL) {
-        // wmHint.initial_state = WithdrawnState;
+        wmHint.initial_state = WithdrawnState;
       } else {
         wmHint.initial_state = NormalState;
       }

--- a/src/x11.cc
+++ b/src/x11.cc
@@ -640,6 +640,8 @@ void x11_init_window(lua::state &l, bool own) {
 #endif /* BUILD_XSHAPE */
       if (own_window_type.get(l) == window_type::DOCK ||
           own_window_type.get(l) == window_type::PANEL) {
+        // Docks and panels MUST have WithdrawnState initially
+        // See: https://github.com/brndnmtthws/conky/issues/2046
         wmHint.initial_state = WithdrawnState;
       } else {
         wmHint.initial_state = NormalState;


### PR DESCRIPTION
# Checklist
- [X] I have described the changes
- [X] I have linked to any relevant GitHub issues, if applicable
- [X] All new code is licensed under GPLv3

## Description

This makes sure the initial state wmhit gets set to withdrawn. This is needed for Conky to run in a dock (aka slit in Fluxbox). I've used this for about a week now without issues in Openbox. Fixes #2046.
