### PR TITLE
Fix out_to_wayland giving nothing

### DIFF
--- a/src/display-console.cc
+++ b/src/display-console.cc
@@ -50,10 +50,7 @@ void register_output<output_t::CONSOLE>(display_outputs_t &outputs) {
 }
 
 display_output_console::display_output_console(const std::string &name_)
-    : display_output_base(name_) {
-  // lowest priority, it's a fallback
-  priority = 0;
-}
+    : display_output_base(name_) {}
 
 bool display_output_console::detect() {
   if ((out_to_stdout.get(*state) || out_to_stderr.get(*state))

--- a/src/display-file.cc
+++ b/src/display-file.cc
@@ -56,8 +56,6 @@ void register_output<output_t::FILE>(display_outputs_t &outputs) {
 
 display_output_file::display_output_file(const std::string &name_)
     : display_output_base(name_) {
-  // lowest priority, it's a fallback
-  priority = 0;
 }
 
 bool display_output_file::detect() {

--- a/src/display-http.cc
+++ b/src/display-http.cc
@@ -127,7 +127,6 @@ std::string string_replace_all(std::string original, const std::string &oldpart,
 //}  // namespace priv
 
 display_output_http::display_output_http() : display_output_base("http") {
-  priority = 0;
   httpd = NULL;
 }
 

--- a/src/display-ncurses.cc
+++ b/src/display-ncurses.cc
@@ -91,9 +91,7 @@ Colour from_ncurses(int nccolor) {
 }
 
 display_output_ncurses::display_output_ncurses()
-    : display_output_console("ncurses") {
-  priority = 1;
-}
+    : display_output_console("ncurses") {}
 
 bool display_output_ncurses::detect() {
   if (out_to_ncurses.get(*state)) {

--- a/src/display-output.hh
+++ b/src/display-output.hh
@@ -61,16 +61,10 @@ class display_output_base {
   const std::string name;
   bool is_active = false;
   bool is_graphical = false;
-  int priority = -1;
 
   explicit display_output_base(const std::string &name) : name(name){};
 
   virtual ~display_output_base() {}
-
-  static bool priority_compare(const display_output_base *a,
-                               const display_output_base *b) {
-    return a->priority > b->priority;
-  }
 
   // check if available and enabled in settings
   virtual bool detect() { return false; }

--- a/src/display-wayland.cc
+++ b/src/display-wayland.cc
@@ -243,7 +243,6 @@ void register_output<output_t::WAYLAND>(display_outputs_t &outputs) {
 display_output_wayland::display_output_wayland()
     : display_output_base("wayland") {
   is_graphical = true;
-  priority = 3;
 }
 
 bool display_output_wayland::detect() {

--- a/src/display-wayland.cc
+++ b/src/display-wayland.cc
@@ -243,7 +243,7 @@ void register_output<output_t::WAYLAND>(display_outputs_t &outputs) {
 display_output_wayland::display_output_wayland()
     : display_output_base("wayland") {
   is_graphical = true;
-  priority = 2;
+  priority = 3;
 }
 
 bool display_output_wayland::detect() {

--- a/src/display-x11.cc
+++ b/src/display-x11.cc
@@ -226,7 +226,6 @@ void register_output<output_t::X11>(display_outputs_t &outputs) {
 
 display_output_x11::display_output_x11() : display_output_base("x11") {
   is_graphical = true;
-  priority = 2;
 }
 
 bool display_output_x11::detect() {


### PR DESCRIPTION
This fix a problem caused by 6adf6b9dd4d368640bf7ef57f3e6199d83154d78:

The display outputs are sorted by priority on src/display-output.cc.

Before the cleanup commit, Wayland was choosed instead of X11. But no thanks to any explicit code. Just because outputs was inserted luckily in the correct order, before the sort.


Because out_to_x is true, and out_to_wayland is false by default, it means the users have to enable explicitely wayland on their config.

We should rather prefer Wayland because it need explicit configuration.


To do so, I think we should define that Wayland priority surpass the X11 one, instead of fixing the register_output order.


(There is yet another issue with Wayland output at the moment (caused by https://github.com/brndnmtthws/conky/pull/1876#issuecomment-2525044908). I'm investigating it. And hopefully, two patch are needed to fix most of the Wayland related tickets)

# Checklist
- [X] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [ ] Documentation in `doc/` has been updated
- [X] All new code is licensed under GPLv3
