### PR TITLE
Add automatic labeling for issues

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -164,12 +164,53 @@ lua:
           - src/lua-config.cc
           - src/lua-config.hh
 
-macos:
+'os: linux':
   - changed-files:
       - any-glob-to-any-file:
-          - src/darwin_sip.h
-          - src/darwin.h
-          - src/darwin.mm
+          - src/linux.cc
+          - src/linux.h
+
+'os: linux':
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/linux.cc
+          - src/linux.h
+
+'os: dragonfly':
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/dragonfly.cc
+          - src/dragonfly.h
+
+'os: freebsd':
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/freebsd.cc
+          - src/freebsd.h
+
+'os: netbsd':
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/netbsd.cc
+          - src/netbsd.h
+  
+'os: openbsd':
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/openbsd.cc
+          - src/openbsd.h
+
+'os: solaris':
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/solaris.cc
+          - src/solaris.h
+
+'os: haiku':
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/haiku.cc
+          - src/haiku.h
 
 'mouse events':
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,6 @@
 version: 1
+issues: True
+appendOnly: true
 
 labels:
   - label: 'documentation'
@@ -7,6 +9,9 @@ labels:
       - doc/*
       - doc/**/*
       - data/conky*.conf
+  - label: 'documentation'
+    type: 'issue'
+    title: "[Dd]ocument(ation)?"
 
   - label: 'extras'
     type: 'pull_request'
@@ -38,6 +43,10 @@ labels:
       - appimage/*
       - appimage/**/*
 
+  - label: 'appimage'
+    type: 'issue'
+    body: "(appimage|AppImage|Appimage)"
+  
   - label: '3rdparty'
     type: 'pull_request'
     files:
@@ -78,6 +87,10 @@ labels:
       - src/pulseaudio.cc
       - src/pulseaudio.h
 
+  - label: 'audio'
+    type: 'issue'
+    body: "([Aa]udacious|CMUS|cmus|MPD|mpd|[Mm]ixer|xmms2|XMMS2|[Pp]ulse[Aa]udio)"
+  
   - label: 'power'
     type: 'pull_request'
     files:
@@ -118,6 +131,10 @@ labels:
       - src/wlr-layer-shell-unstable-v1.xml
       - src/display-wayland.cc
       - src/display-wayland.hh
+  - label: 'display: wayland'
+    type: 'issue'
+    title: "[Ww]ayland"
+  
   - label: 'display: x11'
     type: 'pull_request'
     files:
@@ -127,6 +144,9 @@ labels:
       - src/x11.h
       - src/display-x11.cc
       - src/display-x11.hh
+  - label: 'display: x11'
+    type: 'issue'
+    title: "[Xx]11"
 
   - label: 'build system'
     type: 'pull_request'
@@ -138,6 +158,9 @@ labels:
     type: 'pull_request'
     files:
       - 'lua/*cairo*'
+  - label: 'cairo'
+    type: 'issue'
+    title: "([Cc]airo)" # can be in config
 
   - label: 'disk io'
     type: 'pull_request'
@@ -154,6 +177,9 @@ labels:
       - src/proc.h
       - src/top.cc
       - src/top.h
+  - label: 'cpu'
+    type: 'issue'
+    title: "(CPU|cpu)"
 
   - label: 'lua'
     type: 'pull_request'
@@ -166,42 +192,66 @@ labels:
       - src/luamm.h
       - src/lua-config.cc
       - src/lua-config.hh
+  - label: 'lua'
+    type: 'issue'
+    title: "[Ll](ua|UA)"
 
   - label: 'os: linux'
     type: 'pull_request'
     files:
       - src/linux.cc
       - src/linux.h
+  - label: 'os: linux'
+    type: 'issue'
+    title: "[Ll]inux"
   - label: 'os: dragonfly'
     type: 'pull_request'
     files:
       - src/dragonfly.cc
       - src/dragonfly.h
