### PR TITLE
Use WithdrawnState only for Fluxbox

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1771,6 +1771,7 @@ void get_system_details() {
     // Openbox doesn't set any session name env variables; must be set manually
     info.system.wm = conky::info::window_manager::openbox;
   } else if (!is_wayland() && is_session("Fluxbox")) {
+    // Fluxbox doesn't set any session name env variables; must be set manually 
     info.system.wm = conky::info::window_manager::fluxbox;
   } else if (!is_wayland() && (is_session("i3", "i3wm"))) {
     info.system.wm = conky::info::window_manager::i3;

--- a/src/output/x11.cc
+++ b/src/output/x11.cc
@@ -638,13 +638,18 @@ void x11_init_window(lua::state &l, bool own) {
         }
       }
 #endif /* BUILD_XSHAPE */
+      wmHint.initial_state = NormalState;
       if (own_window_type.get(l) == window_type::DOCK ||
           own_window_type.get(l) == window_type::PANEL) {
-        // Docks and panels MUST have WithdrawnState initially
+        // Docks and panels MUST have WithdrawnState initially for Fluxbox to
+        // move the window into the slit area.
         // See: https://github.com/brndnmtthws/conky/issues/2046
-        wmHint.initial_state = WithdrawnState;
-      } else {
-        wmHint.initial_state = NormalState;
+        // But most other WMs will explicitly ignore windows in WithdrawnState
+        // See: https://github.com/brndnmtthws/conky/issues/2112
+        // So we must resort to checking for WM at runtime
+        if (info.system.wm == conky::info::window_manager::fluxbox) {
+          wmHint.initial_state = WithdrawnState;
+        }
       }
 
       XmbSetWMProperties(display, window.window, nullptr, nullptr, argv_copy,


### PR DESCRIPTION
Openbox completely ignores all atoms set for Conky window if it's started in WithdrawnState. Fluxbox requires docks to be started like this.

Documentation doesn't really state when WithdrawnState should be used, but in general it means "window isn't managed by WM" (based on CPAN docs). We want normal windows (not override) to be managed by the WM, so NormalState is probably a better default for dock and panel windows.

Closes #2112.