### PR TITLE
Added multi pointer support

### DIFF
--- a/src/mouse-events.cc
+++ b/src/mouse-events.cc
@@ -243,7 +243,7 @@ device_info *device_info::from_xi_id(xi_device_id device_id, Display *display) {
   }
 
   device_info info =
-      device_info{.id = device_id, .master = master, .name = std::string(device->name)};
+      device_info{device_id, master, std::string(device->name)};
 
   size_t id = last_device_id++;
   info.init_xi_device(display, device);

--- a/src/mouse-events.cc
+++ b/src/mouse-events.cc
@@ -233,8 +233,17 @@ device_info *device_info::from_xi_id(xi_device_id device_id, Display *display) {
   XIDeviceInfo *device = XIQueryDevice(display, device_id, &num_devices);
   if (num_devices == 0) return nullptr;
 
+  int master;
+  
+  if(device->use == XIMasterPointer){
+    master = device->deviceid;
+  }
+  else{
+    master = device->attachment;
+  }
+
   device_info info =
-      device_info{.id = device_id, .name = std::string(device->name)};
+      device_info{.id = device_id, .master = master, .name = std::string(device->name)};
 
   size_t id = last_device_id++;
   info.init_xi_device(display, device);

--- a/src/mouse-events.h
+++ b/src/mouse-events.h
@@ -282,6 +282,7 @@ struct conky_valuator_info {
 struct device_info {
   /// @brief Device name.
   xi_device_id id;
+  xi_device_id master;
   std::string name;
   std::array<conky_valuator_info, VALUATOR_COUNT> valuators{};
 

--- a/src/output/display-x11.cc
+++ b/src/output/display-x11.cc
@@ -453,7 +453,7 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
   }
   *cookie = data;
 
-  Window event_window = query_x11_window_at_pos(display, data->pos_absolute);
+  Window event_window = query_x11_window_at_pos(display, data->pos_absolute, data->device->master);
 
   bool same_window = query_x11_top_parent(display, event_window) ==
                      query_x11_top_parent(display, window.window);

--- a/src/output/x11.cc
+++ b/src/output/x11.cc
@@ -1498,19 +1498,32 @@ std::vector<Window> query_x11_windows(Display *display, bool eager) {
   return result;
 }
 
-Window query_x11_window_at_pos(Display *display, conky::vec2i pos, int deviceid) {
+Window query_x11_window_at_pos(Display *display, conky::vec2i pos, int device_id) {
+  (void) device_id;
   Window root = DefaultVRootWindow(display);
 
-  // these values are ignored but NULL can't be passed to XQueryPointer.
+  
   Window root_return;
+  Window last = None;
+
+  #ifdef BUILD_XINPUT
+  // these values are ignored but NULL can't be passed to XIQueryPointer.
   double root_x_return, root_y_return, win_x_return, win_y_return;
   XIButtonState buttons_return;
   XIModifierState modifiers_return;
   XIGroupState group_return;
 
-  Window last = None;
-  XIQueryPointer(display,deviceid, window.root, &root_return, &last, &root_x_return,
+  
+  XIQueryPointer(display,device_id, window.root, &root_return, &last, &root_x_return,
                 &root_y_return, &win_x_return, &win_y_return, &buttons_return, &modifiers_return, &group_return);
+  #else
+  // these values are ignored but NULL can't be passed to XQueryPointer.
+  int root_x_return, root_y_return, win_x_return, win_y_return;
+  unsigned int mask_return;
+
+  XQueryPointer(display, window.root, &root_return, &last, &root_x_return,
+                &root_y_return, &win_x_return, &win_y_return, &mask_return);
+  #endif
 
   if (last == 0) return root;
   return last;

--- a/src/output/x11.cc
+++ b/src/output/x11.cc
@@ -1498,17 +1498,19 @@ std::vector<Window> query_x11_windows(Display *display, bool eager) {
   return result;
 }
 
-Window query_x11_window_at_pos(Display *display, conky::vec2i pos) {
+Window query_x11_window_at_pos(Display *display, conky::vec2i pos, int deviceid) {
   Window root = DefaultVRootWindow(display);
 
   // these values are ignored but NULL can't be passed to XQueryPointer.
   Window root_return;
-  int root_x_return, root_y_return, win_x_return, win_y_return;
-  unsigned int mask_return;
+  double root_x_return, root_y_return, win_x_return, win_y_return;
+  XIButtonState buttons_return;
+  XIModifierState modifiers_return;
+  XIGroupState group_return;
 
   Window last = None;
-  XQueryPointer(display, window.root, &root_return, &last, &root_x_return,
-                &root_y_return, &win_x_return, &win_y_return, &mask_return);
+  XIQueryPointer(display,deviceid, window.root, &root_return, &last, &root_x_return,
+                &root_y_return, &win_x_return, &win_y_return, &buttons_return, &modifiers_return, &group_return);
 
   if (last == 0) return root;
   return last;

--- a/src/output/x11.h
+++ b/src/output/x11.h
@@ -157,8 +157,9 @@ Window query_x11_top_parent(Display *display, Window child);
 /// @param display display of parent
 /// @param x screen X position contained by window
 /// @param y screen Y position contained by window
+/// @param device_id pointer device id to be queried (will be ignored if BUILD_XINPUT is disabled)
 /// @return a top-most window at provided screen coordinates, or root
-Window query_x11_window_at_pos(Display *display, conky::vec2i pos, int deviceid);
+Window query_x11_window_at_pos(Display *display, conky::vec2i pos, int device_id);
 
 /// @brief Returns a list of windows overlapping provided screen coordinates.
 ///

--- a/src/output/x11.h
+++ b/src/output/x11.h
@@ -158,7 +158,7 @@ Window query_x11_top_parent(Display *display, Window child);
 /// @param x screen X position contained by window
 /// @param y screen Y position contained by window
 /// @return a top-most window at provided screen coordinates, or root
-Window query_x11_window_at_pos(Display *display, conky::vec2i pos);
+Window query_x11_window_at_pos(Display *display, conky::vec2i pos, int deviceid);
 
 /// @brief Returns a list of windows overlapping provided screen coordinates.
 ///


### PR DESCRIPTION
Conky currently can't handle a second master pointer device. The second master only works while the main master is in the conky window. Reason for the change was a touchscreen as system monitor.

My changes are mainly a replacement of XQueryPointer with XIQueryPointer to be able to select the window with a device id.