### PR TITLE
Add math.h include to Vc/scalar/math.h

### DIFF
--- a/3rdparty/Vc/Vc/scalar/math.h
+++ b/3rdparty/Vc/Vc/scalar/math.h
@@ -31,6 +31,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdlib>
 #include "macros.h"
 
+// PATCH(Caellian): Fix OpenBSD build
+#ifdef __unix__
+#include <cmath>
+#endif
+
 namespace Vc_VERSIONED_NAMESPACE
 {
 // copysign {{{1


### PR DESCRIPTION
Fixes #2073.

This wasn't tested.

Would need to setup a VM with OpenBSD to check whether it actually works, and to verify the issue in the first place.