### PR TITLE
Harden network inputs and fix Darwin feature detection

### DIFF
--- a/cmake/ConkyPlatformChecks.cmake
+++ b/cmake/ConkyPlatformChecks.cmake
@@ -56,6 +56,50 @@ set(conky_libs ${conky_libs} ${CLOCK_GETTIME_LIB})
 # standard path to search for includes
 set(INCLUDE_SEARCH_PATH /usr/include /usr/local/include)
 
+function(conky_append_include_dirs dest_var)
+  foreach(_dir IN LISTS ARGN)
+    if(NOT _dir)
+      continue()
+    endif()
+
+    if(OS_DARWIN)
+      if(_dir MATCHES "/usr/include/?$")
+        continue()
+      endif()
+      if(_dir MATCHES "MacOSX[^/]*/usr/include/?$")
+        continue()
+      endif()
+    endif()
+
+    list(APPEND ${dest_var} ${_dir})
+  endforeach()
+
+  list(REMOVE_DUPLICATES ${dest_var})
+  set(${dest_var} "${${dest_var}}" PARENT_SCOPE)
+endfunction()
+
+function(conky_filter_implicit_include_dirs var_name)
+  set(_filtered)
+  foreach(_dir IN LISTS ${var_name})
+    if(OS_DARWIN AND _dir MATCHES "^/nix/store/")
+      if(_dir MATCHES "libcxx"
+        OR _dir MATCHES "compiler-rt"
+        OR _dir MATCHES "clang-wrapper"
+        OR _dir MATCHES "clang-[0-9]"
+        OR _dir MATCHES "libobjc"
+        OR _dir MATCHES "resource-root"
+        OR _dir MATCHES "libSystem"
+        OR _dir MATCHES "sdkroot")
+        list(APPEND _filtered "${_dir}")
+      endif()
+    else()
+      list(APPEND _filtered "${_dir}")
+    endif()
+  endforeach()
+
+  set(${var_name} "${_filtered}" PARENT_SCOPE)
+endfunction()
+
 # Detect CI
 if(DEFINED ENV{CI})
   # For GitHub actions CI=true is set
