### PR TITLE
Compile cairo_xlib Lua bindings as MODULE

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -126,16 +126,6 @@ cairo:
           - src/data/hardware/diskio.cc
           - src/data/hardware/diskio.h
 
-'power':
-  - changed-files:
-      - any-glob-to-any-file:
-          - src/data/hardware/apcupsd.cc
-          - src/data/hardware/apcupsd.h
-          - src/data/hardware/bsdapm.cc
-          - src/data/hardware/bsdapm.h
-          - src/data/hardware/smapi.cc
-          - src/data/hardware/smapi.h
-
 'sensors':
   - changed-files:
       - any-glob-to-any-file:

--- a/lua/CMakeLists.txt
+++ b/lua/CMakeLists.txt
@@ -48,7 +48,7 @@ if(BUILD_LUA_CAIRO_XLIB)
   link_directories(${X11_SM_LIB_PATH})
   wrap_tolua(luacairoxlib_src cairo_xlib.pkg)
 
-  add_library(conky-cairo_xlib SHARED ${luacairoxlib_src})
+  add_library(conky-cairo_xlib MODULE ${luacairoxlib_src})
   set_target_properties(conky-cairo_xlib PROPERTIES OUTPUT_NAME "cairo_xlib")
 
   target_link_libraries(conky-cairo_xlib


### PR DESCRIPTION
AFAIK this only affects macOS.