### PR TITLE
Update build.sh for switch to newer appimagetool

### DIFF
--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -78,7 +78,7 @@ chmod +x linuxdeploy-x86_64.AppImage
   -i AppDir/usr/share/icons/hicolor/scalable/apps/conky-logomark-violet.svg \
   -d AppDir/usr/share/applications/conky.desktop
 
-wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+wget https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
 
 chmod +x appimagetool-x86_64.AppImage
 


### PR DESCRIPTION
Update build.sh for switch to newer appimagetool, it helps to use conky on non-glibc systems

https://github.com/AppImage/AppImageKit/issues/877#issuecomment-2564702332

# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [ ] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

* Describe the changes, why they were necessary, etc
* Describe how the changes will affect existing behaviour.
* Describe how you tested and validated your changes.
* Include any relevant screenshots/evidence demonstrating that the changes work and have been tested.
