### PR TITLE
Added a new width argument to 'hr' and 'stippled_hr' variables

### DIFF
--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -797,9 +797,12 @@ values:
       - lines
       - (next_check)
   - name: hr
-    desc: Horizontal line, height is the height in pixels.
+    desc: |-
+      Horizontal line, height is the height in pixels. width can be used to
+      set the width, in pixels, of the horizontal line.
     args:
       - (height)
+      - (width)
   - name: hwmon
     desc: |-
       Hwmon sensor from sysfs (Linux 2.6). Parameter dev can be:
@@ -2036,6 +2039,8 @@ values:
     desc: Stippled (dashed) horizontal line.
     args:
       - (space)
+      - (height)
+      - (width)
   - name: stock
     desc: |-
       Displays the data of a stock symbol. The following data is

--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -799,9 +799,12 @@ values:
       - lines
       - (next_check)
   - name: hr
-    desc: Horizontal line, height is the height in pixels.
+    desc: |-
+      Horizontal line, height is the height in pixels. width can be used to
+      set the width, in pixels, of the horizontal line.
     args:
       - (height)
+      - (width)
   - name: hwmon
     desc: |-
       Hwmon sensor from sysfs (Linux 2.6). Parameter dev can be:
@@ -2084,6 +2087,8 @@ values:
     desc: Stippled (dashed) horizontal line.
     args:
       - (space)
+      - (height)
+      - (width)
   - name: stock
     desc: |-
       Displays the data of a stock symbol. The following data is

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1181,7 +1181,11 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
             int h = current->height;
             int mid = font_ascent() / 2;
 
