### PR TITLE
fix(build): Disable root paths when finding protocol files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -342,6 +342,7 @@ if(BUILD_WAYLAND)
         NO_CACHE
         REQUIRED
         NO_DEFAULT_PATH
+        NO_CMAKE_FIND_ROOT_PATH
       )
       message(STATUS "PROTOCOL '${name}' ${VERSION} file: ${PROTOCOL_FILE}")
       unset(VERSION)
@@ -354,6 +355,7 @@ if(BUILD_WAYLAND)
         NO_CACHE
         REQUIRED
         NO_DEFAULT_PATH
+        NO_CMAKE_FIND_ROOT_PATH
       )
       message(STATUS "PROTOCOL '${name}' file: ${PROTOCOL_FILE}")
     endif()


### PR DESCRIPTION
This change ensures that wayland protocol files in `src/wl_protocols/` can be correctly located by `find_file()` when the build directory has been re-rooted (cross-building, etc.)

To give an example of where this would be needed, The packaging system for VoidLinux uses a toolchain file that sets the following when cross-building for `aarch64`...

```
SET(CMAKE_FIND_ROOT_PATH "/usr/aarch64-linux-gnu/usr;/usr/aarch64-linux-gnu")
```

Prior to this change, `find_file()` would prepend these paths onto the search in the local directory `src/wl_protocols/`, meaning the files in that directory would never be found.

This shouldn't affect the search for any of the non-local paths because those are sourced from the variable `${Wayland_PROTOCOLS_DIR}`, which is extracted from the `wayland-protocols` package as-is.

# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [ ] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

* Describe the changes, why they were necessary, etc
* Describe how the changes will affect existing behaviour.
* Describe how you tested and validated your changes.
* Include any relevant screenshots/evidence demonstrating that the changes work and have been tested.