@@ -122,6 +166,24 @@ else(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   set(OS_DARWIN false)
 endif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
 
+if(OS_DARWIN)
+  set(CONKY_C_IMPLICIT_INCLUDE_DIRECTORIES_RAW
+    ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
+  set(CONKY_CXX_IMPLICIT_INCLUDE_DIRECTORIES_RAW
+    ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
+  set(CONKY_PLATFORM_EXTRA_INCLUDE_DIRS
+    ${CONKY_C_IMPLICIT_INCLUDE_DIRECTORIES_RAW}
+    ${CONKY_CXX_IMPLICIT_INCLUDE_DIRECTORIES_RAW})
+  list(REMOVE_DUPLICATES CONKY_PLATFORM_EXTRA_INCLUDE_DIRS)
+
+  # Nix clang wrappers can report third-party package headers as implicit
+  # includes. CMake then drops those directories from generated compile
+  # commands, so feature-enabled builds lose X11/Lua/curl headers unless we
+  # keep only the true toolchain/runtime implicit paths here.
+  conky_filter_implicit_include_dirs(CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES)
+  conky_filter_implicit_include_dirs(CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES)
+endif()
+
 if(NOT OS_LINUX
   AND NOT OS_FREEBSD
   AND NOT OS_OPENBSD
@@ -185,15 +247,74 @@ if(BUILD_I18N)
   include(FindIntl)
   find_package(Intl)
 
+  if(OS_DARWIN AND NOT Intl_FOUND)
+    set(CONKY_DARWIN_GETTEXT_PREFIXES
+      /opt/homebrew/opt/gettext
+      /usr/local/opt/gettext)
+
+    find_path(CONKY_DARWIN_GETTEXT_INCLUDE_DIR
+      NAMES libintl.h
+      PATHS ${CONKY_DARWIN_GETTEXT_PREFIXES}
+      PATH_SUFFIXES include
+      NO_DEFAULT_PATH)
+    find_library(CONKY_DARWIN_GETTEXT_LIBRARY
+      NAMES intl libintl
+      PATHS ${CONKY_DARWIN_GETTEXT_PREFIXES}
+      PATH_SUFFIXES lib
+      NO_DEFAULT_PATH)
+
+    if(CONKY_DARWIN_GETTEXT_INCLUDE_DIR AND CONKY_DARWIN_GETTEXT_LIBRARY)
+      set(Intl_FOUND TRUE)
+      set(Intl_IS_BUILT_IN FALSE)
+      set(Intl_INCLUDE_DIR "${CONKY_DARWIN_GETTEXT_INCLUDE_DIR}")
+      set(Intl_LIBRARY "${CONKY_DARWIN_GETTEXT_LIBRARY}")
+      set(Intl_INCLUDE_DIRS "${CONKY_DARWIN_GETTEXT_INCLUDE_DIR}")
+      set(Intl_LIBRARIES "${CONKY_DARWIN_GETTEXT_LIBRARY}")
+      set(Intl_INCLUDE_DIR "${CONKY_DARWIN_GETTEXT_INCLUDE_DIR}" CACHE PATH
+        "Directory containing libintl headers" FORCE)
+      set(Intl_LIBRARY "${CONKY_DARWIN_GETTEXT_LIBRARY}" CACHE FILEPATH
+        "Path to libintl library" FORCE)
+    endif()
+  endif()
+
   if(NOT Intl_FOUND)
     if(OS_DARWIN)
-      message(WARNING "Try running `brew install gettext` for I18N support")
-      # Should be present by default everywhere else
+      message(FATAL_ERROR
+        "Unable to find libintl.\n"
+        "Checked CMake's default search and Homebrew prefixes:\n"
+        "  /opt/homebrew/opt/gettext\n"
+        "  /usr/local/opt/gettext\n"
+        "If gettext is installed via Homebrew, re-run CMake after ensuring\n"
+        "the prefix exists or pass -DIntl_INCLUDE_DIR and -DIntl_LIBRARY explicitly.")
+    else()
+      message(FATAL_ERROR "Unable to find libintl")
     endif(OS_DARWIN)
-    message(FATAL_ERROR "Unable to find libintl")
   endif(NOT Intl_FOUND)
 
-  include_directories(${Intl_INCLUDE_DIRS})
+  if(OS_DARWIN AND Intl_IS_BUILT_IN)
+    set(CONKY_DARWIN_INTL_IMPLICIT_LIBS)
+    foreach(_lib ${CMAKE_C_IMPLICIT_LINK_LIBRARIES}
+                 ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES})
+      if(_lib STREQUAL "intl" OR _lib STREQUAL "iconv")
+        unset(CONKY_IMPLICIT_LIB_PATH CACHE)
+        find_library(CONKY_IMPLICIT_LIB_PATH
+          NAMES ${_lib}
+          PATHS ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES}
+                ${CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES}
+          NO_DEFAULT_PATH)
+        if(CONKY_IMPLICIT_LIB_PATH)
+          list(APPEND CONKY_DARWIN_INTL_IMPLICIT_LIBS
+            ${CONKY_IMPLICIT_LIB_PATH})
+        else()
+          list(APPEND CONKY_DARWIN_INTL_IMPLICIT_LIBS ${_lib})
+        endif()
+      endif()
+    endforeach()
+    list(REMOVE_DUPLICATES CONKY_DARWIN_INTL_IMPLICIT_LIBS)
+    set(conky_libs ${conky_libs} ${CONKY_DARWIN_INTL_IMPLICIT_LIBS})
+  endif()
+
+  conky_append_include_dirs(conky_includes ${Intl_INCLUDE_DIRS})
   set(conky_libs ${conky_libs} ${Intl_LIBRARIES})
 endif(BUILD_I18N)
 
@@ -253,9 +374,70 @@ if(BUILD_IPV6)
 endif(BUILD_IPV6)
 
 if(BUILD_HTTP)
-  pkg_check_modules(MICROHTTPD REQUIRED libmicrohttpd>=0.9.25)
-  set(conky_libs ${conky_libs} ${MICROHTTPD_LINK_LIBRARIES})
-  set(conky_includes ${conky_includes} ${MICROHTTPD_INCLUDE_DIRS})
+  pkg_check_modules(MICROHTTPD libmicrohttpd>=0.9.25)
+
+  if(MICROHTTPD_FOUND)
+    set(conky_libs ${conky_libs} ${MICROHTTPD_LINK_LIBRARIES})
+    conky_append_include_dirs(conky_includes ${MICROHTTPD_INCLUDE_DIRS})
+  else()
+    if(OS_DARWIN)
+      set(CONKY_DARWIN_MICROHTTPD_PREFIXES
+        /opt/homebrew/opt/libmicrohttpd
+        /usr/local/opt/libmicrohttpd)
+
+      find_path(MICROHTTPD_INCLUDE_DIR
+        NAMES microhttpd.h
+        PATHS ${CONKY_DARWIN_MICROHTTPD_PREFIXES}
+        PATH_SUFFIXES include
+        NO_DEFAULT_PATH)
+      find_library(MICROHTTPD_LIBRARY
+        NAMES microhttpd libmicrohttpd
+        PATHS ${CONKY_DARWIN_MICROHTTPD_PREFIXES}
+        PATH_SUFFIXES lib
+        NO_DEFAULT_PATH)
+    else()
+      find_path(MICROHTTPD_INCLUDE_DIR NAMES microhttpd.h)
+      find_library(MICROHTTPD_LIBRARY NAMES microhttpd libmicrohttpd)
+    endif()
+
+    if(MICROHTTPD_INCLUDE_DIR AND MICROHTTPD_LIBRARY)
+      file(STRINGS "${MICROHTTPD_INCLUDE_DIR}/microhttpd.h"
+        MICROHTTPD_VERSION_LINE
+        REGEX "^#define MHD_VERSION 0x[0-9A-Fa-f]+")
+      if(NOT MICROHTTPD_VERSION_LINE)
+        message(FATAL_ERROR
+          "Unable to determine libmicrohttpd version from "
+          "${MICROHTTPD_INCLUDE_DIR}/microhttpd.h")
+      endif()
+
+      string(REGEX REPLACE ".*0x([0-9A-Fa-f]+).*" "\\1"
+        MICROHTTPD_VERSION_HEX "${MICROHTTPD_VERSION_LINE}")
+      math(EXPR MICROHTTPD_VERSION_NUM "0x${MICROHTTPD_VERSION_HEX}")
+      math(EXPR MICROHTTPD_MIN_VERSION_NUM "0x00092500")
+
+      if(MICROHTTPD_VERSION_NUM LESS MICROHTTPD_MIN_VERSION_NUM)
+        message(FATAL_ERROR
+          "Found libmicrohttpd version 0x${MICROHTTPD_VERSION_HEX}, but "
+          "Conky requires at least 0x00092500 (0.9.25).")
+      endif()
+
+      set(MICROHTTPD_INCLUDE_DIRS "${MICROHTTPD_INCLUDE_DIR}")
+      set(MICROHTTPD_LINK_LIBRARIES "${MICROHTTPD_LIBRARY}")
+      set(conky_libs ${conky_libs} ${MICROHTTPD_LINK_LIBRARIES})
+      conky_append_include_dirs(conky_includes ${MICROHTTPD_INCLUDE_DIRS})
+    elseif(OS_DARWIN)
+      message(FATAL_ERROR
+        "Unable to find libmicrohttpd.\n"
+        "Checked pkg-config and Homebrew prefixes:\n"
+        "  /opt/homebrew/opt/libmicrohttpd\n"
+        "  /usr/local/opt/libmicrohttpd\n"
+        "If installed via Homebrew, ensure PKG_CONFIG_PATH includes\n"
+        "libmicrohttpd/lib/pkgconfig or pass MICROHTTPD_INCLUDE_DIR and\n"
+        "MICROHTTPD_LIBRARY explicitly.")
+    else()
+      message(FATAL_ERROR "Unable to find libmicrohttpd")
+    endif()
+  endif()
 endif(BUILD_HTTP)
 
 if(BUILD_NCURSES)
@@ -475,6 +657,7 @@ if(BUILD_X11)
 
       if(X11_xcb_errors_FOUND)
         set(HAVE_XCB_ERRORS true)
+        set(conky_includes ${conky_includes} ${X11_xcb_errors_INCLUDE_PATH})
         set(conky_libs ${conky_libs} ${X11_xcb_LIB} ${X11_xcb_errors_LIB})
       else(X11_xcb_errors_FOUND)
         set(HAVE_XCB_ERRORS false)
@@ -649,9 +832,79 @@ if(BUILD_PULSEAUDIO)
 endif(BUILD_PULSEAUDIO)
 
 if(WANT_CURL)
-  pkg_check_modules(CURL REQUIRED libcurl)
-  set(conky_libs ${conky_libs} ${CURL_LINK_LIBRARIES})
-  set(conky_includes ${conky_includes} ${CURL_INCLUDE_DIRS})
+  pkg_check_modules(CURL libcurl)
+  if(CURL_FOUND)
+    set(conky_libs ${conky_libs} ${CURL_LINK_LIBRARIES})
+    conky_append_include_dirs(conky_includes ${CURL_INCLUDE_DIRS})
+  else()
+    find_package(CURL REQUIRED)
+    set(CONKY_CURL_INCLUDE_CANDIDATE "${CURL_INCLUDE_DIRS}")
+    if(NOT CONKY_CURL_INCLUDE_CANDIDATE)
+      set(CONKY_CURL_INCLUDE_CANDIDATE "${CURL_INCLUDE_DIR}")
+    endif()
+
+    set(CONKY_CURL_LIBRARY_CANDIDATE "${CURL_LIBRARIES}")
+    if(NOT CONKY_CURL_LIBRARY_CANDIDATE)
+      if(CURL_LIBRARY_RELEASE)
+        set(CONKY_CURL_LIBRARY_CANDIDATE "${CURL_LIBRARY_RELEASE}")
+      elseif(CURL_LIBRARY)
+        set(CONKY_CURL_LIBRARY_CANDIDATE "${CURL_LIBRARY}")
+      endif()
+    endif()
+
+    if(OS_DARWIN AND
+        (NOT CONKY_CURL_INCLUDE_CANDIDATE OR
+         CONKY_CURL_INCLUDE_CANDIDATE MATCHES "MacOSX[^/]*/usr/include/?$"))
+      set(CONKY_DARWIN_CURL_PREFIXES
+        /opt/homebrew/opt/curl
+        /usr/local/opt/curl)
+
+      find_path(CONKY_DARWIN_CURL_INCLUDE_DIR
+        NAMES curl/curl.h
+        PATHS ${CONKY_DARWIN_CURL_PREFIXES}
+        PATH_SUFFIXES include
+        NO_DEFAULT_PATH)
+      find_library(CONKY_DARWIN_CURL_LIBRARY
+        NAMES curl libcurl
+        PATHS ${CONKY_DARWIN_CURL_PREFIXES}
+        PATH_SUFFIXES lib
+        NO_DEFAULT_PATH)
+
+      if(CONKY_DARWIN_CURL_INCLUDE_DIR AND CONKY_DARWIN_CURL_LIBRARY)
+        set(CONKY_CURL_INCLUDE_CANDIDATE "${CONKY_DARWIN_CURL_INCLUDE_DIR}")
+        set(CONKY_CURL_LIBRARY_CANDIDATE "${CONKY_DARWIN_CURL_LIBRARY}")
+      endif()
+    endif()
+
+    if(NOT CONKY_CURL_INCLUDE_CANDIDATE OR
+        NOT EXISTS "${CONKY_CURL_INCLUDE_CANDIDATE}/curl/curl.h" OR
+        NOT CONKY_CURL_LIBRARY_CANDIDATE)
+      message(FATAL_ERROR
+        "Unable to find a consistent libcurl installation.\n"
+        "If libcurl is installed in a non-standard prefix, set PKG_CONFIG_PATH\n"
+        "or pass -DCURL_INCLUDE_DIR and -DCURL_LIBRARY explicitly.")
+    endif()
+
+    get_filename_component(CONKY_CURL_LIBRARY_DIR
+      "${CONKY_CURL_LIBRARY_CANDIDATE}" DIRECTORY)
+    get_filename_component(CONKY_CURL_PREFIX
+      "${CONKY_CURL_INCLUDE_CANDIDATE}" DIRECTORY)
+    get_filename_component(CONKY_CURL_PREFIX
+      "${CONKY_CURL_PREFIX}" DIRECTORY)
+
+    if(NOT CONKY_CURL_LIBRARY_DIR MATCHES "^${CONKY_CURL_PREFIX}(/|$)")
+      message(FATAL_ERROR
+        "Detected libcurl headers in '${CONKY_CURL_INCLUDE_CANDIDATE}' but "
+        "library in '${CONKY_CURL_LIBRARY_CANDIDATE}'.\n"
+        "Refusing to mix libcurl installations; set PKG_CONFIG_PATH or pass "
+        "-DCURL_INCLUDE_DIR and -DCURL_LIBRARY explicitly.")
+    endif()
+
+    set(CURL_INCLUDE_DIRS "${CONKY_CURL_INCLUDE_CANDIDATE}")
+    set(CURL_LIBRARIES "${CONKY_CURL_LIBRARY_CANDIDATE}")
+    set(conky_libs ${conky_libs} ${CURL_LIBRARIES})
+    conky_append_include_dirs(conky_includes ${CURL_INCLUDE_DIRS})
+  endif()
 endif(WANT_CURL)
 
 # Common libraries
@@ -661,12 +914,6 @@ if(WANT_GLIB)
   set(conky_includes ${conky_includes} ${GLIB_INCLUDE_DIRS})
 endif(WANT_GLIB)
 
-if(WANT_CURL)
-  pkg_check_modules(CURL REQUIRED libcurl)
-  set(conky_libs ${conky_libs} ${CURL_LINK_LIBRARIES})
-  set(conky_includes ${conky_includes} ${CURL_INCLUDE_DIRS})
-endif(WANT_CURL)
-
 if(WANT_LIBXML2)
   include(FindLibXml2)
 
@@ -675,7 +922,7 @@ if(WANT_LIBXML2)
   endif(NOT LIBXML2_FOUND)
 
   set(conky_libs ${conky_libs} ${LIBXML2_LIBRARIES})
-  set(conky_includes ${conky_includes} ${LIBXML2_INCLUDE_DIR})
+  conky_append_include_dirs(conky_includes ${LIBXML2_INCLUDE_DIR})
 endif(WANT_LIBXML2)
 
 # Look for doc generation programs

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,47 @@ if(BUILD_BUILTIN_CONFIG OR BUILD_OLD_CONFIG)
   include_directories(${CMAKE_BINARY_DIR}/data)
 endif(BUILD_BUILTIN_CONFIG OR BUILD_OLD_CONFIG)
 
+set(conky_target_includes
+  ${conky_includes}
+  ${CMAKE_CURRENT_BINARY_DIR})
+
+if(BUILD_BUILTIN_CONFIG OR BUILD_OLD_CONFIG)
+  list(APPEND conky_target_includes ${CMAKE_BINARY_DIR}/data)
+endif(BUILD_BUILTIN_CONFIG OR BUILD_OLD_CONFIG)
+
+# Some package probes do not consistently flow through conky_includes on
+# Darwin/Nix, so assemble the compile include set from the resolved package
+# variables as well.
+conky_append_include_dirs(conky_target_includes
+  ${CONKY_PLATFORM_EXTRA_INCLUDE_DIRS}
+  ${Intl_INCLUDE_DIRS}
+  ${MICROHTTPD_INCLUDE_DIRS}
+  ${CURSES_INCLUDE_PATH}
+  ${CURSES_PARENT}
+  ${ICONV_INCLUDE_DIR}
+  ${X11_INCLUDE_DIR}
+  ${FREETYPE_INCLUDE_DIR_freetype2}
+  ${Fontconfig_INCLUDE_DIRS}
+  ${X11_xcb_INCLUDE_PATH}
+  ${Wayland_CLIENT_INCLUDE_DIR}
+  ${EPOLL_INCLUDE_DIRS}
+  ${CAIRO_INCLUDE_DIRS}
+  ${PANGO_INCLUDE_DIRS}
+  ${PANGOCAIRO_INCLUDE_DIRS}
+  ${PANGOFC_INCLUDE_DIRS}
+  ${PANGOFT2_INCLUDE_DIRS}
+  ${LUA_INCLUDE_DIR}
+  ${AUDACIOUS_INCLUDE_DIRS}
+  ${DBUS_GLIB_INCLUDE_DIRS}
+  ${XMMS2_INCLUDE_DIRS}
+  ${XNVCtrl_INCLUDE_PATH}
+  ${IMLIB2_INCLUDE_DIRS}
+  ${SYSTEMD_INCLUDE_DIRS}
+  ${PULSEAUDIO_INCLUDE_DIRS}
+  ${CURL_INCLUDE_DIRS}
+  ${GLIB_INCLUDE_DIRS}
+  ${LIBXML2_INCLUDE_DIR})
+
 # ensure build.h and config.h aren't in the way
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/config.h)
   message(
@@ -218,6 +259,17 @@ if(OS_DARWIN)
     data/os/darwin_top_helpers.h
     i18n.h)
   set(optional_sources ${optional_sources} ${darwin_sources})
+
+  if(CMAKE_OSX_SYSROOT
+    AND EXISTS "${CMAKE_OSX_SYSROOT}/usr/include")
+    # Nix clang wrappers can skip SDK ObjC headers for Objective-C++ sources
+    # even with -isysroot; add them after the normal search order.
+    set_property(
+      SOURCE data/os/darwin.mm
+      APPEND PROPERTY COMPILE_OPTIONS
+      -idirafter
+      ${CMAKE_OSX_SYSROOT}/usr/include)
+  endif()
 endif(OS_DARWIN)
 
 # Optional sources
@@ -456,9 +508,11 @@ if(BUILD_TESTING)
   # Create a library strictly for testing
   add_library(conky_core ${conky_sources} ${optional_sources})
   add_dependencies(conky_core generated_hdr_files)
+  target_include_directories(conky_core PUBLIC ${conky_target_includes})
   target_link_libraries(conky_core ${conky_libs})
   add_executable(conky main.cc)
   add_dependencies(conky generated_hdr_files)
+  target_include_directories(conky PRIVATE ${conky_target_includes})
   target_link_libraries(conky conky_core ${conky_libs})
   install(TARGETS conky_core
     RUNTIME DESTINATION bin
@@ -467,6 +521,7 @@ if(BUILD_TESTING)
 else()
   add_executable(conky main.cc ${conky_sources} ${optional_sources})
   add_dependencies(conky generated_hdr_files)
+  target_include_directories(conky PRIVATE ${conky_target_includes})
   target_link_libraries(conky ${conky_libs})
 endif()
 

--- a/src/common.cc
+++ b/src/common.cc
@@ -46,15 +46,15 @@
 
 #include "config.h"
 #include "conky.h"
-#include "core.h"
-#include "data/fs.h"
-#include "logging.h"
-#include "data/misc.h"
-#include "data/network/net_stat.h"
 #include "content/specials.h"
 #include "content/temphelper.h"
+#include "core.h"
+#include "data/fs.h"
+#include "data/misc.h"
+#include "data/network/net_stat.h"
 #include "data/timeinfo.h"
 #include "data/top.h"
+#include "logging.h"
 
 #if defined(_POSIX_C_SOURCE) && !defined(__OpenBSD__) && !defined(__HAIKU__)
 #include <wordexp.h>
@@ -743,9 +743,7 @@ int if_existing_iftest(struct text_object *obj) {
 }
 
 int if_running_iftest(struct text_object *obj) {
-  if (!is_process_running(obj->data.s)) {
-    return 0;
-  }
+  if (!is_process_running(obj->data.s)) { return 0; }
   return 1;
 }
 
@@ -859,6 +857,17 @@ void print_include(struct text_object *obj, char *p, unsigned int p_max_size) {
 }
 
 #ifdef BUILD_CURL
+namespace {
+constexpr char kGithubNotificationsUrl[] =
+    "https://api.github.com/notifications";
+}
+
+std::string github_notifications_url() { return kGithubNotificationsUrl; }
+
+std::string github_authorization_header(const std::string &token) {
+  return "Authorization: Bearer " + token;
+}
+
 #define NEW_TOKEN                       \
   "https://github.com/settings/tokens/" \
   "new?scopes=notifications&description=conky-query-github\n"
@@ -908,14 +917,14 @@ static size_t read_github_data_cb(char *data, size_t size, size_t nmemb,
 
 void print_github(struct text_object *obj, char *p, unsigned int p_max_size) {
   (void)obj;
-  char github_url[256] = {""};
-  char user_agent[30] = {""};
   static char cached_result[256] = {""};
   static unsigned int last_update = 1U;
   CURL *curl = nullptr;
   CURLcode res;
+  struct curl_slist *headers = nullptr;
+  std::string token = github_token.get(*state);
 
-  if (0 == strcmp(github_token.get(*state).c_str(), "")) {
+  if (token.empty()) {
     NORM_ERR(
         "${github_notifications} requires token. "
         "Go ahead and generate one " NEW_TOKEN
@@ -931,21 +940,19 @@ void print_github(struct text_object *obj, char *p, unsigned int p_max_size) {
     return;
   }
 
-  snprintf(github_url, 255, "%s%s",
-           "https://api.github.com/notifications?access_token=",
-           github_token.get(*state).c_str());
-  /* unique string for each conky user, so we dont hit any query limits */
-  snprintf(user_agent, 29, "conky/%s", github_token.get(*state).c_str());
-
   curl_global_init(CURL_GLOBAL_ALL);
   if (nullptr == (curl = curl_easy_init())) { goto error; }
-  curl_easy_setopt(curl, CURLOPT_URL, github_url);
+  headers =
+      curl_slist_append(headers, github_authorization_header(token).c_str());
+  if (headers == nullptr) { goto error; }
+  curl_easy_setopt(curl, CURLOPT_URL, github_notifications_url().c_str());
+  curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 #if defined(CURLOPT_ACCEPT_ENCODING)
   curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "gzip");
 #else  /* defined(CURLOPT_ACCEPT_ENCODING) */
   curl_easy_setopt(curl, CURLOPT_ENCODING, "gzip");
 #endif /* defined(CURLOPT_ACCEPT_ENCODING) */
-  curl_easy_setopt(curl, CURLOPT_USERAGENT, user_agent);
+  curl_easy_setopt(curl, CURLOPT_USERAGENT, "conky-github/1.0");
   curl_easy_setopt(curl, CURLOPT_USE_SSL, (long)CURLUSESSL_ALL);
   curl_easy_setopt(curl, CURLOPT_TIMEOUT, 20L);
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, read_github_data_cb);
@@ -957,6 +964,7 @@ void print_github(struct text_object *obj, char *p, unsigned int p_max_size) {
   last_update = 60U;
 
 error:
+  if (headers != nullptr) { curl_slist_free_all(headers); }
   if (nullptr != curl) { curl_easy_cleanup(curl); }
   curl_global_cleanup();
 

--- a/src/common.h
+++ b/src/common.h
@@ -33,8 +33,8 @@
 #include <optional>
 #include <string>
 
-#include "lua/setting.hh"
 #include "content/text_object.h"
+#include "lua/setting.hh"
 
 char *readfile(const char *filename, int *total_read, char showerror);
 
@@ -203,6 +203,8 @@ int updatenr_iftest(struct text_object *);
 void print_github(struct text_object *, char *, unsigned int);
 void print_stock(struct text_object *, char *, unsigned int);
 void free_stock(struct text_object *);
+std::string github_notifications_url();
+std::string github_authorization_header(const std::string &token);
 #endif /* BUILD_CURL */
 
 #endif /* _COMMON_H */

--- a/src/data/network/ccurl_thread.cc
+++ b/src/data/network/ccurl_thread.cc
@@ -26,8 +26,8 @@
 #include <cmath>
 #include <mutex>
 #include "../../conky.h"
-#include "../../logging.h"
 #include "../../content/text_object.h"
+#include "../../logging.h"
 
 #ifdef DEBUG
 #include <assert.h>
@@ -86,7 +86,19 @@ curl_internal::curl_internal(const std::string &url) : curl(curl_easy_init()) {
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
   curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
   curl_easy_setopt(curl, CURLOPT_USERAGENT, "conky-curl/1.1");
+#ifdef CURLOPT_PROTOCOLS_STR
+  curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, "http,https");
+#elif defined(CURLOPT_PROTOCOLS)
+  curl_easy_setopt(curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+#endif
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
+  curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 3L);
+#ifdef CURLOPT_REDIR_PROTOCOLS_STR
+  curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS_STR, "http,https");
+#elif defined(CURLOPT_REDIR_PROTOCOLS)
+  curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS,
+                   CURLPROTO_HTTP | CURLPROTO_HTTPS);
+#endif
   curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1000);
   curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, 60);
 

--- a/src/data/network/rss.cc
+++ b/src/data/network/rss.cc
@@ -27,11 +27,11 @@
 #include <time.h>
 #include <cmath>
 #include <mutex>
-#include "ccurl_thread.h"
 #include "../../conky.h"
-#include "../../logging.h"
-#include "prss.h"
 #include "../../content/text_object.h"
+#include "../../logging.h"
+#include "ccurl_thread.h"
+#include "prss.h"
 
 struct rss_data {
   char uri[128];
@@ -60,6 +60,18 @@ class rss_cb : public curl_callback<std::shared_ptr<PRSS>> {
       : Base(period, Base::Tuple(uri)) {}
 };
 }  // namespace
+
+void rss_safe_append(char *dest, unsigned int dest_size, const char *src) {
+  if (dest == nullptr || src == nullptr || dest_size == 0) { return; }
+
+  size_t used = strnlen(dest, dest_size);
+  if (used >= dest_size - 1) {
+    dest[dest_size - 1] = '\0';
+    return;
+  }
+
+  snprintf(dest + used, dest_size - used, "%s", src);
+}
 
 static void rss_process_info(char *p, int p_max_size, const std::string &uri,
                              char *action, int act_par, int interval,
@@ -110,6 +122,7 @@ static void rss_process_info(char *p, int p_max_size, const std::string &uri,
       if (data->item_count > 0) {
         int itmp;
         int show;
+        *p = 0;
         //'tmpspaces' is a string with spaces too be placed in front of each
         // title
         char *tmpspaces = (char *)malloc(nrspaces + 1);
@@ -127,14 +140,14 @@ static void rss_process_info(char *p, int p_max_size, const std::string &uri,
           str = item->title;
           if (str) {
             // don't add new line before first item
-            if (itmp > 0) { strncat(p, "\n", p_max_size); }
+            if (itmp > 0) { rss_safe_append(p, p_max_size, "\n"); }
             /* remove trailing new line if one exists,
              * we have our own */
             if (strlen(str) > 0 && str[strlen(str) - 1] == '\n') {
               str[strlen(str) - 1] = 0;
             }
-            strncat(p, tmpspaces, p_max_size);
-            strncat(p, str, p_max_size);
+            rss_safe_append(p, p_max_size, tmpspaces);
+            rss_safe_append(p, p_max_size, str);
           }
         }
         free(tmpspaces);

--- a/src/data/network/rss.h
+++ b/src/data/network/rss.h
@@ -28,5 +28,6 @@
 void rss_scan_arg(struct text_object *, const char *);
 void rss_print_info(struct text_object *, char *, unsigned int);
 void rss_free_obj_info(struct text_object *);
+void rss_safe_append(char *dest, unsigned int dest_size, const char *src);
 
 #endif /*RSS_H_*/

--- a/src/output/display-http.cc
+++ b/src/output/display-http.cc
@@ -124,6 +124,36 @@ std::string string_replace_all(std::string original, const std::string &oldpart,
   return original;
 }
 
+std::string html_escape(const std::string &input) {
+  std::string escaped;
+  escaped.reserve(input.size());
+
+  for (char ch : input) {
+    switch (ch) {
+      case '&':
+        escaped.append("&amp;");
+        break;
+      case '<':
+        escaped.append("&lt;");
+        break;
+      case '>':
+        escaped.append("&gt;");
+        break;
+      case '"':
+        escaped.append("&quot;");
+        break;
+      case '\'':
+        escaped.append("&#39;");
+        break;
+      default:
+        escaped.push_back(ch);
+        break;
+    }
+  }
+
+  return escaped;
+}
+
 //}  // namespace priv
 
 display_output_http::display_output_http() : display_output_base("http") {
@@ -174,7 +204,7 @@ void display_output_http::end_draw_text() { webpage.append(WEBPAGE_END); }
 
 void display_output_http::draw_string(const char *s, int) {
   std::string::size_type origlen = webpage.length();
-  webpage.append(s);
+  webpage.append(html_escape(s));
   webpage = string_replace_all(webpage, "\n", "<br />", origlen);
   webpage = string_replace_all(webpage, "  ", "&nbsp;&nbsp;", origlen);
   webpage = string_replace_all(webpage, "&nbsp; ", "&nbsp;&nbsp;", origlen);

--- a/src/output/display-http.hh
+++ b/src/output/display-http.hh
@@ -29,8 +29,8 @@
 #include <string>
 #include <type_traits>
 
-#include "display-output.hh"
 #include "../lua/luamm.hh"
+#include "display-output.hh"
 
 namespace conky {
 
@@ -60,6 +60,8 @@ class display_output_http : public display_output_base {
   // std::string webpage;
   // struct MHD_Daemon *httpd;
 };
+
+std::string html_escape(const std::string &input);
 
 }  // namespace conky
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,9 @@ endif()
 add_library(Catch2 STATIC catch2/catch_amalgamated.cpp)
 
 add_executable(test-conky test-common.cc ${test_srcs})
+target_include_directories(test-conky PRIVATE
+  ${CMAKE_SOURCE_DIR}/src
+  ${CMAKE_BINARY_DIR})
 target_link_libraries(test-conky
   PRIVATE Catch2
   PUBLIC conky_core

--- a/tests/test-security.cc
+++ b/tests/test-security.cc
@@ -1,0 +1,44 @@
+#include <string>
+
+#include "catch2/catch.hpp"
+
+#include <config.h>
+
+#ifdef BUILD_HTTP
+#include <output/display-http.hh>
+#endif
+#ifdef BUILD_RSS
+#include <data/network/rss.h>
+#endif
+#ifdef BUILD_CURL
+#include <common.h>
+#endif
+
+#ifdef BUILD_HTTP
+TEST_CASE("html_escape escapes active markup", "[security][http]") {
+  REQUIRE(
+      conky::html_escape("<script>alert('x') & \"y\"</script>") ==
+      "&lt;script&gt;alert(&#39;x&#39;) &amp; &quot;y&quot;&lt;/script&gt;");
+}
+#endif
+
+#ifdef BUILD_RSS
+TEST_CASE("rss_safe_append truncates without overflowing", "[security][rss]") {
+  char buffer[8] = "ab";
+
+  rss_safe_append(buffer, sizeof(buffer), "cdef");
+  REQUIRE(std::string(buffer) == "abcdef");
+
+  rss_safe_append(buffer, sizeof(buffer), "ghijk");
+  REQUIRE(std::string(buffer) == "abcdefg");
+}
+#endif
+
+#ifdef BUILD_CURL
+TEST_CASE("github_notifications uses auth header instead of query params",
+          "[security][github]") {
+  REQUIRE(github_notifications_url() == "https://api.github.com/notifications");
+  REQUIRE(github_authorization_header("secret-token") ==
+          "Authorization: Bearer secret-token");
+}
+#endif


### PR DESCRIPTION
## Summary

This change hardens several network-facing paths and fixes the Darwin/Nix build and test plumbing needed to validate those paths reliably.

Before this patch, Conky had multiple security issues in feature-enabled builds. RSS title aggregation appended into a fixed-size buffer with repeated `strncat()` calls using the full destination size instead of remaining capacity, which could overflow the output buffer on oversized or malicious feed content. The HTTP output backend rendered unescaped text directly into the generated page, so untrusted content from sources such as RSS items or command output could become active markup in a browser. The GitHub notifications fetch leaked credentials by placing the token in the request URL and in the `User-Agent`, which exposed the token to logs and intermediaries. The shared curl wrapper also followed redirects without restricting protocols or redirect targets, which allowed attacker-controlled endpoints to pivot requests unexpectedly.

The root cause in the runtime code was a mix of unsafe string handling, missing output encoding, and permissive network request defaults. The root cause in the build and test layer was weaker Darwin fallback detection under a Nix toolchain, where CMake could resolve incomplete or mismatched dependency information and feature-enabled builds could lose required include paths.

This patch addresses the runtime issues by introducing bounded RSS appends, escaping HTML output before it is served over the HTTP backend, switching GitHub notifications to an `Authorization: Bearer` header, and constraining curl requests and redirects to HTTP(S) with a redirect cap. It also adds regression coverage for those behaviors.

On the build side, the patch tightens feature detection rather than making it more permissive. Darwin gettext lookup now uses Homebrew only as a fallback instead of overriding a valid existing `Intl` result. The `libmicrohttpd` fallback path now enforces the same minimum version requirement as the pkg-config path and reports a clear error when detection fails. The curl fallback rejects mixed header/library installations instead of silently accepting them. For Darwin/Nix specifically, the build now propagates the required include paths for feature-enabled builds and adds the SDK Objective-C headers to `darwin.mm` in a narrow way so Objective-C++ compilation works without regressing libc++ lookup.

For users, the effect is that feature-enabled builds are safer and more predictable. Network-driven content is no longer able to trigger the previously identified memory corruption or HTML injection paths, GitHub tokens are no longer exposed in request metadata, and the feature-enabled Darwin build used to validate these changes is working again in the supported shell environment.

## Validation

I validated the change with the following checks:

- `cmake -S . -B build -G Ninja -DBUILD_CURL=ON -DBUILD_RSS=ON -DBUILD_HTTP=ON -DBUILD_I18N=ON`
- `cmake --build build --target test-conky`
- `ctest --test-dir build --output-on-failure`
- `./build/tests/test-conky "[security]"`
- `git diff --check`

The full test suite passed locally in the Darwin/Nix environment, and the security-specific Catch2 tests passed as well.