+  - label: 'os: dragonfly'
+    type: 'issue'
+    body: "[Dd]ragon[Ff]ly"
   - label: 'os: freebsd'
     type: 'pull_request'
     files:
       - src/freebsd.cc
       - src/freebsd.h
+  - label: 'os: dragonfly'
+    type: 'issue'
+    body: "[Ff]ree\\s?(BSD|bsd)"
   - label: 'os: netbsd'
     type: 'pull_request'
     files:
       - src/netbsd.cc
       - src/netbsd.h
+  - label: 'os: netbsd'
+    type: 'issue'
+    body: "[Nn]et\\s?(BSD|bsd)"
   - label: 'os: openbsd'
     type: 'pull_request'
     files:
       - src/openbsd.cc
       - src/openbsd.h
+  - label: 'os: openbsd'
+    type: 'issue'
+    body: "[Oo]pen\\s?(BSD|bsd)"
   - label: 'os: solaris'
     type: 'pull_request'
     files:
       - src/solaris.cc
       - src/solaris.h
+  - label: 'os: solaris'
+    type: 'issue'
+    body: "[Ss](olaris|OLARIS)"
   - label: 'os: haiku'
     type: 'pull_request'
     files:
       - src/haiku.cc
       - src/haiku.h
+  - label: 'os: haiku'
+    type: 'issue'
+    body: "[Hh](aiku|AIKU)"
 
   - label: 'mouse events'
     type: 'pull_request'
@@ -210,6 +260,9 @@ labels:
       - src/scroll.h
       - src/mouse-events.cc
       - src/mouse-events.h
+  - label: 'mouse events'
+    type: 'issue'
+    body: "(mouse|cursor|pointer) (events?|enters?|leaves?|clicks?|press(es)?))"
 
   - label: 'networking'
     type: 'pull_request'
@@ -220,12 +273,18 @@ labels:
       - src/tcp-portmon.h
       - src/read_tcpip.cc
       - src/read_tcpip.h
+  - label: 'networking'
+    type: 'issue'
+    body: "(network|IP address|download|upload)"
 
   - label: 'nvidia'
     type: 'pull_request'
     files:
       - src/nvidia.cc
       - src/nvidia.h
+  - label: 'nvidia'
+    type: 'issue'
+    body: "[Nn](vidia|VIDIA)"
 
   - label: 'rendering'
     type: 'pull_request'
@@ -246,3 +305,6 @@ labels:
       - src/tailhead.h
       - src/specials.cc
       - src/specials.h
+  - label: 'text'
+    type: 'issue'
+    body: "\\$\\w+ variable"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,103 +2,25 @@ version: 1
 appendOnly: true
 
 labels:
-  - label: 'documentation'
-    type: 'pull_request'
-    files:
-      - doc/*
-      - doc/**/*
-      - data/conky*.conf
-  - label: 'documentation'
+  - label: 'enhancement'
     type: 'issue'
-    title: "[Dd]ocument(ation)?"
-
-  - label: 'extras'
-    type: 'pull_request'
-    files:
-      - extras/*
-      - extras/**/*
-
-  - label: 'sources'
-    type: 'pull_request'
-    files:
-      - src/*
-      - src/**/*
-
-  - label: 'tests'
-    type: 'pull_request'
-    files:
-      - tests/**/*
-      - tests/*
-
-  - label: 'web'
-    type: 'pull_request'
-    files:
-      - web/*
-      - web/**/*
-
-  - label: 'appimage'
-    type: 'pull_request'
-    files:
-      - appimage/*
-      - appimage/**/*
-
-  - label: 'appimage'
+    body: "([Ee]nhance(d|ment)|[Ii]mprove(ment|d))"
+  - label: 'enhancement'
     type: 'issue'
