### PR TITLE
fix(linux): fix off-by-one buffer overflow in process_parse_stat

### DIFF
--- a/src/data/os/linux.cc
+++ b/src/data/os/linux.cc
@@ -3026,8 +3026,9 @@ static void process_parse_stat(struct process *process) {
     strncpy(cmdline_procname, cmdline, BUFFER_LEN);
   } else {
     long int slash_pos = slash_ptr - tmpstr;
-    strncpy(cmdline_procname, cmdline + slash_pos + 1, BUFFER_LEN - slash_pos);
-    cmdline_procname[BUFFER_LEN - slash_pos] = 0;
+    strncpy(cmdline_procname, cmdline + slash_pos + 1,
+            BUFFER_LEN - slash_pos - 1);
+    cmdline_procname[BUFFER_LEN - slash_pos - 1] = 0;
   }
 
   /* Extract cpu times from data in /proc filesystem */


### PR DESCRIPTION
When slash_pos is 0 (executable path starts with '/'), the null terminator was written to cmdline_procname[BUFFER_LEN], which is one byte past the end of the array.

Subtract 1 from both the strncpy length and the null terminator index so they are always within the [0, BUFFER_LEN-1] bounds of the buffer.

# Checklist
- [ ] I have described the changes
- [ ] I have linked to any relevant GitHub issues, if applicable
- [ ] Documentation in `doc/` has been updated
- [ ] All new code is licensed under GPLv3

## Description

* Describe the changes, why they were necessary, etc
* Describe how the changes will affect existing behaviour.
* Describe how you tested and validated your changes.
* Include any relevant screenshots/evidence demonstrating that the changes work and have been tested.
