### PR TITLE
Refactor: Replace magic numbers with named constant in linux.cc

### DIFF
--- a/src/data/os/linux.cc
+++ b/src/data/os/linux.cc
@@ -504,8 +504,9 @@ void update_net_interfaces(FILE *net_dev_fp, bool is_first_update,
 
     /* quit only after all non-header lines from /proc/net/dev parsed */
     // FIXME: arbitrary size chosen to keep code simple.
-    char buf[256];
-    if (fgets(buf, 255, net_dev_fp) == nullptr) { break; }
+    const int BUF_SIZE = 256;
+    char buf[BUF_SIZE];
+    if (fgets(buf, BUF_SIZE - 1, net_dev_fp) == nullptr) { break; }
     p = buf;
     /* change char * p to first non-space character, which is the beginning
      * of the interface name */


### PR DESCRIPTION
### Description
I noticed a `FIXME` comment in `src/data/os/linux.cc` regarding an arbitrary buffer size.
I have replaced the hardcoded magic numbers (`256`, `255`) with a named constant `BUF_SIZE` to improve readability and maintainability.

### Changes
- Defined `const int BUF_SIZE = 256;`
- Updated `char buf[]` and `fgets()` to use `BUF_SIZE`.

### Verification
- [x] Ran `make -j$(nproc)` locally on Ubuntu.
- [x] Confirmed the build completes successfully (100%).