### PR TITLE
Improve X11 strut handling

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -11,6 +11,9 @@
 ### Reformatted all code (SVN@1007)
 3d26a4880e92df2c6004d85c1be458e35c6bfc3a
 
+# Spelling fixes
+b62e1158300f0644b304f2f8b7e8105ba09073b3
+
 ### outsource the whole template object machinery
 # Moves template variables code from core.c into template.c
 ff199355f66216600c4bdc6bec4743afe5b61470

--- a/cmake/ConkyBuildOptions.cmake
+++ b/cmake/ConkyBuildOptions.cmake
@@ -94,12 +94,12 @@ option(BUILD_EXTRAS "Build extras (includes syntax files for editors)" false)
 
 option(BUILD_I18N "Enable if you want internationalization support" true)
 
-option(BUILD_COLOUR_NAME_MAP "Include mappings of colour name -> RGB (e.g. red -> ff0000)" true)
-
 if(BUILD_I18N)
   set(LOCALE_DIR "${CMAKE_INSTALL_PREFIX}/share/locale"
     CACHE STRING "Directory containing the locales")
 endif(BUILD_I18N)
+
+option(BUILD_COLOUR_NAME_MAP "Include mappings of colour name -> RGB (e.g. red -> ff0000)" true)
 
 # Some standard options
 set(SYSTEM_CONFIG_FILE "/etc/conky/conky.conf"
@@ -157,6 +157,8 @@ cmake_dependent_option(
   "Enable cpu freq calculation based on Intel® Power Gadget; otherwise use constant factory value"
   false
   "OS_DARWIN" false)
+
+option(ENABLE_RUNTIME_TWEAKS "Enable runtime environment checks for better system integration" true)
 
 # Optional features etc
 option(BUILD_WLAN "Enable wireless support" false)

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -50,6 +50,8 @@
 
 #cmakedefine OWN_WINDOW 1
 
+#cmakedefine ENABLE_RUNTIME_TWEAKS 1
+
 #cmakedefine BUILD_MOUSE_EVENTS 1
 
 #cmakedefine BUILD_XDAMAGE 1

--- a/doc/config_settings.yaml
+++ b/doc/config_settings.yaml
@@ -475,13 +475,16 @@ values:
         for background, icons and desktop menu, in those cases it might be
         better to use `normal` or one of the below options, as those will cover
         conky when they're clicked on.
-      - `dock` windows reserve space on the desktop, i.e. WMs will try their
-        best to not place windows on top of them. They're the same as `desktop`
-        in other respects, but render on top of `desktop` windows.
+      - `dock` windows are placed on screen edges. They're the same as `desktop`
+        in most respects, but render on top of `desktop` windows and below
+        `normal` ones. Docks don't reserve screen space.
       - `panel` windows are similar to `dock` windows, but they also reserve
-        space _along a desktop edge_ (like taskbars), preventing maximized
-        windows from overlapping them. The edge is chosen based on the
-        `alignment` setting.
+        space _along a workarea edge_ (like taskbars), preventing maximized
+        windows from overlapping them. The edge is chosen based on final conky
+        position and size, and workarea dimensions, to ensure normal windows
+        have most free space available. For WMs that "cut out" entirely covered
+        screens from reserved area, the edge will be chosen based on `alignment`
+        setting.
       - `utility` windows are persistent utility windows (e.g. a palette or
         toolbox). They appear on top of other windows (in the same group), but
         otherwise behave much like `normal` windows.

--- a/doc/config_settings.yaml
+++ b/doc/config_settings.yaml
@@ -477,7 +477,8 @@ values:
         conky when they're clicked on.
       - `dock` windows are placed on screen edges. They're the same as `desktop`
         in most respects, but render on top of `desktop` windows and below
-        `normal` ones. Docks don't reserve screen space.
+        `normal` ones. Conky doesn't define struts for this window type, but
+        some WMs might still implicitly avoid placing windows on top of it.
       - `panel` windows are similar to `dock` windows, but they also reserve
         space _along a workarea edge_ (like taskbars), preventing maximized
         windows from overlapping them. The edge is chosen based on final conky

--- a/src/common.cc
+++ b/src/common.cc
@@ -743,11 +743,7 @@ int if_existing_iftest(struct text_object *obj) {
 }
 
 int if_running_iftest(struct text_object *obj) {
-#ifdef __linux__
-  if (!get_process_by_name(obj->data.s)) {
-#else
-  if (((obj->data.s) != nullptr) && (system(obj->data.s) != 0)) {
-#endif
+  if (!is_process_running(obj->data.s)) {
     return 0;
   }
   return 1;

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1804,8 +1804,12 @@ void get_system_details() {
   } else {
   unknown_session:
     info.system.wm = conky::info::window_manager::unknown;
-    NORM_ERR("unknown %s session running: %s", session_ty, info.system.wm_name);
-    return;
+
+    // probably a misconfigured system... let's attempt a few more things
+    if (getenv("CINNAMON_VERSION") != nullptr) {
+      info.system.wm_name = "Cinnamon";
+      info.system.wm = conky::info::window_manager::mutter;
+    }
   }
 #endif
 

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1810,6 +1810,12 @@ void get_system_details() {
       info.system.wm_name = "Cinnamon";
       info.system.wm = conky::info::window_manager::mutter;
     }
+
+    // TODO: Doesn't work yet. Process information is not yet populated.
+    if (is_process_running("openbox")) {
+      info.system.wm_name = "Openbox";
+      info.system.wm = conky::info::window_manager::openbox;
+    }
   }
 #endif
 

--- a/src/conky.h
+++ b/src/conky.h
@@ -372,6 +372,20 @@ int spaced_print(char *, int, const char *, int, ...)
     __attribute__((format(printf, 3, 5)));
 extern int inotify_fd;
 
+template <
+    typename Iterable = std::initializer_list<conky::info::window_manager>>
+inline bool wm_is(const Iterable &values) {
+  // if constexpr (!ENABLE_RUNTIME_TWEAKS) { return false; }
+  // can't assume unknown isn't in the list...
+  for (const auto &wm : values) {
+    if (info.system.wm == wm) return true;
+  }
+  return false;
+}
+inline bool wm_is(conky::info::window_manager single) {
+  return info.system.wm == single;
+}
+
 /* defined in conky.c
  * evaluates 'text' and places the result in 'p' of max length 'p_max_size'
  */

--- a/src/conky.h
+++ b/src/conky.h
@@ -31,7 +31,6 @@
 #define _conky_h_
 
 #include <cstddef>
-#include <iterator>
 #define __STDC_FORMAT_MACROS
 
 #include "config.h"

--- a/src/conky.h
+++ b/src/conky.h
@@ -30,6 +30,8 @@
 #ifndef _conky_h_
 #define _conky_h_
 
+#include <cstddef>
+#include <iterator>
 #define __STDC_FORMAT_MACROS
 
 #include "config.h"
@@ -157,6 +159,52 @@ char **get_templates(void);
  * needed by conky.c, linux.c and freebsd.c */
 enum { BATTERY_STATUS, BATTERY_TIME };
 
+namespace conky::info {
+
+// Don't guard enum values with #ifdef *_BUILD features; it will only make code
+// harder to maintain - size_t won't change in size.
+
+enum class display_session : std::size_t { unknown, x11, wayland };
+enum class window_manager : std::size_t {
+  unknown,
+
+  // X11
+  awesome,
+  bspwm,
+  compiz,
+  dde,  // Deepin
+  dwm,
+  enlightenment,
+  fluxbox,
+  herbstluftwm,
+  i3,
+  kwin,
+  marco,
+  metacity,
+  mutter,
+  openbox,
+  qtile,
+  xfwm,
+  windowmaker,
+
+  // Wayland (only)
+  hyprland,
+  river,
+  sway,
+  wayfire,
+
+  // Remember to update get_system_details when adding new ones!
+};
+
+struct system {
+  display_session session;
+
+  window_manager wm;
+  const char *wm_name;
+};
+
+}  // namespace conky::info
+
 struct information {
   unsigned int mask;
 
@@ -229,6 +277,11 @@ struct information {
   csr_config_t csr_config;
   csr_config_flags_t csr_config_flags;
 #endif /* defined(__APPLE__) && defined(__MACH__) */
+
+  /**
+   * @brief General information about the system currently running conky.
+   */
+  conky::info::system system;
 };
 
 class music_player_interval_setting

--- a/src/data/top.cc
+++ b/src/data/top.cc
@@ -29,6 +29,7 @@
  */
 
 #include "top.h"
+
 #include "../logging.h"
 #include "../prioqueue.h"
 
@@ -117,20 +118,23 @@ void free_all_processes() {
   unhash_all_processes();
 }
 
-struct process *get_process_by_name(const char *name) {
+struct process *get_process_by_name(std::string_view name) {
   struct process *p = first_process;
 
   while (p != nullptr) {
-    /* Try matching against the full command line first. If that fails,
-     * fall back to the basename.
-     */
-    if (((p->name != nullptr) && (strcmp(p->name, name) == 0)) ||
-        ((p->basename != nullptr) && (strcmp(p->basename, name) == 0))) {
+    // Try matching against the full command line first.
+    if (p->name != nullptr && name == p->name) { return p; }
+    // If matching against full command line fails, fall back to the basename.
+    if (p->basename != nullptr && name == p->basename) {
       return p;
     }
     p = p->next;
   }
+
   return nullptr;
+}
+bool is_process_running(std::string_view name) {
+  return get_process_by_name(name) != nullptr;
 }
 
 static struct process *find_process(pid_t pid) {

--- a/src/data/top.h
+++ b/src/data/top.h
@@ -42,7 +42,11 @@
 
 #include "../conky.h"
 #include "../content/text_object.h"
+
 #define CPU_THRESHHOLD 0 /* threshold for the cpu diff to appear */
+
+#include <string_view>
+
 #include <assert.h>
 #include <ctype.h>
 #include <dirent.h>
@@ -116,8 +120,21 @@ struct sorted_process {
   struct process *proc;
 };
 
-/* lookup a program by it's name */
-struct process *get_process_by_name(const char *);
+/**
+ * @brief Returns process information for specified `name`.
+ * 
+ * @param name full command line or base name of the process.
+ * @return struct process* containing usage details of a process. 
+ */
+struct process *get_process_by_name(std::string_view name);
+/**
+ * @brief Checks if a process is running.
+ *
+ * @param name full command line or base name of the process.
+ * @return `true` if process with given command line or base name is currently
+ *         running, `false` otherwise.
+ */
+bool is_process_running(std::string_view name);
 
 int parse_top_args(const char *s, const char *arg, struct text_object *obj);
 

--- a/src/output/display-x11.cc
+++ b/src/output/display-x11.cc
@@ -333,8 +333,10 @@ bool display_output_x11::main_loop_wait(double t) {
       }
 
       /* update struts */
-      if ((changed != 0) && own_window_type.get(*state) == window_type::PANEL) {
-        set_struts(text_alignment.get(*state));
+      if (changed != 0) {
+        auto window_type = own_window_type.get(*state);
+        // Openbox will implicitly set struts even for window_type::DOCK
+        if (window_type == window_type::PANEL) { set_struts(); }
       }
     }
 #endif

--- a/src/output/display-x11.cc
+++ b/src/output/display-x11.cc
@@ -334,7 +334,6 @@ bool display_output_x11::main_loop_wait(double t) {
 
       /* update struts */
       if ((changed != 0) && own_window_type.get(*state) == window_type::PANEL) {
-        NORM_ERR("defining struts");
         set_struts(text_alignment.get(*state));
       }
     }

--- a/src/output/gui.h
+++ b/src/output/gui.h
@@ -167,7 +167,6 @@ extern char window_created;
 
 void destroy_window(void);
 void create_gc(void);
-void set_struts(int);
 
 bool out_to_gui(lua::state &l);
 

--- a/src/output/x11.h
+++ b/src/output/x11.h
@@ -105,6 +105,11 @@ void destroy_window(void);
 void create_gc(void);
 void set_transparent_background(Window win);
 void get_x11_desktop_info(Display *current_display, Atom atom);
+/// @brief Sets reserved area atoms for the window to avoid other windows
+/// covering it.
+///
+/// Prints out a warning if user is using one of sessions that are known not to
+/// work.
 void set_struts(alignment alignment);
 void x11_init_window(lua::state &l, bool own);
 void deinit_x11();

--- a/src/output/x11.h
+++ b/src/output/x11.h
@@ -105,12 +105,12 @@ void destroy_window(void);
 void create_gc(void);
 void set_transparent_background(Window win);
 void get_x11_desktop_info(Display *current_display, Atom atom);
-/// @brief Sets reserved area atoms for the window to avoid other windows
+/// @brief Sets reserved area atoms for the conky window to avoid other windows
 /// covering it.
 ///
 /// Prints out a warning if user is using one of sessions that are known not to
 /// work.
-void set_struts(alignment alignment);
+void set_struts();
 void x11_init_window(lua::state &l, bool own);
 void deinit_x11();
 


### PR DESCRIPTION
This PR reworks strut code to use compute which side of the screen struts should be placed on for conky, regardless of alignment settings.

This makes more sense because it will always pick the side where windows will have most space left. Most WMs have very simplistic approach to calculating workarea (which is spec compliant):
- [Openbox](https://github.com/Mikachu/openbox/blob/dac6e2f6f8f2e0c5586a9e19f18508a03db639cb/openbox/screen.c#L1428)
- [Fluxbox](https://github.com/fluxbox/fluxbox/blob/88bbf811dade299ca2dac66cb81e4b3d96cfe741/src/HeadArea.cc#L72)
- [Mutter](https://gitlab.gnome.org/GNOME/mutter/-/blob/ea8b65d0c92ebf84060ea0b5c61d02fa9004e1e9/src/core/boxes.c#L564)
- [xfwm](https://github.com/xfce-mirror/xfwm4/blob/37636f55bcbca064e62489d7fe183ef7b9371b4c/src/placement.c#L220)

So this will avoid conky eating up too much space for those.

The [spec](https://specifications.freedesktop.org/wm-spec/1.4/ar01s05.html#id-1.6.11) says:
> ... All coordinates are root window coordinates. ...

I previously used workarea size for computing strut bounds, which is wrong if there's multiple panels with struts on the same display axis (they will be subtracted and the right/bottom aligned struts will be incorrectly placed).

EWMH spec [will likely never be changed](https://gitlab.freedesktop.org/xdg/xdg-specs/-/merge_requests/22) to allow for use cases such as #1917. Some WMs like KWin (KDE; Plasma) and compiz have special handling here and cut out screens from struts in case some strut covers entirety of them (#1917 use case works for those). Some simply _ignore_ the struts if they cover more than certain amount of screen space. See [details](https://gitlab.gnome.org/GNOME/mutter/-/issues/452).

In order to support WMs that _do_ handle cutout behaviors, I added system information to `info` - so now we can account for edge cases like this at runtime. There's also a build option to turn that off, but it's enabled by default to ensure default build works best for most people.

Closes: #2156, #1085, maybe #1961 and #2112.

Tested on single screen and behaves as expected on:
- Cinnamon (mutter), GNOME (mutter)
- XFCE (xfwm)
- Openbox
- KDE (KWin)

Updated the docs to fix the wrong `dock` description stating that dock reserves screen are when that isn't the case. New, WM-dependent behavior is also added to documentation.