-    body: "(appimage|AppImage|Appimage)"
-  
-  - label: '3rdparty'
-    type: 'pull_request'
-    files:
-      - 3rdparty/*
-      - 3rdparty/**/*
-
-  - label: 'gh-actions'
-    type: 'pull_request'
-    files:
-      - .github/workflows/*
-      - .github/workflows/**/*
-      - .github/labeler.yml
-      - .github/pull_request_template.md
-
-  - label: 'dependencies'
-    type: 'pull_request'
-    files:
-      - web/package-lock.json
-      - cmake/ConkyPlatformChecks.cmake
-
-  - label: 'audio'
-    type: 'pull_request'
-    files:
-      - src/audacious.cc
-      - src/audacious.h
-      - src/cmus.cc
-      - src/cmus.h
-      - src/libmpdclient.cc
-      - src/libmpdclient.h
-      - src/mpd.cc
-      - src/mpd.h
-      - src/moc.cc
-      - src/moc.h
-      - src/mixer.cc
-      - src/mixer.h
-      - src/xmms2.cc
-      - src/xmms2.h
-      - src/pulseaudio.cc
-      - src/pulseaudio.h
-
-  - label: 'audio'
+    title: "([Ee]nhance(d|ment)|[Ii]mprove(ment|d))"
+  - label: 'feature'
     type: 'issue'
-    body: "([Aa]udacious|CMUS|cmus|MPD|mpd|[Mm]ixer|xmms2|XMMS2|[Pp]ulse[Aa]udio)"
-  
-  - label: 'power'
-    type: 'pull_request'
-    files:
-      - src/apcupsd.cc
-      - src/apcupsd.h
-      - src/bsdapm.cc
-      - src/bsdapm.h
-      - src/smapi.cc
-      - src/smapi.h
+    title: "([Ff]eature|[Ss]uggestion)"
+  - label: 'packaging'
+    type: 'issue'
+    body: "([Pp]ackage|AUR)"
+  - label: 'question'
+    type: 'issue'
+    body: "([Ww](ondering|ant(ed)? to ask|ould like to (know|understand)))"
+
+  - label: 'priority: low'
+    type: 'issue'
+    body: "low priority"
 
   - label: 'display: console'
     type: 'pull_request'
@@ -146,54 +68,6 @@ labels:
   - label: 'display: x11'
     type: 'issue'
     title: "[Xx]11"
-
-  - label: 'build system'
-    type: 'pull_request'
-    files:
-      - '**/CMakeLists.txt'
-      - '*.cmake'
-
-  - label: 'cairo'
-    type: 'pull_request'
-    files:
-      - 'lua/*cairo*'
-  - label: 'cairo'
-    type: 'issue'
-    title: "([Cc]airo)" # can be in config
-
-  - label: 'disk io'
-    type: 'pull_request'
-    files:
-      - src/diskio.cc
-      - src/diskio.h
-
-  - label: 'cpu'
-    type: 'pull_request'
-    files:
-      - src/cpu.cc
-      - src/cpu.h
-      - src/proc.cc
-      - src/proc.h
-      - src/top.cc
-      - src/top.h
-  - label: 'cpu'
-    type: 'issue'
-    title: "(CPU|cpu)"
-
-  - label: 'lua'
-    type: 'pull_request'
-    files:
-      - lua/*
-      - lua/**/*
-      - src/llua.cc
-      - src/llua.h
-      - src/luamm.cc
-      - src/luamm.h
-      - src/lua-config.cc
-      - src/lua-config.hh
-  - label: 'lua'
-    type: 'issue'
-    title: "[Ll](ua|UA)"
 
   - label: 'os: linux'
     type: 'pull_request'
@@ -252,6 +126,177 @@ labels:
     type: 'issue'
     body: "[Hh](aiku|AIKU)"
 
