### PR TITLE
Add debug AppImage

### DIFF
--- a/.github/workflows/publish-appimage.yml
+++ b/.github/workflows/publish-appimage.yml
@@ -30,6 +30,9 @@ jobs:
           - ubuntu-24.04
         arch:
           - x86_64
+        mode:
+          - debug
+          - release
     permissions:
       contents: write
       discussions: write
@@ -124,7 +127,7 @@ jobs:
             sccache-${{ matrix.os }}
             sccache-
       - name: Build AppImage
-        run: ./appimage/build.sh
+        run: ./appimage/build.sh --${{ matrix.mode }}
         env:
           RELEASE: "${{ startsWith(github.ref, 'refs/tags/') && 'ON' || 'OFF' }}"
       - name: Show sccache stats
@@ -133,19 +136,19 @@ jobs:
       - run: ./conky-x86_64.AppImage --version # print version
       - name: Set CONKY_VERSION
         run: echo "CONKY_VERSION=$(./conky-x86_64.AppImage --short-version)" | tee -a $GITHUB_ENV
-      - run: mv conky-x86_64.AppImage conky-${{ matrix.os }}-${{ matrix.arch }}-v${{ env.CONKY_VERSION }}.AppImage
-      - run: mv conky-x86_64.AppImage.sha256 conky-${{ matrix.os }}-${{ matrix.arch }}-v${{ env.CONKY_VERSION }}.AppImage.sha256
+      - run: mv conky-x86_64.AppImage conky-${{ matrix.os }}-${{ matrix.arch }}-v${{ env.CONKY_VERSION }}-${{ matrix.mode }}.AppImage
+      - run: mv conky-x86_64.AppImage.sha256 conky-${{ matrix.os }}-${{ matrix.arch }}-v${{ env.CONKY_VERSION }}-${{ matrix.mode }}.AppImage.sha256
       - name: Upload AppImage artifact
         uses: actions/upload-artifact@v4
         with:
-          path: 'conky-${{ matrix.os }}-${{ matrix.arch }}-v${{ env.CONKY_VERSION }}.AppImage'
-          name: 'conky-${{ matrix.os }}-${{ matrix.arch }}-v${{ env.CONKY_VERSION }}.AppImage'
+          path: 'conky-${{ matrix.os }}-${{ matrix.arch }}-v${{ env.CONKY_VERSION }}-${{ matrix.mode }}.AppImage'
+          name: 'conky-${{ matrix.os }}-${{ matrix.arch }}-v${{ env.CONKY_VERSION }}-${{ matrix.mode }}.AppImage'
           if-no-files-found: error
       - name: Upload AppImage checksum artifact
         uses: actions/upload-artifact@v4
         with:
-          path: 'conky-${{ matrix.os }}-${{ matrix.arch }}-v${{ env.CONKY_VERSION }}.AppImage.sha256'
-          name: 'conky-${{ matrix.os }}-${{ matrix.arch }}-v${{ env.CONKY_VERSION }}.AppImage.sha256'
+          path: 'conky-${{ matrix.os }}-${{ matrix.arch }}-v${{ env.CONKY_VERSION }}-${{ matrix.mode }}.AppImage.sha256'
+          name: 'conky-${{ matrix.os }}-${{ matrix.arch }}-v${{ env.CONKY_VERSION }}-${{ matrix.mode }}.AppImage.sha256'
           if-no-files-found: error
       - name: Upload man page artifact
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,10 @@ src/colour-names.hh
 
 # Ignore direnv
 .direnv
+
+# Built AppImages
+/conky*.AppImage
+/conky*.AppImage.sha256
+
+# Built manual
+/conky.1.gz

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -3,6 +3,12 @@
 set -e
 set -x
 
+MODE=Release
+if [ "$1" == "--debug" ]; then
+    MODE=Debug
+    export NO_STRIP=1 # disable strip in linuxdeploy
+fi
+
 # building in temporary directory to keep system clean
 # use RAM disk if possible (as in: not building on CI system like Travis, and RAM disk is available)
 if [ "$CI" == "" ] && [ -d /dev/shm ]; then
@@ -38,14 +44,13 @@ pushd "$BUILD_DIR"
 # configure build files with cmake
 # we need to explicitly set the install prefix, as CMake's default is /usr/local for some reason...
 cmake -G Ninja                         \
-  -DCMAKE_BUILD_TYPE=RelWithDebInfo    \
+  -DCMAKE_BUILD_TYPE=$MODE             \
   -DRELEASE=$RELEASE                   \
   -DBUILD_AUDACIOUS=ON                 \
   -DBUILD_DOCS=ON                      \
   -DBUILD_HTTP=ON                      \
   -DBUILD_ICAL=ON                      \
   -DBUILD_ICONV=ON                     \
-  -DBUILD_IRC=ON                       \
   -DBUILD_IRC=ON                       \
   -DBUILD_JOURNAL=ON                   \
   -DBUILD_LUA_CAIRO=ON                 \


### PR DESCRIPTION
- RelWithDebugInfo build was previously stripped by linuxdeploy.
- Made it use Release instead.
- Added Debug mode which sets NO_STRIP to prevent stripping.
- Updated GH action to publish both so people can easily run debug builds when reporting issues.

Closes #2243.