### PR TITLE
Fix mouse button events for owned windows with XInput2 - Fixes #2047

### DIFF
--- a/src/output/x11.cc
+++ b/src/output/x11.cc
@@ -851,12 +851,9 @@ void x11_init_window(lua::state &l, bool own) {
     XISetMask(mask_bytes, XI_HierarchyChanged);
 #ifdef BUILD_MOUSE_EVENTS
     XISetMask(mask_bytes, XI_Motion);
+    XISetMask(mask_bytes, XI_ButtonPress);
+    XISetMask(mask_bytes, XI_ButtonRelease);
 #endif /* BUILD_MOUSE_EVENTS */
-    // Capture click events for "override" window type
-    if (!own) {
-      XISetMask(mask_bytes, XI_ButtonPress);
-      XISetMask(mask_bytes, XI_ButtonRelease);
-    }
 
     XIEventMask ev_masks[1];
     ev_masks[0].deviceid = XIAllDevices;


### PR DESCRIPTION
## Description
Fixes mouse button click events not working for owned windows (DOCK, PANEL, NORMAL, etc.) when `BUILD_XINPUT` is enabled.

**NOTE: Please review the below description closely as I am not C programmer and used Claude to help root cause and determine this fix. The PR changes are minimal and the described rationale seems sound.**

## Root Cause
The bug was introduced in commit f4b3229f (v1.20.0, PR #1821) which only registered `XI_ButtonPress` and `XI_ButtonRelease` events on the root window for non-owned windows (`!own`). This prevented owned windows from receiving any button events. The commit comment suggests the author intended to only capture click events for "override" window types, but the implementation was backwards - it excluded owned windows instead of specifically targeting override windows.

## Solution
XInput2 events are delivered from the root window and then filtered in the event handler based on cursor position. The registration must happen for all window types. The `cursor_over_conky` check in `display-x11.cc:545` already ensures events are only processed when the cursor is over conky.

## Testing
- Built conky with `-DBUILD_XINPUT=ON -DBUILD_LUA_CAIRO=ON -DBUILD_LUA_IMLIB2=ON`
- Tested on Fedora 43 with GNOME 49 (XWayland)
- Verified mouse click events now work correctly with lua mouse hooks

## Affected Versions
All versions since v1.20.0 (April 2024) through current v1.22.2

Fixes #2047