+  - label: 'documentation'
+    type: 'pull_request'
+    files:
+      - doc/*
+      - doc/**/*
+      - data/conky*.conf
+  - label: 'documentation'
+    type: 'issue'
+    title: "[Dd]ocument(ation)?" # can be mentioned but unrelated
+
+  - label: 'extras'
+    type: 'pull_request'
+    files:
+      - extras/*
+      - extras/**/*
+
+  - label: 'sources'
+    type: 'pull_request'
+    files:
+      - src/*
+      - src/**/*
+
+  - label: 'tests'
+    type: 'pull_request'
+    files:
+      - tests/**/*
+      - tests/*
+
+  - label: 'web'
+    type: 'pull_request'
+    files:
+      - web/*
+      - web/**/*
+
+  - label: 'appimage'
+    type: 'issue'
+    body: "(appimage|AppImage|Appimage)"
+  
+  - label: '3rdparty'
+    type: 'pull_request'
+    files:
+      - 3rdparty/*
+      - 3rdparty/**/*
+
+  - label: 'gh-actions'
+    type: 'pull_request'
+    files:
+      - .github/workflows/*
+      - .github/workflows/**/*
+      - .github/labeler.yml
+      - .github/pull_request_template.md
+
+  - label: 'dependencies'
+    type: 'pull_request'
+    files:
+      - web/package-lock.json
+      - cmake/ConkyPlatformChecks.cmake
+
+  - label: 'appimage'
+    type: 'pull_request'
+    files:
+      - appimage/*
+      - appimage/**/*
+
+  - label: 'audio'
+    type: 'pull_request'
+    files:
+      - src/audacious.cc
+      - src/audacious.h
+      - src/cmus.cc
+      - src/cmus.h
+      - src/libmpdclient.cc
+      - src/libmpdclient.h
+      - src/mpd.cc
+      - src/mpd.h
+      - src/moc.cc
+      - src/moc.h
+      - src/mixer.cc
+      - src/mixer.h
+      - src/xmms2.cc
+      - src/xmms2.h
+      - src/pulseaudio.cc
+      - src/pulseaudio.h
+  - label: 'audio'
+    type: 'issue'
+    title: "([Aa]udio|[Aa]udacious|CMUS|cmus|MPD|libmpd|[Mm]ixer|xmms2|XMMS2|[Pp]ulse[Aa]udio|[Mm]usic|[Ss]ong)" # can be in config
+  
+  - label: 'power'
+    type: 'pull_request'
+    files:
+      - src/apcupsd.cc
+      - src/apcupsd.h
+      - src/bsdapm.cc
+      - src/bsdapm.h
+      - src/smapi.cc
+      - src/smapi.h
+  - label: 'power'
+    type: 'issue'
+    title: "([Bb]attery|[Cc]harged)" # can be in config
+
+  - label: 'build system'
+    type: 'pull_request'
+    files:
+      - '**/CMakeLists.txt'
+      - '*.cmake'
+
+  - label: 'cairo'
+    type: 'pull_request'
+    files:
+      - 'lua/*cairo*'
+  - label: 'cairo'
+    type: 'issue'
+    title: "([Cc]airo)" # can be in config
+
+  - label: 'sensors'
+    type: 'pull_request'
+    files:
+      - src/hddtemp.cc
+      - src/hddtemp.h
+  - label: 'disk io'
+    type: 'issue'
+    title: "(temperature|temp)" # can be in config
+
+  - label: 'disk io'
+    type: 'pull_request'
+    files:
+      - src/diskio.cc
+      - src/diskio.h
+  - label: 'disk io'
+    type: 'issue'
+    title: "(HDD|hdd|SSD|ssd|[Dd](isk|rive) space|filesystem)" # can be in config
+
+  - label: 'cpu'
+    type: 'pull_request'
+    files:
+      - src/cpu.cc
+      - src/cpu.h
+      - src/proc.cc
+      - src/proc.h
+      - src/top.cc
+      - src/top.h
+  - label: 'cpu'
+    type: 'issue'
+    title: "(CPU|cpu)" # can be in config
+
+  - label: 'lua'
+    type: 'pull_request'
+    files:
+      - lua/*
+      - lua/**/*
+      - src/llua.cc
+      - src/llua.h
+      - src/luamm.cc
+      - src/luamm.h
+      - src/lua-config.cc
+      - src/lua-config.hh
+  - label: 'lua'
+    type: 'issue'
+    title: "[Ll](ua|UA)" # can be in config
+
+  - label: 'mail'
+    type: 'pull_request'
+    files:
+      - src/mail.cc
+      - src/mail.h
+      - src/mboxscan.cc
+      - src/mboxscan.h
+  - label: 'mail'
+    type: 'issue'
+    title: "(e?mail|[Mm][Bb](ox|OX))" # can be in config
+
   - label: 'mouse events'
     type: 'pull_request'
     files:
