### PR TITLE
fix: Fixed rendering of gradients in graphs

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1000,7 +1000,7 @@ static inline void set_foreground_color(Colour c) {
 
 static inline void draw_graph_bars(special_node *current, std::unique_ptr<Colour[]>& tmpcolour, 
                             conky::vec2i& text_offset, int i, int &j, int w, 
-                            int colour_idx, int cur_x, int by, int h) {
+                            int &colour_idx, int cur_x, int by, int h) {
   double graphheight = current->graph[j] * (h - 1) / current->scale;
   /* Check if graphheight is less than the minheight threshold, if so we must change it to the threshold */
   if(graphheight > 0 && current->minheight - graphheight > 0) {


### PR DESCRIPTION
The incrementation of the colour_idx variable was no longer working after it was moved into a function and only incremented the parameter instead.

Closes #2169

# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [ ] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

* Describe the changes, why they were necessary, etc

Gradient rendering in graphs did not work.

* Describe how you tested and validated your changes.

Ran the old and patched version and verified that gradients only work in the patched version.

