### PR TITLE
feat(text): add sysfs monitoring bar variables

### DIFF
--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -823,6 +823,21 @@ values:
       - (factor offset)
     other:
       filename: null
+  - name: hwmonbar
+    desc: |-
+      Same as hwmon, except if the first value returned is a value
+      between 0-100, it will use that number to draw a horizontal bar (use the
+      factor and offset to transform the raw value). The height and width
+      parameters are optional, and default to the default_bar_height and
+      default_bar_width config settings, respectively.
+    args:
+      - (height),(width)
+      - (dev)
+      - type
+      - n
+      - (factor offset)
+    other:
+      filename: null
   - name: i2c
     desc: |-
       I2C sensor from sysfs (Linux 2.6). Parameter dev may be omitted if you have
@@ -834,6 +849,21 @@ values:
       they have to be given as decimal values (i.e. contain at least one decimal
       place).
     args:
+      - (dev)
+      - type
+      - n
+      - (factor offset)
+    other:
+      filename: null
+  - name: i2cbar
+    desc: |-
+      Same as i2c, except if the first value returned is a value between 0-100,
+      it will use that number to draw a horizontal bar (use the
+      factor and offset to transform the raw value). The height and width
+      parameters are optional, and default to the default_bar_height and
+      default_bar_width config settings, respectively.
+    args:
+      - (height),(width)
       - (dev)
       - type
       - n
