### PR TITLE
Fix if_match comparison for string operands containing operator symbols (#1988)

### DIFF
--- a/src/algebra.cc
+++ b/src/algebra.cc
@@ -176,6 +176,7 @@ long arg_to_long(const char *arg) {
   }
   return l;
 }
+
 int compare(const char *expr) {
   char *expr_dup;
   int idx, mtype;

--- a/src/algebra.cc
+++ b/src/algebra.cc
@@ -40,9 +40,15 @@
  * returns the index of the first op character or -1 on error
  */
 int find_match_op(const char *expr) {
-  unsigned int idx;
+  unsigned int idx = 0;
 
-  for (idx = 0; idx < strlen(expr); idx++) {
+  /* if first operand is a string, skip it */
+  if (expr[idx] == '"') {
+    for (idx=1; expr[idx] && expr[idx] != '"'; idx++);
+    idx++;
+  }
+
+  for (; idx < strlen(expr); idx++) {
     switch (expr[idx]) {
       case '=':
       case '!':

--- a/src/algebra.h
+++ b/src/algebra.h
@@ -47,5 +47,7 @@ enum arg_type {
 
 int compare(const char *);
 int check_if_match(struct text_object *);
+int get_match_type(const char *expr);
+int find_match_op(const char *expr);
 
 #endif /* _ALGEBRA_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(test_srcs ${test_srcs} test-fs.cc)
 set(test_srcs ${test_srcs} test-gradient.cc)
 set(test_srcs ${test_srcs} test-graph.cc)
 set(test_srcs ${test_srcs} test-colours.cc)
+set(test_srcs ${test_srcs} test-algebra.cc)
 
 add_executable(test-conky test-common.cc ${test_srcs})
 target_link_libraries(test-conky conky_core)
@@ -27,29 +28,29 @@ catch_discover_tests(test-conky)
 
 if(CODE_COVERAGE)
   set(COVERAGE_LCOV_EXCLUDES
-      "*/include/c++/v1/*"
-      "/usr/include/*"
-      "/usr/lib/*"
-      "/usr/local/Cellar/*"
-      "/usr/local/include/*"
-      "/usr/local/lib/*"
-      "/usr/include/libkern/i386/*"
-      "/usr/include/sys/_types/*"
-      "/usr/local/opt/gettext/include/*"
-      "${CMAKE_CURRENT_SOURCE_DIR}/*"
-      "${CMAKE_CURRENT_SOURCE_DIR}/catch2/*"
-      "${CMAKE_SOURCE_DIR}/3rdparty/*")
+    "*/include/c++/v1/*"
+    "/usr/include/*"
+    "/usr/lib/*"
+    "/usr/local/Cellar/*"
+    "/usr/local/include/*"
+    "/usr/local/lib/*"
+    "/usr/include/libkern/i386/*"
+    "/usr/include/sys/_types/*"
+    "/usr/local/opt/gettext/include/*"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*"
+    "${CMAKE_CURRENT_SOURCE_DIR}/catch2/*"
+    "${CMAKE_SOURCE_DIR}/3rdparty/*")
 
   setup_target_for_coverage_lcov_html(NAME
-                                      test-conky-coverage-html
-                                      EXECUTABLE
-                                      test-conky
-                                      DEPENDENCIES
-                                      test-conky)
+    test-conky-coverage-html
+    EXECUTABLE
+    test-conky
+    DEPENDENCIES
+    test-conky)
   setup_target_for_coverage_lcov_txt(NAME
-                                     test-conky-coverage-txt
-                                     EXECUTABLE
-                                     test-conky
-                                     DEPENDENCIES
-                                     test-conky)
+    test-conky-coverage-txt
+    EXECUTABLE
+    test-conky
+    DEPENDENCIES
+    test-conky)
 endif()

--- a/tests/test-algebra.cc
+++ b/tests/test-algebra.cc
@@ -1,0 +1,133 @@
+#include "catch2/catch.hpp"
+
+#include <algebra.h>
+#include <config.h>
+
+TEST_CASE("GetMatchTypeTest - ValidOperators") {
+  REQUIRE(get_match_type("a==b") == OP_EQ);
+  REQUIRE(get_match_type("a!=b") == OP_NEQ);
+  REQUIRE(get_match_type("a>b") == OP_GT);
+  REQUIRE(get_match_type("a>=b") == OP_GEQ);
+  REQUIRE(get_match_type("a<b") == OP_LT);
+  REQUIRE(get_match_type("a<=b") == OP_LEQ);
+}
+
+TEST_CASE("GetMatchTypeTest - InvalidOperators") {
+  REQUIRE(get_match_type("a=b") == -1);
+  REQUIRE(get_match_type("a!b") == -1);
+  REQUIRE(get_match_type("a=b") == -1);
+}
+
+TEST_CASE("GetMatchTypeTest - NoOperators") {
+  REQUIRE(get_match_type("abc") == -1);
+  REQUIRE(get_match_type("123") == -1);
+  REQUIRE(get_match_type("") == -1);
+}
+
+TEST_CASE("find_match_op identifies operators correctly", "[find_match_op]") {
+  SECTION("Single character operators") {
+    REQUIRE(find_match_op("a < b") == 2);
+    REQUIRE(find_match_op("a > b") == 2);
+  }
+
+  SECTION("Double character operators") {
+    REQUIRE(find_match_op("a == b") == 2);
+    REQUIRE(find_match_op("a != b") == 2);
+    REQUIRE(find_match_op("a >= b") == 2);
+    REQUIRE(find_match_op("a <= b") == 2);
+  }
+
+  SECTION("No operator present") { REQUIRE(find_match_op("a b") == -1); }
+
+  SECTION("Invalid operators") {
+    REQUIRE(find_match_op("a = b") == -1);
+    REQUIRE(find_match_op("a ! b") == -1);
+  }
+
+  SECTION("Operators at different positions") {
+    REQUIRE(find_match_op("x == y") == 2);
+    REQUIRE(find_match_op("x != y") == 2);
+    REQUIRE(find_match_op("x >= y") == 2);
+    REQUIRE(find_match_op("x <= y") == 2);
+    REQUIRE(find_match_op("x < y") == 2);
+    REQUIRE(find_match_op("x > y") == 2);
+  }
+
+  SECTION("Empty string") { REQUIRE(find_match_op("") == -1); }
+}
+
+TEST_CASE("GetMatchTypeTest - More test cases") {
+  REQUIRE(get_match_type("\"a!b\" == \"ab\"") == -1);     // "a!b" == "ab"
+  REQUIRE(get_match_type("\"a!/b\" == \"a!/b\"") == -1);  // "a!/b" == "a!/b"
+  REQUIRE(get_match_type("\"a!=/a==b\" == \"a!=/a==b\"") ==
+          6);  // "a!=/a==b" == "a!=/a==b"
+  REQUIRE(get_match_type("\"a!=/b==b\" == \"a!==/a==b\"") ==
+          6);  // "a!=/b==b" == "a!==/a==b"
+  REQUIRE(get_match_type("\"a!======b\" == \"!==/==\"") ==
+          6);  // "a!======b" == "!==/=="
+  REQUIRE(get_match_type("\" !=<>==\" == \" !=<>==\"") ==
+          6);  // " !=<>==" == " !=<>=="
+  REQUIRE(get_match_type("\"a!=><==\" < \"b!=><==\"") ==
+          6);  // "a!=><==" < "b!=><=="
+  REQUIRE(get_match_type("\"!=<>==\" == \"!=<>==\"") ==
+          6);                                       // "!=<>==" == "!=<>=="
+  REQUIRE(get_match_type("\"=\" == \"=\"") == -1);  // "=" == "="
+  REQUIRE(get_match_type("\"FRITZ!Box 7520 HI\" == \"off/any\"") ==
+          -1);  // "FRITZ!Box 7520 HI" == "off/any"
+}
+
+TEST_CASE("CompareTest - ValidOperators") {
+  REQUIRE(compare("\"a\"==\"b\"") == 0);
+  REQUIRE(compare("\"a\"!=\"b\"") == 1);
+  REQUIRE(compare("\"a\">\"b\"") == 0);
+  REQUIRE(compare("\"a\">=\"b\"") == 0);
+  REQUIRE(compare("\"a\"<\"b\"") == 1);
+  REQUIRE(compare("\"a\"<=\"b\"") == 1);
+}
+TEST_CASE("CompareTest - ValidOperators with Integers") {
+  REQUIRE(compare("1==1") == 1);
+  REQUIRE(compare("1!=2") == 1);
+  REQUIRE(compare("2>1") == 1);
+  REQUIRE(compare("2>=1") == 1);
+  REQUIRE(compare("1<2") == 1);
+  REQUIRE(compare("1<=2") == 1);
+}
+
+TEST_CASE("CompareTest - ValidOperators with Doubles") {
+  REQUIRE(compare("1.0==1.0") == 1);
+  REQUIRE(compare("1.0!=2.0") == 1);
+  REQUIRE(compare("2.0>1.0") == 1);
+  REQUIRE(compare("2.0>=1.0") == 1);
+  REQUIRE(compare("1.0<2.0") == 1);
+  REQUIRE(compare("1.0<=2.0") == 1);
+}
+
+TEST_CASE("CompareTest - InvalidOperators") {
+  REQUIRE(compare("\"a\"=\"b\"") == -2);
+  REQUIRE(compare("\"a\"!\"b\"") == -2);
+  REQUIRE(compare("\"a\"=\"b\"") == -2);
+}
+
+TEST_CASE("CompareTest - NoOperators") {
+  REQUIRE(compare("abc") == -2);
+  REQUIRE(compare("123") == -2);
+  REQUIRE(compare("") == -2);
+}
+
+TEST_CASE("CompareTest - More test cases") {
+  REQUIRE(compare("\"a!b\" == \"ab\"") == -2);     // "a!b" == "ab"
+  REQUIRE(compare("\"a!/b\" == \"a!/b\"") == -2);  // "a!/b" == "a!/b"
+  REQUIRE(compare("\"a!=/a==b\" == \"a!=/a==b\"") ==
+          -2);  // "a!=/a==b" == "a!=/a==b"
+  REQUIRE(compare("\"a!=/b==b\" == \"a!==/a==b\"") ==
+          -2);  // "a!=/b==b" == "a!==/a==b"
+  REQUIRE(compare("\"a!======b\" == \"!==/==\"") ==
+          -2);  // "a!======b" == "!==/=="
+  REQUIRE(compare("\" !=<>==\" == \" !=<>==\"") ==
+          -2);  // " !=<>==" == " !=<>=="
+  REQUIRE(compare("\"a!=><==\" < \"b!=><==\"") == -2);  // "a!=><==" < "b!=><=="
+  REQUIRE(compare("\"!=<>==\" == \"!=<>==\"") == -2);   // "!=<>==" == "!=<>=="
+  REQUIRE(compare("\"=\" == \"=\"") == -2);             // "=" == "="
+  REQUIRE(compare("\"FRITZ!Box 7520 HI\" == \"off/any\"") ==
+          -2);  // "FRITZ!Box 7520 HI" == "off/any"
+}

--- a/tests/test-algebra.cc
+++ b/tests/test-algebra.cc
@@ -57,23 +57,23 @@ TEST_CASE("find_match_op identifies operators correctly", "[find_match_op]") {
 }
 
 TEST_CASE("GetMatchTypeTest - More test cases") {
-  REQUIRE(get_match_type("\"a!b\" == \"ab\"") == -1);     // "a!b" == "ab"
-  REQUIRE(get_match_type("\"a!/b\" == \"a!/b\"") == -1);  // "a!/b" == "a!/b"
+  REQUIRE(get_match_type("\"a!b\" == \"ab\"") == OP_EQ);     // "a!b" == "ab"
+  REQUIRE(get_match_type("\"a!/b\" == \"a!/b\"") == OP_EQ);  // "a!/b" == "a!/b"
   REQUIRE(get_match_type("\"a!=/a==b\" == \"a!=/a==b\"") ==
-          6);  // "a!=/a==b" == "a!=/a==b"
+          OP_EQ);  // "a!=/a==b" == "a!=/a==b"
   REQUIRE(get_match_type("\"a!=/b==b\" == \"a!==/a==b\"") ==
-          6);  // "a!=/b==b" == "a!==/a==b"
+          OP_EQ);  // "a!=/b==b" == "a!==/a==b"
   REQUIRE(get_match_type("\"a!======b\" == \"!==/==\"") ==
-          6);  // "a!======b" == "!==/=="
+          OP_EQ);  // "a!======b" == "!==/=="
   REQUIRE(get_match_type("\" !=<>==\" == \" !=<>==\"") ==
-          6);  // " !=<>==" == " !=<>=="
+          OP_EQ);  // " !=<>==" == " !=<>=="
   REQUIRE(get_match_type("\"a!=><==\" < \"b!=><==\"") ==
-          6);  // "a!=><==" < "b!=><=="
+          OP_LT);  // "a!=><==" < "b!=><=="
   REQUIRE(get_match_type("\"!=<>==\" == \"!=<>==\"") ==
-          6);                                       // "!=<>==" == "!=<>=="
-  REQUIRE(get_match_type("\"=\" == \"=\"") == -1);  // "=" == "="
+          OP_EQ);                                      // "!=<>==" == "!=<>=="
+  REQUIRE(get_match_type("\"=\" == \"=\"") == OP_EQ);  // "=" == "="
   REQUIRE(get_match_type("\"FRITZ!Box 7520 HI\" == \"off/any\"") ==
-          -1);  // "FRITZ!Box 7520 HI" == "off/any"
+          OP_EQ);  // "FRITZ!Box 7520 HI" == "off/any"
 }
 
 TEST_CASE("CompareTest - ValidOperators") {
@@ -115,19 +115,19 @@ TEST_CASE("CompareTest - NoOperators") {
 }
 
 TEST_CASE("CompareTest - More test cases") {
-  REQUIRE(compare("\"a!b\" == \"ab\"") == -2);     // "a!b" == "ab"
-  REQUIRE(compare("\"a!/b\" == \"a!/b\"") == -2);  // "a!/b" == "a!/b"
+  REQUIRE(compare("\"a!b\" == \"ab\"") == 0);     // "a!b" == "ab"
+  REQUIRE(compare("\"a!/b\" == \"a!/b\"") == 1);  // "a!/b" == "a!/b"
   REQUIRE(compare("\"a!=/a==b\" == \"a!=/a==b\"") ==
-          -2);  // "a!=/a==b" == "a!=/a==b"
+          1);  // "a!=/a==b" == "a!=/a==b"
   REQUIRE(compare("\"a!=/b==b\" == \"a!==/a==b\"") ==
-          -2);  // "a!=/b==b" == "a!==/a==b"
+          0);  // "a!=/b==b" == "a!==/a==b"
   REQUIRE(compare("\"a!======b\" == \"!==/==\"") ==
-          -2);  // "a!======b" == "!==/=="
+          0);  // "a!======b" == "!==/=="
   REQUIRE(compare("\" !=<>==\" == \" !=<>==\"") ==
-          -2);  // " !=<>==" == " !=<>=="
-  REQUIRE(compare("\"a!=><==\" < \"b!=><==\"") == -2);  // "a!=><==" < "b!=><=="
-  REQUIRE(compare("\"!=<>==\" == \"!=<>==\"") == -2);   // "!=<>==" == "!=<>=="
-  REQUIRE(compare("\"=\" == \"=\"") == -2);             // "=" == "="
+          1);                                          // " !=<>==" == " !=<>=="
+  REQUIRE(compare("\"a!=><==\" < \"b!=><==\"") == 1);  // "a!=><==" < "b!=><=="
+  REQUIRE(compare("\"!=<>==\" == \"!=<>==\"") == 1);   // "!=<>==" == "!=<>=="
+  REQUIRE(compare("\"=\" == \"=\"") == 1);             // "=" == "="
   REQUIRE(compare("\"FRITZ!Box 7520 HI\" == \"off/any\"") ==
-          -2);  // "FRITZ!Box 7520 HI" == "off/any"
+          0);  // "FRITZ!Box 7520 HI" == "off/any"
 }


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [x] All new code is licensed under GPLv3

## Description
Maybe too naive, but skipping the first comparison operand if it is a string avoids the issue. Fixes #1988.
