### PR TITLE
Revert "Use private mapping from provided shm_pool buffer"

### DIFF
--- a/src/display-wayland.cc
+++ b/src/display-wayland.cc
@@ -1055,7 +1055,7 @@ static struct wl_shm_pool *make_shm_pool(struct wl_shm *shm, int size,
     return NULL;
   }
 
-  *data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
+  *data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
   if (*data == MAP_FAILED) {
     fprintf(stderr, "mmap failed: %m\n");
     close(fd);


### PR DESCRIPTION
This reverts commit b486263b27c6c13a14a89d0940c74b19a7a63940, as suggested by @stacyharper in #2103.

It was guided by wrong part of documentation ([`wl_keyboard::keymap`](https://wayland.app/protocols/wayland#wl_keyboard:event:keymap)).

I can confirm it closes #1960, as conky now shows up for me on wayland.
Re-opens #1824.