@@ -274,7 +319,7 @@ labels:
       - src/read_tcpip.h
   - label: 'networking'
     type: 'issue'
-    body: "(network|IP address|download|upload)"
+    title: "(network( (interface|id|ID))|(IP|machine|gateway)('?s)? address|download|upload|gateway)" # can be in config
 
   - label: 'nvidia'
     type: 'pull_request'
@@ -283,7 +328,7 @@ labels:
       - src/nvidia.h
   - label: 'nvidia'
     type: 'issue'
-    body: "[Nn](vidia|VIDIA)"
+    title: "[Nn](vidia|VIDIA)" # can be in config
 
   - label: 'rendering'
     type: 'pull_request'
@@ -292,10 +337,21 @@ labels:
       - src/text_object.h
       - src/specials.cc
       - src/specials.h
+  - label: 'rendering'
+    type: 'issue'
+    title: "([Xx](ft|FT))"
+  - label: 'rendering'
+    type: 'issue'
+    body: "(incorrect|bad|wrong)(ly)? (size|align|position)(ed|ment)"
+  - label: 'rendering'
+    type: 'issue'
+    body: "(flicker(ing)?|font icons?|[Xx](ft|FT))"
 
   - label: 'text'
     type: 'pull_request'
     files:
+      - src/core.cc
+      - src/core.h
       - src/text_object.cc
       - src/text_object.h
       - src/template.cc
@@ -306,4 +362,14 @@ labels:
       - src/specials.h
   - label: 'text'
     type: 'issue'
+    body: "exec(i(bar))"
+  - label: 'text'
+    type: 'issue'
     body: "\\$\\w+ variable"
+
+  - label: 'build system'
+    type: 'issue'
+    title: "([Cc]?[Cc][Mm]ake|([Mm]ake|[Bb]uild) error|compil(e|ation))"
+  - label: 'build system'
+    type: 'issue'
+    body: "([Cc]?[Cc][Mm]ake|([Mm]ake|[Bb]uild) error|compil(e|ation))"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,4 @@
 version: 1
-issues: True
 appendOnly: true
 
 labels:
@@ -262,7 +261,7 @@ labels:
       - src/mouse-events.h
   - label: 'mouse events'
     type: 'issue'
-    body: "(mouse|cursor|pointer) (events?|enters?|leaves?|clicks?|press(es)?))"
+    body: "(mouse|cursor|pointer) (buttons?|events?|enters?|leaves?|clicks?|press(es)?))"
 
   - label: 'networking'
     type: 'pull_request'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,257 +1,248 @@
-documentation:
-  - changed-files:
-      - any-glob-to-any-file:
-          - doc/*
-          - doc/**/*
-          - data/conky*.conf
+version: 1
 
-extras:
-  - changed-files:
-      - any-glob-to-any-file:
-          - extras/*
-          - extras/**/*
+labels:
+  - label: 'documentation'
+    type: 'pull_request'
+    files:
+      - doc/*
+      - doc/**/*
+      - data/conky*.conf
 
-sources:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/*
-          - src/**/*
+  - label: 'extras'
+    type: 'pull_request'
+    files:
+      - extras/*
+      - extras/**/*
 
