### PR TITLE
Check whether first_colour is set before using it as foreground color

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1398,8 +1398,10 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
             }
 #ifdef BUILD_MATH
             if (show_graph_scale.get(*state) && (current->show_scale == 1)) {
-              // Set the foreground colour to the first colour, ensures the scale text is always drawn in the same colour
-              set_foreground_color(current->first_colour);
+              if (current->colours_set) {
+                  // Set the foreground colour to the first colour, ensures the scale text is always drawn in the same colour
+                  set_foreground_color(current->first_colour);
+              }
               int tmp_x = cur_x;
               int tmp_y = cur_y;
               cur_x += font_ascent() / 2;


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [ ] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

For several months now, the first color of a graph's gradient is also being used as the foreground color, but without properly checking whether the gradient colors are actually set. If they are not, the scale text of the graph is set to black instead of the default color:
![immagine](https://github.com/user-attachments/assets/9399840a-44fa-43a3-8113-004154e94bee)


With this change, the scale text correctly follows the default color:
![immagine](https://github.com/user-attachments/assets/ece18f45-8317-4f39-a4bf-fc459a1c0725)


(I don't think the documentation needs an update, but I will do it if requested)