### PR TITLE
Add blame ignore file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -48,6 +48,9 @@ c6ad28074af3ec1bb4b3cc052df58062ce2a7c9b
 ### Fix issues building without BUILD_ARGB flag
 # Changes a lot of indentations in x11.cc
 f6d42c5a69fed134a8b4ed0602c892f6f7b6e242
+### Fix DependentOptions splitting arguments on spaces
+# Again, indentation changes in x11.cc
+cbebe447078e28c50957d568303f42d6b8aae126
 
 ### Cleanup build flags, global namespace and includes (#1841)
 # Large refactor of global namespace

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,56 @@
+# Run this command to always ignore formatting commits in `git blame`
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Following commits only reformat/cleanup code and can be ignored when tracking
+# down regressions and introduced bugs:
+
+### Clarifying licensing (SVN@904)
+# Updates license headers
+27b4c8550cfae4fd0f2169962e33f4907a8e7d71
+
+### Reformatted all code (SVN@1007)
+3d26a4880e92df2c6004d85c1be458e35c6bfc3a
+
+### outsource the whole template object machinery
+# Moves template variables code from core.c into template.c
+ff199355f66216600c4bdc6bec4743afe5b61470
+
+### Add formatting/static analysis (#486)
+# Large cleanup of codebase that fixed indentation in most files
+eebc8c653b34eb946d23ceb913ed5d69cc22f10e
+
+### Build improvements: clang-tidy, sonar, Dockerfile. (#488)
+# Touches most files with minor changes (NULL -> nullptr)
+4b92556fca9cbede3cbac4112f0a24b554390099
+
+### Use clang-format
+# Applies clang-format formatting
+033508a93e6b0440ddbd2376c1e97b69e3308687
+
+### Move X11 stuff from conky.cc to display-x11
+281097a2a562ef58e5604a3519f739c715ba5410
+
+### Get rid of silly `if (not ...` expressions (#713)
+3a3092902ee8a5fda71996d264f981b98375c6a3
+
+### Fix docbook2x handling.
+# Large diff, affects only docbook2x which is no longer used
+c6ad28074af3ec1bb4b3cc052df58062ce2a7c9b
+
+### Fix MAINTAINER_MODE (-Wall -Werror -Wpedantic) (#714)
+# Large diff, minor refactoring changes
+9af6fa7903c5cb6f05614deac23373d4d0cf5959
+
+### Refactor docs, make a new website
+# Large diff, no changes affecting code
+47ad3f9982baea4069a5c37ffdb2e1523e504f18
+
+### Fix issues building without BUILD_ARGB flag
+# Changes a lot of indentations in x11.cc
+f6d42c5a69fed134a8b4ed0602c892f6f7b6e242
+
+### Cleanup build flags, global namespace and includes (#1841)
+# Large refactor of global namespace
+# Includes changes to functionality so it can't be ignored:
+# color parsing, text alignment, output registration
+# 6adf6b9dd4d368640bf7ef57f3e6199d83154d78

--- a/extras/git_ranked.py
+++ b/extras/git_ranked.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+import subprocess
+
+def get_first_number(s):
+    number = ""
+    found_digit = False
+
+    for char in s:
+        if char.isdigit():
+            number += char
+            found_digit = True
+        elif found_digit:
+            break
+
+    return int(number) if number else None
+
+
+def git_log():
+    entries = []
+    try:
+        result = subprocess.run(
+            ["git", "log", "--no-merges", "--shortstat", "--pretty=format:%H %n %s"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=True,
+        )
+        entries = result.stdout.split("\n\n")
+    except subprocess.CalledProcessError as e:
+        print(f"Error running git command: {e.stderr}")
+        return []
+
+    commits = []
+    for line in entries:
+        info = line.split("\n")
+        changes = info[2].split(",")
+        files_changed = get_first_number(changes[0])
+        insertions = 0
+        deletions = 0
+        if len(changes) > 1:
+            if "insertions" in changes[1]:
+                insertions = get_first_number(changes[1])
+            elif "deletions" in changes[1]:
+                deletions = get_first_number(changes[1])
+        if len(changes) > 2:
+            if "insertions" in changes[2]:
+                insertions = get_first_number(changes[2])
+            elif "deletions" in changes[2]:
+                deletions = get_first_number(changes[2])
+        commit = {
+            "hash": info[0].strip(),
+            "message": info[1].strip(),
+            "changes": {
+                "files": files_changed,
+                "insertions": insertions,
+                "deletions": deletions,
+            },
+        }
+        commits.append(commit)
+
+    return commits
+
+def main():
+    log = git_log()
+    if len(log) == 0:
+        return
+
+    large_changes = sorted(log, key=lambda it: it["changes"]["insertions"] + it["changes"]["deletions"], reverse=True)
+
+    print(f"{'Hash':41} {'Insertions':11} {'Deletions':11} {'Message'}")
+    print("-" * 90)
+    for commit in large_changes:
+        print(
+            f"{commit['hash']:41} {commit["changes"]['insertions']:11} {commit["changes"]['deletions']:11} {commit['message']}"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Also added a small utility script in extras to aid in maintainence of the file.

This file, when enabled with `git config blame.ignoreRevsFile .git-blame-ignore-revs`, allows `git blame` to produce outputs without commits that don't affect functionality (e.g. refactors, indentation changes, etc.).