### PR TITLE
doc: Fix mismatched backticks

### DIFF
--- a/doc/config_settings.yaml
+++ b/doc/config_settings.yaml
@@ -500,7 +500,7 @@ values:
   - name: pop3
     desc: |-
       Default global POP3 server. Arguments are: `host user pass
-      [-i interval (in seconds)] [-p port] [-e 'command'] [-r retries]\".
+      [-i interval (in seconds)] [-p port] [-e 'command'] [-r retries]`.
       Default port is 110, default interval is 5 minutes, and default number
       of retries before giving up is 5. If the password is supplied as '*',
       you will be prompted to enter the password when Conky starts.

--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -809,7 +809,7 @@ values:
       Hwmon sensor from sysfs (Linux 2.6). Parameter dev can be:
       1. Number. e.g `1` means hwmon1.
       2. Module name. e.g. `k10temp` means the first hwmon device whose module
-      name is `k10temp.
+      name is `k10temp`.
       3. Omitted. Then the first hwmon device (hwmon0) will be used.
 
       Parameter type is either `in` or `vol` meaning voltage; `fan` meaning fan;


### PR DESCRIPTION
This is really very minor, but I was looking into the pandoc/LaTeX warnings about backticks and although the original issue seems to be fairly unavoidable, I found these mismatches that might as well be fixed.

# Checklist
- [x] I have described the changes
- [ ] I have linked to any relevant GitHub issues, if applicable
- [ ] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

* Describe the changes, why they were necessary, etc
* Describe how the changes will affect existing behaviour.
* Describe how you tested and validated your changes.
* Include any relevant screenshots/evidence demonstrating that the changes work and have been tested.
