### PR TITLE
Added an optional argument to the 'memperc' variable

### DIFF
--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -1368,6 +1368,10 @@ values:
       - (-x)
       - (-y)
       - (-m value)
+  - name: memwithbuffersperc
+    desc: |-
+      Percentage of memory in use (including memory used by system buffers
+      and caches).
   - name: mixer
     desc: |-
       Prints the mixer value as reported by the OS. On Linux, this

--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -1338,7 +1338,24 @@ values:
   - name: memmax
     desc: Total amount of memory.
   - name: memperc
-    desc: Percentage of memory in use.
+    desc: |-
+      Percentage of memory in use.
+
+      Can be fine-tuned using optional arguments:
+
+      * **-b**: includes system buffers and caches.
+      * **-e**: includes memory that is very easily freed.
+      * **-l**: calculated the same way as in the `free` program.
+      * **-f**: amount of free memory.
+      * **-d**: amount of "dirty" memory. Linux only.
+      * **-a**: amount of available memory as recorded in /proc/meminfo.
+    args:
+      - (-b)
+      - (-e)
+      - (-l)
+      - (-f)
+      - (-d)
+      - (-a)
   - name: memwired
     desc: Amount of wired memory. FreeBSD only.
   - name: memwithbuffers

--- a/src/common.cc
+++ b/src/common.cc
@@ -580,6 +580,14 @@ uint8_t mem_percentage(struct text_object *obj) {
               : 0);
 }
 
+uint8_t mem_with_buffers_percentage(struct text_object *obj) {
+  (void)obj;
+
+  return (info.memmax != 0u
+              ? round_to_positive_int(info.memwithbuffers * 100 / info.memmax)
+              : 0);
+}
+
 double mem_barval(struct text_object *obj) {
   (void)obj;
 

--- a/src/common.cc
+++ b/src/common.cc
@@ -573,10 +573,34 @@ PRINT_HR_GENERATOR(swapfree)
 PRINT_HR_GENERATOR(swapmax)
 
 uint8_t mem_percentage(struct text_object *obj) {
+  auto mem = info.mem;
+  auto arg = obj != nullptr ? obj->data.s : nullptr;
+  if (arg != nullptr) {
+    if(!strcmp("-b", arg)) {
+      mem = info.memwithbuffers;
+    } else if (!strcmp("-e", arg)) {
+      mem = info.memeasyfree;
+    } else if (!strcmp("-l", arg)) {
+      mem = info.legacymem;
+    } else if (!strcmp("-f", arg)) {
+      mem = info.memfree;
+    } else if (!strcmp("-d", arg)) {
+      mem = info.memdirty;
+    } else if (!strcmp("-a", arg)) {
+      mem = info.memavail;
+    }
+  }
+
+  return (info.memmax != 0u
+              ? round_to_positive_int(mem * 100 / info.memmax)
+              : 0);
+}
+
+uint8_t mem_with_buffers_percentage(struct text_object *obj) {
   (void)obj;
 
   return (info.memmax != 0u
-              ? round_to_positive_int(info.mem * 100 / info.memmax)
+              ? round_to_positive_int(info.memwithbuffers * 100 / info.memmax)
               : 0);
 }
 

--- a/src/common.h
+++ b/src/common.h
@@ -139,6 +139,7 @@ void print_swap(struct text_object *, char *, unsigned int);
 void print_swapfree(struct text_object *, char *, unsigned int);
 void print_swapmax(struct text_object *, char *, unsigned int);
 uint8_t mem_percentage(struct text_object *);
+uint8_t mem_with_buffers_percentage(struct text_object *);
 double mem_barval(struct text_object *);
 double mem_with_buffers_barval(struct text_object *);
 uint8_t swap_percentage(struct text_object *);

--- a/src/core.cc
+++ b/src/core.cc
@@ -1209,6 +1209,8 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   obj->callbacks.print = &print_memmax;
   obj->callbacks.free = &gen_free_opaque;
   END OBJ(memperc, &update_meminfo) obj->callbacks.percentage = &mem_percentage;
+  END OBJ(memwithbuffersperc, &update_meminfo)
+  obj->callbacks.percentage = &mem_with_buffers_percentage;
 #ifdef __linux__
   END OBJ(memdirty, &update_meminfo) obj->data.s = STRNDUP_ARG;
   obj->callbacks.print = &print_memdirty;

--- a/src/core.cc
+++ b/src/core.cc
@@ -1216,7 +1216,9 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ(memmax, &update_meminfo) obj->data.s = STRNDUP_ARG;
   obj->callbacks.print = &print_memmax;
   obj->callbacks.free = &gen_free_opaque;
-  END OBJ(memperc, &update_meminfo) obj->callbacks.percentage = &mem_percentage;
+  END OBJ(memperc, &update_meminfo) if (arg) obj->data.s = STRNDUP_ARG;
+  obj->callbacks.percentage = &mem_percentage;
+  obj->callbacks.free = &gen_free_opaque;
 #ifdef __linux__
   END OBJ(memdirty, &update_meminfo) obj->data.s = STRNDUP_ARG;
   obj->callbacks.print = &print_memdirty;


### PR DESCRIPTION
## Description

Added an optional argument to the 'memperc' variable to specify which kind of memory to use.

As an Android OS developer, I am rebuilding the AOSP daily, and the build process is heavily multi-threaded, consuming almost all my RAM. Since I want to avoid the oomd killer kicking in, I am closely monitoring RAM usage, not only using `mem` and `memperc`, but also `memwithbuffers`.

Since the 'memperc' variable only uses the 'mem' value, I tought about adding an optional paramter to tailor which memory should be used when computing the percentage.

The code should not affect existing conky configurations, since it is a new optional argument addition.
It has been tested locally using the following configuration
```
[...]
${font DejaVu Sans:bold:size=14}MEMORY ${hr 2}${font}${voffset 8}
${font DejaVu Sans:bold:size=10}RAM${font}${alignc}$mem / $memmax${alignr}${font DejaVu Sans:bold:size=10}$memperc%${font}${voffset 2}
${membar 16}${voffset 4}
${font DejaVu Sans:bold:size=10}BUFFERED${font}${alignc}${memwithbuffers} / ${memmax}${alignr}${font DejaVu Sans:bold:size=10}${memperc -b}%${font}${voffset 2}
${memwithbuffersbar 16}${voffset 4}
${font DejaVu Sans:bold:size=10}SWAP${font}${alignc}${swap} / ${swapmax}${alignr}${font DejaVu Sans:bold:size=10}${swapperc}%${font}${voffset 2}
${swapbar 16}
[...]
```
