### PR TITLE
NetBSD: Fix CPU usage and top info.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -174,7 +174,7 @@ if(OS_SOLARIS)
 endif(OS_SOLARIS)
 
 if(OS_NETBSD)
-  set(netbsd netbsd.cc netbsd.h)
+  set(netbsd netbsd.cc netbsd.h bsdcommon.cc bsdcommon.h)
   set(optional_sources ${optional_sources} ${netbsd})
 endif(OS_NETBSD)
 

--- a/src/bsdcommon.cc
+++ b/src/bsdcommon.cc
@@ -259,7 +259,6 @@ static void proc_from_bsdproc(struct process *proc, BSD_COMMON_PROC_STRUCT *p) {
   #error Not supported BSD system 
 #endif
 
-  proc->total_cpu_time = proc->user_time + proc->kernel_time;
   if (proc->previous_user_time == ULONG_MAX) {
     proc->previous_user_time = proc->user_time;
   }

--- a/src/bsdcommon.cc
+++ b/src/bsdcommon.cc
@@ -1,0 +1,163 @@
+/*
+ *
+ * Conky, a system monitor, based on torsmo
+ *
+ * Please see COPYING for details
+ *
+ * Copyright (c) 2005-2024 Brenden Matthews, Philip Kovacs, et. al.
+ *      (see AUTHORS)
+ * All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "bsdcommon.h"
+#include "logging.h"
+
+#include <kvm.h>
+
+#include <sys/sysctl.h>
+
+static kvm_t *kd = nullptr;
+static bool kvm_initialised = false;
+static bool cpu_initialised = false;
+
+static struct bsdcommon::cpu_load *cpu_loads = nullptr;
+
+bool bsdcommon::init_kvm() {
+  if (kvm_initialised) {
+      return true;
+  }
+
+  kd = kvm_open(nullptr, nullptr, nullptr, KVM_NO_FILES, nullptr);
+  if (kd == nullptr) {
+    NORM_ERR("opening kvm");
+    return false;
+  }
+
+  kvm_initialised = true;
+  return false;
+}
+
+void bsdcommon::deinit_kvm() {
+  if (!kvm_initialised || kd == nullptr) {
+    return;
+  }
+
+  kvm_close(kd);
+}
+
+void bsdcommon::get_cpu_count(float **cpu_usage, unsigned int *cpu_count) {
+  int ncpu = 1;
+  int mib[2] = {CTL_HW, HW_NCPU};
+  size_t len = sizeof(ncpu);
+
+  if (sysctl(mib, 2, &ncpu, &len, nullptr, 0) != 0) {
+    NORM_ERR("error getting kern.ncpu, defaulting to 1");
+    ncpu = 1;
+  }
+
+  if (*cpu_count != ncpu) {
+    *cpu_count = ncpu;
+
+    if (*cpu_usage != nullptr) {
+      free(*cpu_usage);
+      *cpu_usage = nullptr;
+    }
+
+    if (cpu_loads != nullptr) {
+      free(cpu_loads);
+      cpu_loads = nullptr;
+    }
+  }
+
+  if (*cpu_usage == nullptr) {
+    // [0] - Total CPU
+    // [1, 2, ... ] - CPU1, CPU2, ...
+    *cpu_usage = (float*)calloc(ncpu + 1, sizeof(float));
+    if (*cpu_usage == nullptr) {
+      CRIT_ERR("calloc of cpu_usage");
+    }
+  }
+
+  if (cpu_loads == nullptr) {
+    cpu_loads = (struct cpu_load*)calloc(ncpu + 1, sizeof(struct cpu_load));
+    if (cpu_loads == nullptr) {
+      CRIT_ERR("calloc of cpu_loads");
+    }
+  }
+}
+
+void bsdcommon::update_cpu_usage(float **cpu_usage, unsigned int *cpu_count) {
+  uint64_t cp_time0[CPUSTATES];
+  int mib_cpu0[2] = {CTL_KERN, KERN_CP_TIME};
+  uint64_t cp_timen[CPUSTATES];
+  int mib_cpun[3] = {CTL_KERN, KERN_CP_TIME, 0};
+  size_t size = 0;
+  u_int64_t used = 0, total = 0;
+
+  if (!cpu_initialised) {
+    get_cpu_count(cpu_usage, cpu_count);
+    cpu_initialised = true;
+  }
+
+  size = sizeof(cp_time0);
+  if (sysctl(mib_cpu0, 2, &cp_time0, &size, nullptr, 0) != 0) {
+      NORM_ERR("unable to get kern.cp_time for cpu0");
+      return;
+  }
+
+  for (int j = 0; j < CPUSTATES; ++j) {
+    total += cp_time0[j];
+  }
+  used = total - cp_time0[CP_IDLE];
+
+  if ((total - cpu_loads[0].old_total) != 0) {
+    const float diff_used = (float)(used - cpu_loads[0].old_used);
+    const float diff_total = (float)(total - cpu_loads[0].old_total);
+    (*cpu_usage)[0] = diff_used / diff_total;
+  } else {
+    (*cpu_usage)[0] = 0;
+  }
+  cpu_loads[0].old_used = used;
+  cpu_loads[0].old_total = total;
+
+  for (int i = 0; i < *cpu_count; ++i) {
+    mib_cpun[2] = i;
+    size = sizeof(cp_timen);
+    if (sysctl(mib_cpun, 3, &cp_timen, &size, nullptr, 0) != 0) {
+      NORM_ERR("unable to get kern.cp_time for cpu%d", i);
+      return;
+    }
+
+    total = 0;
+    used = 0;
+    for (int j = 0; j < CPUSTATES; ++j) {
+      total += cp_timen[j];
+    }
+    used = total - cp_timen[CP_IDLE];
+
+    const int n = i + 1; // [0] is the total CPU, must shift by 1
+    if ((total - cpu_loads[n].old_total) != 0) {
+      const float diff_used = (float)(used - cpu_loads[n].old_used);
+      const float diff_total = (float)(total - cpu_loads[n].old_total);
+      (*cpu_usage)[n] = diff_used / diff_total;
+    } else {
+      (*cpu_usage)[n] = 0;
+    }
+
+    cpu_loads[n].old_used = used;
+    cpu_loads[n].old_total = total;
+  }
+}

--- a/src/bsdcommon.cc
+++ b/src/bsdcommon.cc
@@ -184,3 +184,30 @@ BSD_COMMON_PROC_STRUCT* bsdcommon::get_processes(short unsigned int *procs)
   *procs = n_processes;
   return ki;
 }
+
+static bool is_process_running(BSD_COMMON_PROC_STRUCT *p)
+{
+  return p->p_stat == LSRUN || p->p_stat == LSIDL || p->p_stat == LSONPROC;
+}
+
+void bsdcommon::get_number_of_running_processes(short unsigned int *run_procs)
+{
+  if (!init_kvm()) {
+    return;
+  }
+
+  short unsigned int nprocs = 0;
+  BSD_COMMON_PROC_STRUCT* ps = get_processes(&nprocs);
+  if (ps == nullptr) {
+    return;
+  }
+
+  short unsigned int ctr = 0;
+  for (int i = 0; i < nprocs; ++i) {
+    if (is_process_running(&ps[i])) {
+      ++ctr;
+    }
+  }
+
+  *run_procs = ctr;
+}

--- a/src/bsdcommon.h
+++ b/src/bsdcommon.h
@@ -35,7 +35,7 @@
   #include "sys/sysctl.h"
   #define BSD_COMMON_PROC_STRUCT struct kinfo_proc2
 #else
-  #error "Not supported BSD system"
+  #error Not supported BSD system
 #endif
 
 #include <stdint.h>
@@ -55,6 +55,7 @@ namespace bsdcommon {
   BSD_COMMON_PROC_STRUCT* get_processes(short unsigned int *procs);
 
   void get_number_of_running_processes(short unsigned int *run_procs);
+  void update_top_info();
 };
 
 #endif /*BSDCOMMON_H_*/

--- a/src/bsdcommon.h
+++ b/src/bsdcommon.h
@@ -31,6 +31,13 @@
 
 #define BSD_COMMON
 
+#if defined(__NetBSD__)
+  #include "sys/sysctl.h"
+  #define BSD_COMMON_PROC_STRUCT struct kinfo_proc2
+#else
+  #error "Not supported BSD system"
+#endif
+
 #include <stdint.h>
 
 namespace bsdcommon {
@@ -44,6 +51,8 @@ namespace bsdcommon {
 
   void get_cpu_count(float **cpu_usage, unsigned int *cpu_count);
   void update_cpu_usage(float **cpu_usage, unsigned int *cpu_count);
+
+  BSD_COMMON_PROC_STRUCT* get_processes(short unsigned int *procs);
 };
 
 #endif /*BSDCOMMON_H_*/

--- a/src/bsdcommon.h
+++ b/src/bsdcommon.h
@@ -1,0 +1,49 @@
+/*
+ *
+ * Conky, a system monitor, based on torsmo
+ *
+ * Please see COPYING for details
+ *
+ * Copyright (c) 2005-2024 Brenden Matthews, Philip Kovacs, et. al.
+ *	(see AUTHORS)
+ * All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*
+ * Shared or very similar code across BSDs.
+ */
+
+#ifndef BSDCOMMON_H_
+#define BSDCOMMON_H_
+
+#define BSD_COMMON
+
+#include <stdint.h>
+
+namespace bsdcommon {
+  struct cpu_load {
+    uint64_t old_used;
+    uint64_t old_total;
+  };
+
+  bool init_kvm();
+  void deinit_kvm();
+
+  void get_cpu_count(float **cpu_usage, unsigned int *cpu_count);
+  void update_cpu_usage(float **cpu_usage, unsigned int *cpu_count);
+};
+
+#endif /*BSDCOMMON_H_*/

--- a/src/bsdcommon.h
+++ b/src/bsdcommon.h
@@ -53,6 +53,8 @@ namespace bsdcommon {
   void update_cpu_usage(float **cpu_usage, unsigned int *cpu_count);
 
   BSD_COMMON_PROC_STRUCT* get_processes(short unsigned int *procs);
+
+  void get_number_of_running_processes(short unsigned int *run_procs);
 };
 
 #endif /*BSDCOMMON_H_*/

--- a/src/main.cc
+++ b/src/main.cc
@@ -52,6 +52,10 @@
 #include "freebsd.h"
 #endif /* FreeBSD */
 
+#if defined(__NetBSD__)
+#include "netbsd.h"
+#endif /* NetBSD */
+
 #if defined(__HAIKU__)
 #include "haiku.h"
 #endif /* Haiku */
@@ -411,6 +415,11 @@ int main(int argc, char **argv) {
 
   conky::shutdown_display_outputs();
 
+#ifdef BSD_COMMON
+  bsdcommon::deinit_kvm();
+#endif
+
+//TODO(gmb): Move this to bsdcommon and remove external kd.
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
   kvm_close(kd);
 #endif

--- a/src/netbsd.cc
+++ b/src/netbsd.cc
@@ -229,23 +229,7 @@ int update_net_stats() {
 }
 
 int update_total_processes() {
-  /* It's easier to use kvm here than sysctl */
-
-// TODO(gmb): Use bsdcommon.
-/*
-  int n_processes;
-
-  info.procs = 0;
-
-  if (init_kvm() < 0) {
-    return 1;
-  } else {
-    kvm_getproc2(kd, KERN_PROC_ALL, 0, sizeof(struct kinfo_proc2),
-                 &n_processes);
-  }
-
-  info.procs = n_processes;
-*/
+  bsdcommon::get_processes(&info.procs);
   return 1;
 }
 

--- a/src/netbsd.cc
+++ b/src/netbsd.cc
@@ -247,6 +247,10 @@ int update_cpu_usage() {
   return 1;
 }
 
+void get_top_info(void) {
+  bsdcommon::update_top_info();
+}
+
 void free_cpu(struct text_object *) { /* no-op */
 }
 
@@ -318,6 +322,3 @@ int update_diskio(void) {
   return 1;
 }
 
-void get_top_info(void) {
-  bsdcommon::update_top_info();
-}

--- a/src/netbsd.cc
+++ b/src/netbsd.cc
@@ -234,30 +234,7 @@ int update_total_processes() {
 }
 
 int update_running_processes() {
-
-// TODO(gmb): Use bsdcommon.
-/*
-  struct kinfo_proc2 *p;
-  int n_processes;
-  int i, cnt = 0;
-
-  info.run_procs = 0;
-
-  if (init_kvm() < 0) {
-    return 1;
-  } else {
-    p = kvm_getproc2(kd, KERN_PROC_ALL, 0, sizeof(struct kinfo_proc2),
-                     &n_processes);
-    for (i = 0; i < n_processes; i++) {
-      if (p[i].p_stat == LSRUN || p[i].p_stat == LSIDL ||
-          p[i].p_stat == LSONPROC) {
-        cnt++;
-      }
-    }
-  }
-
-  info.run_procs = cnt;
-*/
+  bsdcommon::get_number_of_running_processes(&info.run_procs);
   return 1;
 }
 

--- a/src/netbsd.cc
+++ b/src/netbsd.cc
@@ -319,5 +319,5 @@ int update_diskio(void) {
 }
 
 void get_top_info(void) {
-  // TODO(gmb)
+  bsdcommon::update_top_info();
 }

--- a/src/netbsd.h
+++ b/src/netbsd.h
@@ -15,6 +15,8 @@
 #include "common.h"
 #include "conky.h"
 
+#include "bsdcommon.h"
+
 int get_entropy_avail(unsigned int *);
 int get_entropy_poolsize(unsigned int *);
 


### PR DESCRIPTION
Report the correct number of CPUs and calculate the per-CPU load.
Populate top info.

I've started implementing a common BSD interface, as all BSD implementations use *slightly* different functions to achieve the same goal, and maintaining them in one place would be easier.

Fixes #2097.