### PR TITLE
fix(darwin): correct top cpu percentage math

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -210,7 +210,13 @@ if(OS_HAIKU)
 endif(OS_HAIKU)
 
 if(OS_DARWIN)
-  set(darwin_sources data/os/darwin.mm data/os/darwin.h data/os/darwin_sip.h i18n.h)
+  set(darwin_sources
+    data/os/darwin.mm
+    data/os/darwin.h
+    data/os/darwin_sip.h
+    data/os/darwin_top_helpers.cc
+    data/os/darwin_top_helpers.h
+    i18n.h)
   set(optional_sources ${optional_sources} ${darwin_sources})
 endif(OS_DARWIN)
 

--- a/src/data/os/darwin_top_helpers.cc
+++ b/src/data/os/darwin_top_helpers.cc
@@ -1,0 +1,80 @@
+/*
+ * Conky, a system monitor, based on torsmo
+ *
+ * Any original torsmo code is licensed under the BSD license
+ *
+ * All code written since the fork of torsmo is licensed under the GPL
+ *
+ * Please see COPYING for details
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "darwin_top_helpers.h"
+
+#include <mach/mach_time.h>
+
+void reset_cpu_sample_overall(struct cpusample *sample) {
+  if (sample == nullptr) { return; }
+
+  sample[0].totalUserTime = 0;
+  sample[0].totalSystemTime = 0;
+  sample[0].totalIdleTime = 0;
+}
+
+void sum_cpu_sample_overall(struct cpusample *sample, size_t processorCount) {
+  if (sample == nullptr) { return; }
+
+  reset_cpu_sample_overall(sample);
+
+  for (size_t i = 1; i < processorCount + 1; i++) {
+    sample[0].totalSystemTime += sample[i].totalSystemTime;
+    sample[0].totalUserTime += sample[i].totalUserTime;
+    sample[0].totalIdleTime += sample[i].totalIdleTime;
+  }
+}
+
+uint64_t cpu_total_delta(uint64_t current_total,
+                         unsigned long *previous_total_cpu_time) {
+  if (previous_total_cpu_time == nullptr) { return 0; }
+
+  if (*previous_total_cpu_time == ULONG_MAX) {
+    *previous_total_cpu_time = current_total;
+    return 0;
+  }
+
+  uint64_t delta = current_total - *previous_total_cpu_time;
+  *previous_total_cpu_time = current_total;
+  return delta;
+}
+
+uint64_t mach_ticks_to_centis(uint64_t ticks, uint32_t numer, uint32_t denom) {
+  if (ticks == 0 || denom == 0) { return 0; }
+
+  unsigned __int128 ns = static_cast<unsigned __int128>(ticks) * numer;
+  ns /= denom;
+  return static_cast<uint64_t>(ns / 10000000ULL);
+}
+
+uint64_t mach_ticks_to_centis_system(uint64_t ticks) {
+  static bool initialized = false;
+  static mach_timebase_info_data_t timebase{};
+
+  if (!initialized) {
+    (void)mach_timebase_info(&timebase);
+    initialized = true;
+  }
+
+  return mach_ticks_to_centis(ticks, timebase.numer, timebase.denom);
+}

--- a/src/data/os/darwin_top_helpers.h
+++ b/src/data/os/darwin_top_helpers.h
@@ -1,0 +1,52 @@
+/*
+ * Conky, a system monitor, based on torsmo
+ *
+ * Any original torsmo code is licensed under the BSD license
+ *
+ * All code written since the fork of torsmo is licensed under the GPL
+ *
+ * Please see COPYING for details
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef CONKY_DARWIN_TOP_HELPERS_H
+#define CONKY_DARWIN_TOP_HELPERS_H
+
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+
+/*
+ * useful info about the cpu used by functions such as update_cpu_usage() and
+ * get_top_info()
+ */
+struct cpusample {
+  uint64_t totalUserTime;   /* ticks of CPU in userspace */
+  uint64_t totalSystemTime; /* ticks of CPU in kernelspace */
+  uint64_t totalIdleTime;   /* ticks in idleness */
+
+  uint64_t total;          /* delta of current and previous */
+  uint64_t current_total;  /* total CPU ticks of current iteration */
+  uint64_t previous_total; /* total CPU tick of previous iteration */
+};
+
+void reset_cpu_sample_overall(struct cpusample *sample);
+void sum_cpu_sample_overall(struct cpusample *sample, size_t processorCount);
+uint64_t cpu_total_delta(uint64_t current_total,
+                         unsigned long *previous_total_cpu_time);
+uint64_t mach_ticks_to_centis(uint64_t ticks, uint32_t numer, uint32_t denom);
+uint64_t mach_ticks_to_centis_system(uint64_t ticks);
+
+#endif /* CONKY_DARWIN_TOP_HELPERS_H */