-tests:
-  - changed-files:
-      - any-glob-to-any-file:
-          - tests/**/*
-          - tests/*
+  - label: 'sources'
+    type: 'pull_request'
+    files:
+      - src/*
+      - src/**/*
 
-web:
-  - changed-files:
-      - any-glob-to-any-file:
-          - web/*
-          - web/**/*
+  - label: 'tests'
+    type: 'pull_request'
+    files:
+      - tests/**/*
+      - tests/*
 
-appimage:
-  - changed-files:
-      - any-glob-to-any-file:
-          - appimage/*
-          - appimage/**/*
+  - label: 'web'
+    type: 'pull_request'
+    files:
+      - web/*
+      - web/**/*
 
-3rdparty:
-  - changed-files:
-      - any-glob-to-any-file:
-          - 3rdparty/*
-          - 3rdparty/**/*
+  - label: 'appimage'
+    type: 'pull_request'
+    files:
+      - appimage/*
+      - appimage/**/*
 
-gh-actions:
-  - changed-files:
-      - any-glob-to-any-file:
-          - .github/workflows/*
-          - .github/workflows/**/*
-          - .github/labeler.yml
-          - .github/pull_request_template.md
+  - label: '3rdparty'
+    type: 'pull_request'
+    files:
+      - 3rdparty/*
+      - 3rdparty/**/*
 
-dependencies:
-  - changed-files:
-      - any-glob-to-any-file:
-          - web/package-lock.json
-          - cmake/ConkyPlatformChecks.cmake
+  - label: 'gh-actions'
+    type: 'pull_request'
+    files:
+      - .github/workflows/*
+      - .github/workflows/**/*
+      - .github/labeler.yml
+      - .github/pull_request_template.md
 
-audio:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/audacious.cc
-          - src/audacious.h
-          - src/cmus.cc
-          - src/cmus.h
-          - src/libmpdclient.cc
-          - src/libmpdclient.h
-          - src/mpd.cc
-          - src/mpd.h
-          - src/moc.cc
-          - src/moc.h
-          - src/mixer.cc
-          - src/mixer.h
-          - src/xmms2.cc
-          - src/xmms2.h
-          - src/pulseaudio.cc
-          - src/pulseaudio.h
+  - label: 'dependencies'
+    type: 'pull_request'
+    files:
+      - web/package-lock.json
+      - cmake/ConkyPlatformChecks.cmake
 
-power:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/apcupsd.cc
-          - src/apcupsd.h
-          - src/bsdapm.cc
-          - src/bsdapm.h
-          - src/smapi.cc
-          - src/smapi.h
+  - label: 'audio'
+    type: 'pull_request'
+    files:
+      - src/audacious.cc
+      - src/audacious.h
+      - src/cmus.cc
+      - src/cmus.h
+      - src/libmpdclient.cc
+      - src/libmpdclient.h
+      - src/mpd.cc
+      - src/mpd.h
+      - src/moc.cc
+      - src/moc.h
+      - src/mixer.cc
+      - src/mixer.h
+      - src/xmms2.cc
+      - src/xmms2.h
+      - src/pulseaudio.cc
+      - src/pulseaudio.h
 
-'display: console':
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/display-console.cc
-          - src/display-console.hh
-'display: file':
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/display-file.cc
-          - src/display-file.hh
-'display: http':
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/display-http.cc
-          - src/display-http.hh
-'display: ncurses':
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/nc.cc
-          - src/nc.h
-          - src/display-ncurses.cc
-          - src/display-ncurses.hh
-'display: wayland':
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/wl.cc
-          - src/wl.h
-          - src/wlr-layer-shell-unstable-v1.xml
-          - src/display-wayland.cc
-          - src/display-wayland.hh
-'display: x11':
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/x11-color.cc
-          - src/x11-color.h
-          - src/x11.cc
-          - src/x11.h
-          - src/display-x11.cc
-          - src/display-x11.hh
+  - label: 'power'
+    type: 'pull_request'
+    files:
+      - src/apcupsd.cc
+      - src/apcupsd.h
+      - src/bsdapm.cc
+      - src/bsdapm.h
+      - src/smapi.cc
+      - src/smapi.h
 
