### PR TITLE
wayland: fix clean_text bug

### DIFF
--- a/src/display-wayland.cc
+++ b/src/display-wayland.cc
@@ -926,6 +926,7 @@ void display_output_wayland::clear_text(int exposures) {
   cairo_set_operator(window->cr, CAIRO_OPERATOR_CLEAR);
   cairo_rectangle(window->cr, 0, 0, window->rectangle.width(),
                   window->rectangle.height());
+  cairo_fill(window->cr);
   cairo_restore(window->cr);
 }
 


### PR DESCRIPTION
The current wayland display's clean_text function is missing cairo_fill to actually clear the background, causing the text to overlap.

The cairo_rectangle just adds a sub-path rectangle and doesn't draw , you need to call cairo_fill to actually draw it.
