### PR TITLE
lua-imlib2: fix memory leak

### DIFF
--- a/lua/libcairo_imlib2_helper.h
+++ b/lua/libcairo_imlib2_helper.h
@@ -5,7 +5,7 @@
  * Please see COPYING for details
  *
  * Copyright (c) 2005-2024 Brenden Matthews, Philip Kovacs, et. al.
- *	(see AUTHORS)
+ *  (see AUTHORS)
  * All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -61,7 +61,6 @@ void cairo_place_image(const char *file, cairo_t *cr, int x, int y,
     return;
   }
 
-  /* create scaled version of image to later extract the alpha channel */
   alpha_image = imlib_create_cropped_scaled_image(0, 0, w, h, width, height);
 
   /* create temporary image */
@@ -151,6 +150,8 @@ void cairo_draw_image(const char *file, cairo_surface_t *cs, int x, int y,
 
   cr = cairo_create(cs);
   cairo_place_image(file, cr, x, y, scaled_w, scaled_h, 1.0);
+  imlib_context_set_image(image);
+  imlib_free_image_and_decache();
 
   cairo_destroy(cr);
 }


### PR DESCRIPTION
If you frequently use this function to draw new images this leak becomes quite significant. I use this function for a "Photo Frame" that shows a new photo every 30 seconds, without this change the image was leaked once each time, with this change that leak is resolved.

# Checklist
- [ X] I have described the changes
- [X ] I have linked to any relevant GitHub issues, if applicable
- [ X] Documentation in `doc/` has been updated
- [X ] All new code is licensed under GPLv3

## Description

* Describe the changes, why they were necessary, etc
* Describe how the changes will affect existing behaviour.
* Describe how you tested and validated your changes.
* Include any relevant screenshots/evidence demonstrating that the changes work and have been tested.
