### PR TITLE
Added a check to verify if the script path is absolute or not.

### DIFF
--- a/src/lua/llua.cc
+++ b/src/lua/llua.cc
@@ -267,7 +267,21 @@ inline bool file_exists(const char *path) {
 void llua_load(const char *script) {
   int error;
 
-  std::filesystem::path path = to_real_path(script);
+  std::filesystem::path path;
+  std::filesystem::path script_path(script);
+  
+  if (!script_path.is_absolute()) {
+    auto cfg_path = std::filesystem::path(to_real_path(XDG_CONFIG_FILE));
+    auto cfg_dir  = cfg_path.parent_path();
+
+    // prepend the config directory to the script path
+    auto full = cfg_dir / script_path;
+    path = to_real_path(full.c_str());
+  }
+  else {
+    // Already an absolute path
+    path = to_real_path(script);
+  }
 
   if (!file_exists(path.c_str())) {
     bool found_alternative = false;


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [ ] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

#2192 

Added a check to verify if the script path is absolute or not as it is buggy when you use '-c' cli argument to change `conky.conf`'s file location to anywhere other than `.config`. View the issue for more information.

It also builds correctly.