### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/doc/render.py
+++ b/doc/render.py
@@ -2,6 +2,7 @@
 
 import sys
 import os
+import time
 import yaml
 import datetime
 
@@ -16,12 +17,16 @@ with open(os.path.join(base_path, "variables.yaml")) as file:
 with open(os.path.join(base_path, "lua.yaml")) as file:
     lua = yaml.safe_load(file)
 
+build_date = datetime.datetime.fromtimestamp(
+    int(os.environ.get('SOURCE_DATE_EPOCH', time.time())),
+    tz=datetime.timezone.utc,
+)
 data = {
     "config_settings": config_settings,
     "variables": variables,
     "lua": lua,
-    "date": datetime.date.today().isoformat(),
-    "copyright_year": datetime.date.today().year,
+    "date": build_date.date().isoformat(),
+    "copyright_year": build_date.year,
 }
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape


### PR DESCRIPTION
# Checklist
- [X] I have described the changes
- [ ] I have linked to any relevant GitHub issues, if applicable
- [ ] Documentation in `doc/` has been updated
- [X] All new code is licensed under GPLv3

## Description

Allow to override build date with `SOURCE_DATE_EPOCH`
to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

Also use UTC to be independent of timezone.

* Describe the changes, why they were necessary, etc
    * Without this patch, `man1/conky.1` would vary between builds on different days, which makes reproducible-builds hard.
* Describe how the changes will affect existing behaviour.
    * behaviour only changes, if the `SOURCE_DATE_EPOCH` env var is set.
* Describe how you tested and validated your changes.
    * I ran two builds with this change and they produced expected identical results
* Include any relevant screenshots/evidence demonstrating that the changes work and have been tested.