### PR TITLE
Fix uninstall script syntax

### DIFF
--- a/cmake/UninstallConky.cmake.in
+++ b/cmake/UninstallConky.cmake.in
@@ -7,7 +7,7 @@
 #reserved.
 #
 #This program is free software : you can redistribute it and / or \
-    modify it under
+#    modify it under
 #the terms of the GNU General Public License as published by the Free Software
 #Foundation, either version 3 of the License, or (at your option) any later
 #version.
@@ -19,7 +19,7 @@
 #along with this program.If not, see < http:  // www.gnu.org/licenses/>.
 #
 
-if (NOT EXISTS ${CMAKE_BINARY_DIR} / install_manifest.txt)
+if (NOT EXISTS "${CMAKE_BINARY_DIR}/install_manifest.txt")
     message(FATAL_ERROR "Cannot find install manifest: ${CMAKE_BINARY_DIR}/install_manifest.txt")
 endif()
 
@@ -29,9 +29,9 @@ string(REGEX REPLACE "\n" ";" files "${files}")
 foreach (file ${files})
     message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
     if (IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
-        execute_process(COMMAND ${CMAKE_COMMAND} "-E" "remove" "\"$ENV{DESTDIR}${file}\""
+        execute_process(COMMAND ${CMAKE_COMMAND} -E remove "$ENV{DESTDIR}${file}"
             OUTPUT_VARIABLE rm_out
-            RETURN_VALUE rm_retval)
+            RESULT_VARIABLE rm_retval)
         if (NOT "${rm_retval}" STREQUAL 0)
             message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
         endif()


### PR DESCRIPTION
Corrected syntax in UninstallConky.cmake.in:
- Fixed path check for install_manifest.txt
- Adjusted execute_process command and error variable

This resolves parse errors and ensures `make uninstall` works properly.