-            w = text_start.x() + text_size.x() - cur_x;
+            /* if no width was specified, current->width is set to 0 */
+            w = current->width;
+            if (w <= 0) {
+              w = text_start.x() + text_size.x() - cur_x;
+            }
 
             if (display_output()) {
               display_output()->set_line_style(h, true);
@@ -1200,7 +1204,12 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
             int mid = font_ascent() / 2;
             char ss[2] = {tmp_s, tmp_s};
 
-            w = text_start.x() + text_size.x() - cur_x - 1;
+            /* if no width was specified, current->width is set to 0 */
+            w = current->width;
+            if (w <= 0) {
+              w = text_start.x() + text_size.x() - cur_x - 1;
+            }
+
             if (display_output()) {
               display_output()->set_line_style(h, false);
               display_output()->set_dashes(ss);

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1187,8 +1187,13 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
           if (display_output() && display_output()->graphical()) {
             int h = current->height;
             int mid = font_ascent() / 2;
+            int max_width = text_start.x() + text_size.x() - cur_x;
 
-            w = text_start.x() + text_size.x() - cur_x;
+            /* if no width was specified, current->width is set to 0 */
+            w = current->width;
+            if (w <= 0 || w > max_width) {
+              w = max_width;
+            }
 
             if (display_output()) {
               display_output()->set_line_style(h, true);
@@ -1205,9 +1210,15 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
             int h = current->height;
             char tmp_s = current->arg;
             int mid = font_ascent() / 2;
+            int max_width = text_start.x() + text_size.x() - cur_x - 1;
             char ss[2] = {tmp_s, tmp_s};
 
-            w = text_start.x() + text_size.x() - cur_x - 1;
+            /* if no width was specified, current->width is set to 0 */
+            w = current->width;
+            if (w <= 0 || w > max_width) {
+              w = max_width;
+            }
+
             if (display_output()) {
               display_output()->set_line_style(h, false);
               display_output()->set_dashes(ss);

--- a/src/content/specials.cc
+++ b/src/content/specials.cc
@@ -113,7 +113,7 @@ struct graph {
 };
 
 struct stippled_hr {
-  int height, arg;
+  int width, height, space;
 };
 
 struct tab {
@@ -665,12 +665,42 @@ void new_graph(struct text_object *obj, char *buf, int buf_max_size,
   if (out_to_stdout.get(*state)) { new_graph_in_shell(s, buf, buf_max_size); }
 }
 
+void scan_hr(struct text_object *obj, const char *arg) {
+  struct stippled_hr *sh;
+
+  sh = static_cast<struct stippled_hr *>(malloc(sizeof(struct stippled_hr)));
+  memset(sh, 0, sizeof(struct stippled_hr));
+
+  sh->space  = 0;
+  sh->width  = 0;
+  sh->height = 1;
+
+  if (arg != nullptr) {
+    if (sscanf(arg, "%d %d", &sh->height, &sh->width) != 2) {
+      sscanf(arg, "%d", &sh->height);
+    }
+  }
+
+  sh->height = std::max(1, sh->height);
+  obj->special_data = sh;
+}
+
 void new_hr(struct text_object *obj, char *p, unsigned int p_max_size) {
+  struct special_node *s = nullptr;
+  auto *sh = static_cast<struct stippled_hr *>(obj->special_data);
+
   if (display_output() == nullptr || !display_output()->graphical()) { return; }
 
   if (p_max_size == 0) { return; }
 
-  new_special(p, text_node_t::HORIZONTAL_LINE)->height = dpi_scale(obj->data.l);
+  s = new_special(p, text_node_t::HORIZONTAL_LINE);
+  s->width  = dpi_scale(sh->width);
+  s->height = dpi_scale(sh->height);
+}
+
+void free_hr(struct text_object *obj) {
+  auto *sh = static_cast<struct stippled_hr *>(obj->special_data);
+  free_and_zero(sh);
 }
 
 void scan_stippled_hr(struct text_object *obj, const char *arg) {
@@ -679,15 +709,19 @@ void scan_stippled_hr(struct text_object *obj, const char *arg) {
   sh = static_cast<struct stippled_hr *>(malloc(sizeof(struct stippled_hr)));
   memset(sh, 0, sizeof(struct stippled_hr));
 
-  sh->arg = stippled_borders.get(*state);
+  sh->space  = stippled_borders.get(*state);
+  sh->width  = 0;
   sh->height = 1;
 
   if (arg != nullptr) {
-    if (sscanf(arg, "%d %d", &sh->arg, &sh->height) != 2) {
-      sscanf(arg, "%d", &sh->height);
+    if (sscanf(arg, "%d %d %d", &sh->space, &sh->height, &sh->width) != 3) {
+      if (sscanf(arg, "%d %d", &sh->space, &sh->height) != 2) {
+        sscanf(arg, "%d", &sh->height);
+      }
     }
   }
-  if (sh->arg <= 0) { sh->arg = 1; }
+  sh->space  = std::max(1, sh->space);
+  sh->height = std::max(1, sh->height);
   obj->special_data = sh;
 }
 
@@ -702,8 +736,14 @@ void new_stippled_hr(struct text_object *obj, char *p,
 
   s = new_special(p, text_node_t::STIPPLED_HR);
 
+  s->width  = dpi_scale(sh->width);
   s->height = dpi_scale(sh->height);
-  s->arg = dpi_scale(sh->arg);
+  s->arg    = dpi_scale(sh->space);
+}
+
+void free_stippled_hr(struct text_object *obj) {
+  auto *sh = static_cast<struct stippled_hr *>(obj->special_data);
+  free_and_zero(sh);
 }
 #endif /* BUILD_GUI */
 

--- a/src/content/specials.cc
+++ b/src/content/specials.cc
@@ -671,8 +671,8 @@ void scan_hr(struct text_object *obj, const char *arg) {
   sh = static_cast<struct stippled_hr *>(malloc(sizeof(struct stippled_hr)));
   memset(sh, 0, sizeof(struct stippled_hr));
 
-  sh->space  = 0;
-  sh->width  = 0;
+  sh->space = 0;
+  sh->width = 0;
   sh->height = 1;
 
   if (arg != nullptr) {
@@ -694,13 +694,8 @@ void new_hr(struct text_object *obj, char *p, unsigned int p_max_size) {
   if (p_max_size == 0) { return; }
 
   s = new_special(p, text_node_t::HORIZONTAL_LINE);
-  s->width  = dpi_scale(sh->width);
+  s->width = dpi_scale(sh->width);
   s->height = dpi_scale(sh->height);
-}
-
-void free_hr(struct text_object *obj) {
-  auto *sh = static_cast<struct stippled_hr *>(obj->special_data);
-  free_and_zero(sh);
 }
 
 void scan_stippled_hr(struct text_object *obj, const char *arg) {
@@ -709,8 +704,8 @@ void scan_stippled_hr(struct text_object *obj, const char *arg) {
   sh = static_cast<struct stippled_hr *>(malloc(sizeof(struct stippled_hr)));
   memset(sh, 0, sizeof(struct stippled_hr));
 
-  sh->space  = stippled_borders.get(*state);
-  sh->width  = 0;
+  sh->space = stippled_borders.get(*state);
+  sh->width = 0;
   sh->height = 1;
 
   if (arg != nullptr) {
@@ -720,7 +715,7 @@ void scan_stippled_hr(struct text_object *obj, const char *arg) {
       }
     }
   }
-  sh->space  = std::max(1, sh->space);
+  sh->space = std::max(1, sh->space);
   sh->height = std::max(1, sh->height);
   obj->special_data = sh;
 }
@@ -736,15 +731,11 @@ void new_stippled_hr(struct text_object *obj, char *p,
 
   s = new_special(p, text_node_t::STIPPLED_HR);
 
-  s->width  = dpi_scale(sh->width);
+  s->width = dpi_scale(sh->width);
   s->height = dpi_scale(sh->height);
-  s->arg    = dpi_scale(sh->space);
+  s->arg = dpi_scale(sh->space);
 }
 
-void free_stippled_hr(struct text_object *obj) {
-  auto *sh = static_cast<struct stippled_hr *>(obj->special_data);
-  free_and_zero(sh);
-}
 #endif /* BUILD_GUI */
 
 void new_fg(struct text_object *obj, char *p, unsigned int p_max_size) {

--- a/src/content/specials.h
+++ b/src/content/specials.h
@@ -106,6 +106,7 @@ void scan_font(struct text_object *, const char *);
 std::pair<char *, size_t> scan_command(const char *);
 bool scan_graph(struct text_object *, const char *, double, char);
 void scan_tab(struct text_object *, const char *);
+void scan_hr(struct text_object *, const char *);
 void scan_stippled_hr(struct text_object *, const char *);
 
 /* printing specials */

--- a/src/content/specials.h
+++ b/src/content/specials.h
@@ -113,6 +113,7 @@ std::pair<char *, size_t> scan_command(const char *);
 bool scan_graph(struct text_object *, const char *, double, char,
                 graph_data_key key = graph_parent_obj_key);
 void scan_tab(struct text_object *, const char *);
+void scan_hr(struct text_object *, const char *);
 void scan_stippled_hr(struct text_object *, const char *);
 
 /* printing specials */
@@ -120,6 +121,9 @@ void new_font(struct text_object *, char *, unsigned int);
 void new_graph(struct text_object *, char *, int, double);
 void new_hr(struct text_object *, char *, unsigned int);
 void new_stippled_hr(struct text_object *, char *, unsigned int);
+
+void free_hr(struct text_object *);
+void free_stippled_hr(struct text_object *);
 #endif /* BUILD_GUI */
 void new_gauge(struct text_object *, char *, unsigned int, double);
 void new_bar(struct text_object *, char *, unsigned int, double);

--- a/src/content/specials.h
+++ b/src/content/specials.h
@@ -121,9 +121,6 @@ void new_font(struct text_object *, char *, unsigned int);
 void new_graph(struct text_object *, char *, int, double);
 void new_hr(struct text_object *, char *, unsigned int);
 void new_stippled_hr(struct text_object *, char *, unsigned int);
-
-void free_hr(struct text_object *);
-void free_stippled_hr(struct text_object *);
 #endif /* BUILD_GUI */
 void new_gauge(struct text_object *, char *, unsigned int, double);
 void new_bar(struct text_object *, char *, unsigned int, double);

--- a/src/core.cc
+++ b/src/core.cc
@@ -1017,8 +1017,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ(fs_used, &update_fs_stats) init_fs(obj, arg);
   obj->callbacks.print = &print_fs_used;
 #ifdef BUILD_GUI
-  END OBJ(hr, nullptr) obj->data.l =
-      arg != nullptr ? strtol(arg, nullptr, 10) : 1;
+  END OBJ(hr, nullptr) scan_hr(obj, arg);
   obj->callbacks.print = &new_hr;
 #endif /* BUILD_GUI */
   END OBJ(nameserver, &update_dns_data) parse_nameserver_arg(obj, arg);

--- a/src/core.cc
+++ b/src/core.cc
@@ -1016,9 +1016,9 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ(fs_used, &update_fs_stats) init_fs(obj, arg);
   obj->callbacks.print = &print_fs_used;
 #ifdef BUILD_GUI
-  END OBJ(hr, nullptr) obj->data.l =
-      arg != nullptr ? strtol(arg, nullptr, 10) : 1;
+  END OBJ(hr, nullptr) scan_hr(obj, arg);
   obj->callbacks.print = &new_hr;
+  obj->callbacks.free = &free_hr;
 #endif /* BUILD_GUI */
   END OBJ(nameserver, &update_dns_data) parse_nameserver_arg(obj, arg);
   obj->callbacks.print = &print_nameserver;
@@ -1462,10 +1462,10 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
           .to_argb32();
   obj->callbacks.print = &new_outline;
 #endif /* BUILD_GUI */
-  END OBJ(stippled_hr, nullptr)
 #ifdef BUILD_GUI
-      scan_stippled_hr(obj, arg);
+  END OBJ(stippled_hr, nullptr) scan_stippled_hr(obj, arg);
   obj->callbacks.print = &new_stippled_hr;
+  obj->callbacks.free = &free_stippled_hr;
 #endif /* BUILD_GUI */
   END OBJ(swap, &update_meminfo) obj->data.s = STRNDUP_ARG;
   obj->callbacks.print = &print_swap;

--- a/src/core.cc
+++ b/src/core.cc
@@ -1018,7 +1018,6 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
 #ifdef BUILD_GUI
   END OBJ(hr, nullptr) scan_hr(obj, arg);
   obj->callbacks.print = &new_hr;
-  obj->callbacks.free = &free_hr;
 #endif /* BUILD_GUI */
   END OBJ(nameserver, &update_dns_data) parse_nameserver_arg(obj, arg);
   obj->callbacks.print = &print_nameserver;
@@ -1057,7 +1056,8 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ_ARG(hwmon, 0, "hwmon needs arguments") parse_hwmon_sensor(obj, arg);
   obj->callbacks.print = &print_sysfs_sensor;
   obj->callbacks.free = &free_sysfs_sensor;
-  END OBJ_ARG(hwmonbar, 0, "hwmonbar needs arguments") parse_hwmon_bar(obj, arg);
+  END OBJ_ARG(hwmonbar, 0, "hwmonbar needs arguments")
+      parse_hwmon_bar(obj, arg);
   obj->callbacks.barval = &sysfs_sensor_barval;
   obj->callbacks.free = &free_sysfs_sensor;
 #endif /* __linux__ */
@@ -1462,10 +1462,10 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
           .to_argb32();
   obj->callbacks.print = &new_outline;
 #endif /* BUILD_GUI */
+  END OBJ(stippled_hr, nullptr)
 #ifdef BUILD_GUI
-  END OBJ(stippled_hr, nullptr) scan_stippled_hr(obj, arg);
+      scan_stippled_hr(obj, arg);
   obj->callbacks.print = &new_stippled_hr;
-  obj->callbacks.free = &free_stippled_hr;
 #endif /* BUILD_GUI */
   END OBJ(swap, &update_meminfo) obj->data.s = STRNDUP_ARG;
   obj->callbacks.print = &print_swap;


### PR DESCRIPTION
## Description

When using an `hr` variable there is currently no real way to restrict the width of it, in order to draw something between the end of the line, and the right side of the window. I have therefore added a new optional parameter for both `hr` and `stippled_hr` variables to fix that.

There should be no impact on existing behavior, since we are adding a new (optional) parameter.

However, please note that the logic inside the `scan_stippled_hr()` function favors the height/thickness parameter instead of the space parameter when only one argument is given. In order to preserve this logic, I kept the space + height combo when 2 arguments are passed, so there is now way to have a `stippled_hr height width` combination.

I have tested both `hr` and `stippled_hr` in all possible combinations, checking that the line rendered on screen fits what is expected.

|Variable|Width|Height|
|:-|:-:|:-:|
|`${hr}`|_100%_| _1px_ |
|`${hr 10}` |_100%_| _10px_ |
|`${hr 10 150}` |150px| 10px |

<sup>_italics_ - default</sup>