--- a/src/data/top.cc
+++ b/src/data/top.cc
@@ -175,6 +175,7 @@ static struct process *new_process(pid_t pid) {
   p->previous_user_time = ULONG_MAX;
   p->previous_kernel_time = ULONG_MAX;
   p->total_cpu_time = 0;
+  p->previous_total_cpu_time = ULONG_MAX;
   p->vsize = 0;
   p->rss = 0;
 #ifdef BUILD_IOSTATS

--- a/tests/test-darwin-top.cc
+++ b/tests/test-darwin-top.cc
@@ -1,0 +1,72 @@
+/*
+ * Conky, a system monitor, based on torsmo
+ *
+ * Any original torsmo code is licensed under the BSD license
+ *
+ * All code written since the fork of torsmo is licensed under the GPL
+ *
+ * Please see COPYING for details
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "data/os/darwin_top_helpers.h"
+
+#include <climits>
+
+#include "catch2/catch_amalgamated.hpp"
+
+TEST_CASE("darwin cpu sample overall totals are reset before summing",
+          "[darwin][top]") {
+  struct cpusample sample[3] = {};
+
+  sample[0].totalUserTime = 100;
+  sample[0].totalSystemTime = 200;
+  sample[0].totalIdleTime = 300;
+
+  sample[1].totalUserTime = 7;
+  sample[1].totalSystemTime = 11;
+  sample[1].totalIdleTime = 13;
+
+  sample[2].totalUserTime = 17;
+  sample[2].totalSystemTime = 19;
+  sample[2].totalIdleTime = 23;
+
+  sum_cpu_sample_overall(sample, 2);
+
+  REQUIRE(sample[0].totalUserTime == 24);
+  REQUIRE(sample[0].totalSystemTime == 30);
+  REQUIRE(sample[0].totalIdleTime == 36);
+}
+
+TEST_CASE("darwin cpu total delta initializes safely", "[darwin][top]") {
+  unsigned long previous = ULONG_MAX;
+
+  uint64_t delta = cpu_total_delta(1000, &previous);
+  REQUIRE(delta == 0);
+  REQUIRE(previous == 1000);
+
+  delta = cpu_total_delta(1600, &previous);
+  REQUIRE(delta == 600);
+  REQUIRE(previous == 1600);
+}
+
+TEST_CASE("darwin mach ticks convert to centiseconds", "[darwin][top]") {
+  REQUIRE(mach_ticks_to_centis(0, 1, 1) == 0);
+  REQUIRE(mach_ticks_to_centis(10000000, 1, 1) == 1);
+  REQUIRE(mach_ticks_to_centis(20000000, 1, 1) == 2);
+
+  REQUIRE(mach_ticks_to_centis(240000, 125, 3) == 1);
+  REQUIRE(mach_ticks_to_centis(480000, 125, 3) == 2);
+}


### PR DESCRIPTION
Normalize Darwin process CPU times to centiseconds using mach_timebase_info rather than assuming nanoseconds, and avoid reusing aggregate tick totals across updates. Align total CPU normalization with expected per-core vs aggregate behavior and guard zero deltas. Add helper module for Darwin top calculations and unit tests covering sample reset, delta init, and timebase conversion.

Fixes #2276.