### PR TITLE
Handle paths for lua_load

### DIFF
--- a/src/lua/llua.cc
+++ b/src/lua/llua.cc
@@ -215,7 +215,7 @@ void llua_init() {
     }
 
     auto parent_path = current_config.parent_path();
-    if (xdg_path != parent_path && stat(path_ext.c_str(), &file_stat) == 0) {
+    if (xdg_path != parent_path && stat(parent_path.c_str(), &file_stat) == 0) {
       path_ext.append(parent_path);
       path_ext.append("/?.lua");
       path_ext.push_back(';');
@@ -269,18 +269,21 @@ void llua_load(const char *script) {
 
   std::filesystem::path path;
   std::filesystem::path script_path(script);
-  
-  if (!script_path.is_absolute()) {
-    auto cfg_path = std::filesystem::path(to_real_path(XDG_CONFIG_FILE));
-    auto cfg_dir  = cfg_path.parent_path();
 
-    // prepend the config directory to the script path
-    auto full = cfg_dir / script_path;
-    path = to_real_path(full.c_str());
-  }
-  else {
-    // Already an absolute path
-    path = to_real_path(script);
+  path = to_real_path(script); // handles ~/some/path.lua
+  if (!file_exists(path.c_str())) {
+    if (!script_path.is_absolute()) {
+      auto cfg_path = std::filesystem::path(to_real_path(XDG_CONFIG_FILE));
+      auto cfg_dir  = cfg_path.parent_path();
+  
+      // prepend the config directory to the script path
+      auto full = cfg_dir / script_path;
+      path = to_real_path(full.c_str());
+    }
+    else {
+      // Already an absolute path
+      path = to_real_path(script);
+    }
   }
 
   if (!file_exists(path.c_str())) {


### PR DESCRIPTION
# Checklist

- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [ ] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

Change in llua_init:
Calling `stat` on `path_ext` probably was an error. Check `parent_path` instead like we did with `xdg_path` before we append it to `path_ext`.

In `llua_load` (better to see with [no white space diff](https://github.com/brndnmtthws/conky/commit/27cbc3b2e21532c2d0e0ebc5c28cc408ef92c27c?w=1)) first try to make script path absolute in case it starts with ~.
With this conky handles all four variants:
```
lua_load = "/home/user/.conky/helper.lua",
lua_load = "$HOME/.conky/helper.lua",
lua_load = "~/.conky/helper.lua",
lua_load = "helper.lua",
```
Fixes #2226
Compiled with `cmake --build build` and tested.