-'build system':
-  - changed-files:
-      - any-glob-to-any-file:
-          - '**/CMakeLists.txt'
-          - '*.cmake'
+  - label: 'display: console'
+    type: 'pull_request'
+    files:
+      - src/display-console.cc
+      - src/display-console.hh
+  - label: 'display: file'
+    type: 'pull_request'
+    files:
+      - src/display-file.cc
+      - src/display-file.hh
+  - label: 'display: http'
+    type: 'pull_request'
+    files:
+      - src/display-http.cc
+      - src/display-http.hh
+  - label: 'display: ncurses'
+    type: 'pull_request'
+    files:
+      - src/nc.cc
+      - src/nc.h
+      - src/display-ncurses.cc
+      - src/display-ncurses.hh
+  - label: 'display: wayland'
+    type: 'pull_request'
+    files:
+      - src/wl.cc
+      - src/wl.h
+      - src/wlr-layer-shell-unstable-v1.xml
+      - src/display-wayland.cc
+      - src/display-wayland.hh
+  - label: 'display: x11'
+    type: 'pull_request'
+    files:
+      - src/x11-color.cc
+      - src/x11-color.h
+      - src/x11.cc
+      - src/x11.h
+      - src/display-x11.cc
+      - src/display-x11.hh
 
-cairo:
-  - changed-files:
-      - any-glob-to-any-file:
-          - 'lua/*cairo*'
+  - label: 'build system'
+    type: 'pull_request'
+    files:
+      - '**/CMakeLists.txt'
+      - '*.cmake'
 
-'disk io':
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/diskio.cc
-          - src/diskio.h
+  - label: 'cairo'
+    type: 'pull_request'
+    files:
+      - 'lua/*cairo*'
 
-cpu:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/cpu.cc
-          - src/cpu.h
-          - src/proc.cc
-          - src/proc.h
-          - src/top.cc
-          - src/top.h
+  - label: 'disk io'
+    type: 'pull_request'
+    files:
+      - src/diskio.cc
+      - src/diskio.h
 
-lua:
-  - changed-files:
-      - any-glob-to-any-file:
-          - lua/*
-          - lua/**/*
-          - src/llua.cc
-          - src/llua.h
-          - src/luamm.cc
-          - src/luamm.h
-          - src/lua-config.cc
-          - src/lua-config.hh
+  - label: 'cpu'
+    type: 'pull_request'
+    files:
+      - src/cpu.cc
+      - src/cpu.h
+      - src/proc.cc
+      - src/proc.h
+      - src/top.cc
+      - src/top.h
 
-'os: linux':
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/linux.cc
-          - src/linux.h
+  - label: 'lua'
+    type: 'pull_request'
+    files:
+      - lua/*
+      - lua/**/*
+      - src/llua.cc
+      - src/llua.h
+      - src/luamm.cc
+      - src/luamm.h
+      - src/lua-config.cc
+      - src/lua-config.hh
 
-'os: linux':
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/linux.cc
-          - src/linux.h
+  - label: 'os: linux'
+    type: 'pull_request'
+    files:
+      - src/linux.cc
+      - src/linux.h
+  - label: 'os: dragonfly'
+    type: 'pull_request'
+    files:
+      - src/dragonfly.cc
+      - src/dragonfly.h
+  - label: 'os: freebsd'
+    type: 'pull_request'
+    files:
+      - src/freebsd.cc
+      - src/freebsd.h
+  - label: 'os: netbsd'
+    type: 'pull_request'
+    files:
+      - src/netbsd.cc
+      - src/netbsd.h
+  - label: 'os: openbsd'
+    type: 'pull_request'
+    files:
+      - src/openbsd.cc
+      - src/openbsd.h
+  - label: 'os: solaris'
+    type: 'pull_request'
+    files:
+      - src/solaris.cc
+      - src/solaris.h
+  - label: 'os: haiku'
+    type: 'pull_request'
+    files:
+      - src/haiku.cc
+      - src/haiku.h
 
