### PR TITLE
Install syntax files

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -38,7 +38,5 @@ if(BUILD_DOCS)
 
     install(FILES ${DOC_FILES} DESTINATION ${DOC_PATH})
 
-    if(BUILD_DOCS)
-        install(FILES ${MAN_FILES} DESTINATION ${MAN_PATH})
-    endif(BUILD_DOCS)
+    install(FILES ${MAN_FILES} DESTINATION ${MAN_PATH})
 endif(BUILD_DOCS)

--- a/extras/CMakeLists.txt
+++ b/extras/CMakeLists.txt
@@ -29,6 +29,7 @@ add_custom_target(conky.nanorc
     ${CMAKE_SOURCE_DIR}/doc/lua.yaml
     ${CMAKE_CURRENT_SOURCE_DIR}/nano/conky.nanorc.j2
 )
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/nano/conky.nanorc DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/nano)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/vim/syntax)
 add_custom_target(conkyrc.vim
     ALL
@@ -40,3 +41,4 @@ add_custom_target(conkyrc.vim
     ${CMAKE_SOURCE_DIR}/doc/lua.yaml
     ${CMAKE_CURRENT_SOURCE_DIR}/vim/syntax/conkyrc.vim.j2
 )
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/vim/syntax/conkyrc.vim DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/vim/syntax)


### PR DESCRIPTION
I've been [updating the `conky` derivation in nixpkgs](https://github.com/NixOS/nixpkgs/pull/400497) and in the process I've also added support for the BUILD_EXTRAS flag.
However, I noticed that the generated syntax files are not installed, so they are basically "lost" inside the Nix build sandbox unless I [move them manually](https://github.com/NixOS/nixpkgs/pull/400497/commits/ad47f62d64fda487ecc35109861b801f4da1ed59). I think it would be reasonable to just install them by default.

Tested by using this branch as the source for the updated nixpkgs derivation.

I'm not sure if this needs a doc update?

# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [ ] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

* Describe the changes, why they were necessary, etc
* Describe how the changes will affect existing behaviour.
* Describe how you tested and validated your changes.
* Include any relevant screenshots/evidence demonstrating that the changes work and have been tested.
