### PR TITLE
Fix detection of postmaretOs in /etc/os-release parsing

### DIFF
--- a/src/data/os/linux.cc
+++ b/src/data/os/linux.cc
@@ -2793,10 +2793,26 @@ void print_distribution(struct text_object *obj, char *p,
   char *buf;
   struct stat sb;
 
+if ((buf = readfile("/etc/os-release", &bytes_read, 1))) {
+    fprintf(stderr, "DEBUG: /etc/os-release loaded: %.*s\n", bytes_read, buf);
+    if (strstr(buf, "ID=\"postmarketos\"")) { 
+    snprintf(p, p_max_size, "%s", "postmarketOS");
+        free(buf);
+        return;
+    }
+    free(buf);
+} else {
+    fprintf(stderr, "DEBUG: /etc/os-release read failed!\n");
+}
+
+
   if (stat("/etc/arch-release", &sb) == 0) {
     snprintf(p, p_max_size, "%s", "Arch Linux");
     return;
   }
+
+
+
   snprintf(p, p_max_size, "Unknown");
   buf = readfile("/proc/version", &bytes_read, 1);
   if (buf) {


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [ ] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

This fixes the reported issue #2211 where the distro name was incorrectly displayed as AlpineOs) instead of postmarketOS
Output logs and console output confirm the correct display of the distro name.
![image](https://github.com/user-attachments/assets/6ba90de0-50c8-4d7a-8483-793c6d4e1ba4)