-'os: dragonfly':
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/dragonfly.cc
-          - src/dragonfly.h
+  - label: 'mouse events'
+    type: 'pull_request'
+    files:
+      - src/scroll.cc
+      - src/scroll.h
+      - src/mouse-events.cc
+      - src/mouse-events.h
 
-'os: freebsd':
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/freebsd.cc
-          - src/freebsd.h
+  - label: 'networking'
+    type: 'pull_request'
+    files:
+      - src/net_stat.cc
+      - src/net_stat.h
+      - src/tcp-portmon.cc
+      - src/tcp-portmon.h
+      - src/read_tcpip.cc
+      - src/read_tcpip.h
 
-'os: netbsd':
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/netbsd.cc
-          - src/netbsd.h
-  
-'os: openbsd':
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/openbsd.cc
-          - src/openbsd.h
+  - label: 'nvidia'
+    type: 'pull_request'
+    files:
+      - src/nvidia.cc
+      - src/nvidia.h
 
-'os: solaris':
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/solaris.cc
-          - src/solaris.h
+  - label: 'rendering'
+    type: 'pull_request'
+    files:
+      - src/text_object.cc
+      - src/text_object.h
+      - src/specials.cc
+      - src/specials.h
 
-'os: haiku':
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/haiku.cc
-          - src/haiku.h
-
-'mouse events':
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/scroll.cc
-          - src/scroll.h
-          - src/mouse-events.cc
-          - src/mouse-events.h
-
-networking:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/net_stat.cc
-          - src/net_stat.h
-          - src/tcp-portmon.cc
-          - src/tcp-portmon.h
-          - src/read_tcpip.cc
-          - src/read_tcpip.h
-
-nvidia:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/nvidia.cc
-          - src/nvidia.h
-
-rendering:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/text_object.cc
-          - src/text_object.h
-          - src/specials.cc
-          - src/specials.h
-
-text:
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/text_object.cc
-          - src/text_object.h
-          - src/template.cc
-          - src/template.h
-          - src/tailhead.cc
-          - src/tailhead.h
-          - src/specials.cc
-          - src/specials.h
+  - label: 'text'
+    type: 'pull_request'
+    files:
+      - src/text_object.cc
+      - src/text_object.h
+      - src/template.cc
+      - src/template.h
+      - src/tailhead.cc
+      - src/tailhead.h
+      - src/specials.cc
+      - src/specials.h

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,7 @@
 name: 'Pull Request Labeler'
 on:
   - pull_request_target
+  - issues
 
 jobs:
   triage:
@@ -12,7 +13,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Run labeler
-        uses: actions/labeler@v5
-        with:
-          sync-labels: true
-          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+        uses: srvaroa/labeler@v1
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,9 +5,6 @@ on:
 
 jobs:
   triage:
-    permissions:
-      contents: read
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,8 +7,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
       - name: Run labeler
         uses: srvaroa/labeler@v1
         env:


### PR DESCRIPTION
This PR:
- replaces old labeler action with a [different one](https://github.com/srvaroa/labeler) that works on both PRs (as the previous one) _and_ issues.
- adds support for labeling of os related things.
- adds regex checking for issue content to automatically label issues based on keywords in (mostly) titles and body.
  - because users include configs in issues, a lot of keywords can't be checked for in the issue body as too many labels would be detected ([maybe in future](https://github.com/srvaroa/labeler/issues/156))

The only thing I don't like is that it re-applies labels to all issues when a new one is created. I made it pick labels very conservatively, but it could be annoying in some cases.