### PR TITLE
Fix background rendering for wayland output

### DIFF
--- a/src/output/display-wayland.cc
+++ b/src/output/display-wayland.cc
@@ -938,9 +938,11 @@ void display_output_wayland::clear_text(int exposures) {
     color.alpha = own_window_argb_value.get(*state);
   }
 
+  cairo_set_operator(window->cr, CAIRO_OPERATOR_CLEAR);
+  cairo_paint(window->cr);
   cairo_set_source_rgba(window->cr, color.red / 255.0, color.green / 255.0,
                         color.blue / 255.0, color.alpha / 255.0);
-  cairo_set_operator(window->cr, CAIRO_OPERATOR_CLEAR);
+  cairo_set_operator(window->cr, CAIRO_OPERATOR_OVER);
   cairo_rectangle(window->cr, 0, 0, window->rectangle.width(),
                   window->rectangle.height());
   cairo_fill(window->cr);


### PR DESCRIPTION
Previously, the background was rendered with cairo's CLEAR operator which just clears the surface and does not render any visible contents.

The changes here first clear the surface (with CAIRO_OPERATOR_CLEAR) and then use (CAIRO_OPERATOR_OVER) to render the contents. The result is that the background colour is rendered correctly, including with semi-transparent colours.

# Checklist
- [X] I have described the changes
- [n/a] I have linked to any relevant GitHub issues, if applicable
- [n/a] Documentation in `doc/` has been updated
- [X] All new code is licensed under GPLv3

## Description

* Describe the changes, why they were necessary, etc
* Describe how the changes will affect existing behaviour.
* Describe how you tested and validated your changes.
* Include any relevant screenshots/evidence demonstrating that the changes work and have been tested.

Before:
<img width="579" height="343" alt="20251026_142235" src="https://github.com/user-attachments/assets/491219c4-7b17-47b7-a378-a4b8c62869a5" />

After:
<img width="576" height="344" alt="20251026_142157" src="https://github.com/user-attachments/assets/99b8ae66-f160-45f0-aad5-6b2415c822d3" />

The above screenshots are from qtile (I am one of the developers).