### PR TITLE
Fix .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,9 +6,9 @@ Dockerfile
 .git/
 .gitlab-ci.yml
 
-.DS_Store
-*~
-.*.swp
+**/.DS_Store
+**/*~
+**/.*.swp
 Doxyfile
 patches/
 doc/conky.1


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [ ] ~~Documentation in `doc/` has been updated~~
- [x] All new code is licensed under GPLv3

## Description

Fixes #2257

This PR fixes minor .dockerignore misconfigurations (#2257). I added `**/` at the beginning of the patterns I thought should match recursively. However, since I am not very familiar with this project, I might have missed patterns that also need `**/`. Please let me know (or directly update my PR) if any other lines should include `**/` as well.