### PR TITLE
fix: percent_print respects use_spacer when pad_percents is unset

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -507,7 +507,11 @@ int spaced_print(char *buf, int size, const char *format, int width, ...) {
  * - i.e., unsigned values between 0 and 100
  * - respect the value of pad_percents */
 int percent_print(char *buf, int size, unsigned value) {
-  return spaced_print(buf, size, "%u", pad_percents.get(*state), value);
+  int width = pad_percents.get(*state);
+  if(width == 0){
+    width = 3;
+  }
+  return spaced_print(buf, size, "%u", width, value);
 }
 
 /* converts from bytes to human readable format (K, M, G, T)


### PR DESCRIPTION
## Problem
`use_spacer = 'left'` was ignored for `${cpu}` and other percentage 
values when `pad_percents` was not explicitly set.

## Root Cause
`percent_print()` passed `pad_percents` (default: 0) as width to 
`spaced_print()`. A width of 0 means no padding, so spacer had no effect.

## Fix
Default width to 3 when `pad_percents` is unset, since percentage 
values are always 1-3 digits (0-100).

## Testing
Tested on Arch Linux with `use_spacer = 'left'`:
Before: `CPU: 5%` `CPU: 14%` (inconsistent width)
After:  `CPU:   5%` `CPU:  14%` (consistent width)

Closes #2078