### PR TITLE
Add error for missing wayland-scanner

### DIFF
--- a/cmake/ConkyPlatformChecks.cmake
+++ b/cmake/ConkyPlatformChecks.cmake
@@ -502,8 +502,11 @@ if(BUILD_WAYLAND)
 
     # find 'wayland-scanner' executable
     pkg_get_variable(Wayland_SCANNER wayland-scanner wayland_scanner)
+    if(NOT Wayland_SCANNER)
+      message(FATAL_ERROR "Unable to find wayland-scanner")
+    endif(NOT Wayland_SCANNER)
   else(Wayland_FOUND AND wayland-protocols_FOUND)
-    message(FATAL_ERROR "Unable to find wayland-scanner and xdg-shell protocol")
+    message(FATAL_ERROR "Unable to find wayland or wayland protocols")
   endif(Wayland_FOUND AND wayland-protocols_FOUND)
 
   if(OS_DARWIN OR OS_DRAGONFLY OR OS_FREEBSD OR OS_NETBSD OR OS_OPENBSD)


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [ ] I have linked to any relevant GitHub issues, if applicable
- [ ] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

I have fixed cross-compilation for conky in nixpkgs (to be reviewed/merged), but in the process I encountered a situation where wayland was found, but wayland-scanner was not. That allowed the configuration process to continue with just a warning, but then the build process failed when the wayland-scanner executable was not available. In my opinion it would be nicer to fail earlier, with a clear error message.

Tested locally as a patch applied to the nixpkgs derivation.
