### PR TITLE
Add #include <cstdint> to fix building with gcc 15

### DIFF
--- a/src/content/colours.hh
+++ b/src/content/colours.hh
@@ -34,6 +34,7 @@
 
 #include <cassert>
 #include <climits>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>


### PR DESCRIPTION
With gcc 15, the C++ Standard Library no longer includes other headers that were internally used by the library. In conky's case the missing header is `<cstdint>`

Downstream Gentoo bug: https://bugs.gentoo.org/939667

```
FAILED: src/CMakeFiles/conky.dir/colours.cc.o 
/usr/bin/x86_64-pc-linux-gnu-g++ -D_LARGEFILE64_SOURCE -D_POSIX_C_SOURCE=200809L -I/var/tmp/portage/app-admin/conky-1.21.5/work/conky-1.21.5/3rdparty/toluapp/include -I/var/tmp/portage/app-admin/conky-1.21.5/work/conky-1.21.5_build -I/usr/include/lua5.4 -I/var/tmp/portage/app-admin/conky-1.21.5/work/conky-1.21.5/3rdparty/Vc -I/var/tmp/portage/app-admin/conky-1.21.5/work/conky-1.21.5_build/src -I/var/tmp/portage/app-admin/conky-1.21.5/work/conky-1.21.5_build/data  -O2 -pipe -march=native -fno-diagnostics-color -O3 -g -std=c++17 -fno-diagnostics-color -MD -MT src/CMakeFiles/conky.dir/colours.cc.o -MF src/CMakeFiles/conky.dir/colours.cc.o.d -o src/CMakeFiles/conky.dir/colours.cc.o -c /var/tmp/portage/app-admin/conky-1.21.5/work/conky-1.21.5/src/colours.cc
In file included from /var/tmp/portage/app-admin/conky-1.21.5/work/conky-1.21.5/src/colours.cc:30:
/var/tmp/portage/app-admin/conky-1.21.5/work/conky-1.21.5/src/colours.h:46:3: error: ‘uint8_t’ does not name a type
   46 |   uint8_t red;
      |   ^~~~~~~
```

# Checklist
- [x] I have described the changes
- [ ] I have linked to any relevant GitHub issues, if applicable
- [ ] Documentation in `doc/` has been updated
- [ ] All new code is licensed under GPLv3