@@ -1841,6 +1871,19 @@ values:
       factor + offset`. Note that they have to be given as decimal values (i.e.
       contain at least one decimal place).
     args:
+      - (dev)
+      - type
+      - n
+      - (factor offset)
+  - name: platformbar
+    desc: |-
+      Same as platform, except if the first value returned is a value between
+      0-100, it will use that number to draw a horizontal bar (use the factor
+      and offset to transform the raw value). The height and width parameters
+      are optional, and default to the default_bar_height and default_bar_width
+      config settings, respectively.
+    args:
+      - (height),(width)
       - (dev)
       - type
       - n

--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -825,11 +825,10 @@ values:
       filename: null
   - name: hwmonbar
     desc: |-
-      Same as hwmon, except if the first value returned is a value
-      between 0-100, it will use that number to draw a horizontal bar (use the
-      factor and offset to transform the raw value). The height and width
-      parameters are optional, and default to the default_bar_height and
-      default_bar_width config settings, respectively.
+      Same as hwmon, but displays the sensor reading as a horizontal bar. Use
+      factor and offset to scale the raw sysfs value into the 0-100 range
+      (e.g. millidegree temps need factor 0.001). Height and width default to
+      default_bar_height and default_bar_width respectively.
     args:
       - (height),(width)
       - (dev)
@@ -857,11 +856,10 @@ values:
       filename: null
   - name: i2cbar
     desc: |-
-      Same as i2c, except if the first value returned is a value between 0-100,
-      it will use that number to draw a horizontal bar (use the
-      factor and offset to transform the raw value). The height and width
-      parameters are optional, and default to the default_bar_height and
-      default_bar_width config settings, respectively.
+      Same as i2c, but displays the sensor reading as a horizontal bar. Use
+      factor and offset to scale the raw sysfs value into the 0-100 range.
+      Height and width default to default_bar_height and default_bar_width
+      respectively.
     args:
       - (height),(width)
       - (dev)
@@ -1877,17 +1875,18 @@ values:
       - (factor offset)
   - name: platformbar
     desc: |-
-      Same as platform, except if the first value returned is a value between
-      0-100, it will use that number to draw a horizontal bar (use the factor
-      and offset to transform the raw value). The height and width parameters
-      are optional, and default to the default_bar_height and default_bar_width
-      config settings, respectively.
+      Same as platform, but displays the sensor reading as a horizontal bar. Use
+      factor and offset to scale the raw sysfs value into the 0-100 range.
+      Height and width default to default_bar_height and default_bar_width
+      respectively.
     args:
       - (height),(width)
       - (dev)
       - type
       - n
       - (factor offset)
+    other:
+      filename: null
   - name: pop3_unseen
     desc: |-
       Displays the number of unseen messages in your global POP3

--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -826,9 +826,10 @@ values:
   - name: hwmonbar
     desc: |-
       Same as hwmon, but displays the sensor reading as a horizontal bar. Use
-      factor and offset to scale the raw sysfs value into the 0-100 range
-      (e.g. millidegree temps need factor 0.001). Height and width default to
-      default_bar_height and default_bar_width respectively.
+      factor and offset to scale the value reported by hwmon into the 0-100
+      range. Temperature values are already converted from millidegrees. Height
+      and width default to default_bar_height and default_bar_width
+      respectively.
     args:
       - (height),(width)
       - (dev)
@@ -857,9 +858,9 @@ values:
   - name: i2cbar
     desc: |-
       Same as i2c, but displays the sensor reading as a horizontal bar. Use
-      factor and offset to scale the raw sysfs value into the 0-100 range.
-      Height and width default to default_bar_height and default_bar_width
-      respectively.
+      factor and offset to scale the value reported by i2c into the 0-100 range.
+      Temperature values are already converted from millidegrees. Height and
+      width default to default_bar_height and default_bar_width respectively.
     args:
       - (height),(width)
       - (dev)
@@ -1876,8 +1877,9 @@ values:
   - name: platformbar
     desc: |-
       Same as platform, but displays the sensor reading as a horizontal bar. Use
-      factor and offset to scale the raw sysfs value into the 0-100 range.
-      Height and width default to default_bar_height and default_bar_width
+      factor and offset to scale the value reported by platform into the 0-100
+      range. Temperature values are already converted from millidegrees. Height
+      and width default to default_bar_height and default_bar_width
       respectively.
     args:
       - (height),(width)

--- a/src/core.cc
+++ b/src/core.cc
@@ -1043,12 +1043,22 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ_ARG(i2c, 0, "i2c needs arguments") parse_i2c_sensor(obj, arg);
   obj->callbacks.print = &print_sysfs_sensor;
   obj->callbacks.free = &free_sysfs_sensor;
+  END OBJ_ARG(i2cbar, 0, "i2cbar needs arguments") parse_i2c_bar(obj, arg);
+  obj->callbacks.barval = &sysfs_sensor_barval;
+  obj->callbacks.free = &free_sysfs_sensor;
   END OBJ_ARG(platform, 0, "platform needs arguments")
       parse_platform_sensor(obj, arg);
   obj->callbacks.print = &print_sysfs_sensor;
   obj->callbacks.free = &free_sysfs_sensor;
+  END OBJ_ARG(platformbar, 0, "platformbar needs arguments")
+      parse_platform_bar(obj, arg);
+  obj->callbacks.barval = &sysfs_sensor_barval;
+  obj->callbacks.free = &free_sysfs_sensor;
   END OBJ_ARG(hwmon, 0, "hwmon needs arguments") parse_hwmon_sensor(obj, arg);
   obj->callbacks.print = &print_sysfs_sensor;
+  obj->callbacks.free = &free_sysfs_sensor;
+  END OBJ_ARG(hwmonbar, 0, "hwmonbar needs arguments") parse_hwmon_bar(obj, arg);
+  obj->callbacks.barval = &sysfs_sensor_barval;
   obj->callbacks.free = &free_sysfs_sensor;
 #endif /* __linux__ */
   END

--- a/src/data/os/linux.cc
+++ b/src/data/os/linux.cc
@@ -1468,6 +1468,10 @@ static void parse_sysfs_sensor(struct text_object *obj, const char *arg,
 #define PARSER_GENERATOR(name, path)                                     \
   void parse_##name##_sensor(struct text_object *obj, const char *arg) { \
     parse_sysfs_sensor(obj, arg, path, #name);                           \
+  }                                                                      \
+  void parse_##name##_bar(struct text_object *obj, const char *arg) {    \
+    arg = scan_bar(obj, arg, 100);                                       \
+    parse_sysfs_sensor(obj, arg, path, #name);                           \
   }
 
 PARSER_GENERATOR(i2c, "/sys/bus/i2c/devices/")
@@ -1494,6 +1498,29 @@ void print_sysfs_sensor(struct text_object *obj, char *p,
   } else {
     snprintf(p, p_max_size, "%.1f", r);
   }
+}
+
+double sysfs_sensor_barval(struct text_object *obj) {
+  double r;
+  struct sysfs *sf = (struct sysfs *)obj->data.opaque;
+
+  if (!sf || sf->fd < 0) return 0.0;
+
+  r = get_sysfs_info(&sf->fd, sf->arg, sf->devtype, sf->type);
+
+  r = r * sf->factor + sf->offset;
+
+  if (r > 100.0) {
+    DBGP("your sysfs bar value is higher than 100. Please adjust factor and "
+        "offset to avoid this");
+    r = 100.0;
+  } else if (r < 0.0) {
+    DBGP("your sysfs bar value is lower than 0. Please adjust factor and "
+        "offset to avoid this");
+    r = 0.0;
+  }
+
+  return r;
 }
 
 void free_sysfs_sensor(struct text_object *obj) {

--- a/src/data/os/linux.cc
+++ b/src/data/os/linux.cc
@@ -47,6 +47,7 @@
 #include <unistd.h>
 // #include <assert.h>
 #include <time.h>
+#include <algorithm>
 #include <unordered_map>
 #include "../../lua/setting.hh"
 #include "../top.h"
@@ -1510,17 +1511,10 @@ double sysfs_sensor_barval(struct text_object *obj) {
 
   r = r * sf->factor + sf->offset;
 
-  if (r > 100.0) {
-    DBGP("your sysfs bar value is higher than 100. Please adjust factor and "
-        "offset to avoid this");
-    r = 100.0;
-  } else if (r < 0.0) {
-    DBGP("your sysfs bar value is lower than 0. Please adjust factor and "
-        "offset to avoid this");
-    r = 0.0;
+  if (r < 0.0 || r > 100.0) {
+    LOG_WARNING("sysfs bar value {} out of [0, 100]; adjust factor/offset", r);
   }
-
-  return r;
+  return std::clamp(r, 0.0, 100.0);
 }
 
 void free_sysfs_sensor(struct text_object *obj) {

--- a/src/data/os/linux.cc
+++ b/src/data/os/linux.cc
@@ -1466,12 +1466,30 @@ static void parse_sysfs_sensor(struct text_object *obj, const char *arg,
   obj->data.opaque = sf;
 }
 
+static bool is_sysfs_sensor_type(const char *type) {
+  return strcmp(type, "fan") == 0 || strcmp(type, "in") == 0 ||
+         strcmp(type, "temp") == 0 || strcmp(type, "temp2") == 0 ||
+         strcmp(type, "tempf") == 0 || strcmp(type, "vol") == 0;
+}
+
+static const char *scan_sysfs_bar(struct text_object *obj, const char *arg) {
+  char maybe_dev[64], maybe_type[64];
+
+  if (arg != nullptr && sscanf(arg, " %63s %63s", maybe_dev, maybe_type) == 2 &&
+      is_sysfs_sensor_type(maybe_type)) {
+    scan_bar(obj, nullptr, 100);
+    return arg;
+  }
+
+  return scan_bar(obj, arg, 100);
+}
+
 #define PARSER_GENERATOR(name, path)                                     \
   void parse_##name##_sensor(struct text_object *obj, const char *arg) { \
     parse_sysfs_sensor(obj, arg, path, #name);                           \
   }                                                                      \
   void parse_##name##_bar(struct text_object *obj, const char *arg) {    \
-    arg = scan_bar(obj, arg, 100);                                       \
+    arg = scan_sysfs_bar(obj, arg);                                      \
     parse_sysfs_sensor(obj, arg, path, #name);                           \
   }
 

--- a/src/data/os/linux.h
+++ b/src/data/os/linux.h
@@ -48,7 +48,13 @@ void get_powerbook_batt_info(struct text_object *, char *, unsigned int);
 void parse_i2c_sensor(struct text_object *, const char *);
 void parse_hwmon_sensor(struct text_object *, const char *);
 void parse_platform_sensor(struct text_object *, const char *);
+
+void parse_i2c_bar(struct text_object *, const char *);
+void parse_hwmon_bar(struct text_object *, const char *);
+void parse_platform_bar(struct text_object *, const char *);
+
 void print_sysfs_sensor(struct text_object *, char *, unsigned int);
+double sysfs_sensor_barval(struct text_object *);
 void free_sysfs_sensor(struct text_object *);
 
 int get_entropy_avail(unsigned int *);


### PR DESCRIPTION
## Description

I used "hwmon" for years now to monitor my CPU core temps, but needed to fallback to an execbar to have those values shown as bar nearby. Since doing so for all cores is quite heavy, I added some sysfs bar variables (hwmonbar, i2cbar and platformbar) that basically fill this gap. Doing so, spared me some CPU usage.

The code should not affect existing conky configurations, since it is new variables addition.

I tested this using the "hwmonbar" variable to monitor my AMD CPU core package temps, replacing this
    `${execbar sensors -u k10temp-pci-00c3 | grep temp1_input | awk '{print $2}' | cut -d '.' -f1}`
with this
    `${hwmonbar k10temp temp2 1 1.0 0.0}`

One important note: Due to the bar scaling when calling setup_bar(), the factor and offset should be adjusted properly so that the value is always inside a 0-100 range.