### PR TITLE
fix(x11): mouse event handling - scroll direction, hit testing, XInput2 performance; always use XI2

### DIFF
--- a/cmake/ConkyBuildOptions.cmake
+++ b/cmake/ConkyBuildOptions.cmake
@@ -223,10 +223,6 @@ dependent_option(BUILD_IMLIB2 "Enable Imlib2 support" true
 dependent_option(BUILD_XSHAPE "Enable Xshape support" true
   "BUILD_X11" false
   "Xshape support requires X11")
-dependent_option(BUILD_XINPUT "Build Xinput 2 support (slow)" false
-  "BUILD_X11" false
-  "Xinput 2 support requires X11")
-
 # if we build with any GUI support
 if(BUILD_X11)
   set(BUILD_GUI true)

--- a/cmake/ConkyPlatformChecks.cmake
+++ b/cmake/ConkyPlatformChecks.cmake
@@ -641,14 +641,11 @@ if(BUILD_X11)
       set(conky_libs ${conky_libs} ${X11_Xfixes_LIB})
     endif(BUILD_XFIXES)
 
-    # check for Xinput
-    if(BUILD_XINPUT)
-      if(NOT X11_Xinput_FOUND)
-        message(FATAL_ERROR "Unable to find Xinput library")
-      endif(NOT X11_Xinput_FOUND)
-
-      set(conky_libs ${conky_libs} ${X11_Xinput_LIB})
-    endif(BUILD_XINPUT)
+    # XInput2 (always enabled with X11)
+    if(NOT X11_Xinput_FOUND)
+      message(FATAL_ERROR "Unable to find Xinput library")
+    endif(NOT X11_Xinput_FOUND)
+    set(conky_libs ${conky_libs} ${X11_Xinput_LIB})
 
     if(X11_xcb_FOUND)
       set(HAVE_XCB true)

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -64,8 +64,6 @@
 
 #cmakedefine BUILD_XFIXES 1
 
-#cmakedefine BUILD_XINPUT 1
-
 #cmakedefine BUILD_ARGB 1
 
 #cmakedefine BUILD_XDBE 1

--- a/data/conky_mouse_events.conf
+++ b/data/conky_mouse_events.conf
@@ -1,0 +1,55 @@
+-- Example: Lua mouse event handling
+--
+-- Demonstrates the lua_mouse_hook API. Run with:
+--   conky -c conky_mouse_events.conf
+--
+-- The hook receives a table with the following fields:
+--
+--   All events:
+--     type      string  "button_down", "button_up", "mouse_scroll",
+--                       "mouse_move", "mouse_enter", "mouse_leave"
+--     time      number  milliseconds since epoch
+--     x, y      number  position relative to conky window
+--     x_abs, y_abs  number  position relative to root/screen
+--
+--   button_down / button_up:
+--     button       string  "left", "right", "middle", "back", "forward"
+--     button_code  number  raw evdev button code
+--     mods         table   { shift, control, alt, super, caps_lock, num_lock }
+--
+--   mouse_scroll:
+--     direction  string  "up", "down", "left", "right"
+--     mods       table   (same as above)
+--
+--   mouse_move:
+--     mods  table  (same as above)
+--
+-- Return true from the hook to consume the event (prevent propagation
+-- to windows below conky). Return false to let it pass through.
+
+conky.config = {
+    alignment = 'top_left',
+    background = false,
+    double_buffer = true,
+    font = 'DejaVu Sans Mono:size=10',
+    gap_x = 60,
+    gap_y = 60,
+    minimum_width = 300,
+    minimum_height = 200,
+    own_window = true,
+    own_window_class = 'Conky',
+    own_window_type = 'normal',
+    own_window_hints = 'undecorated,sticky,below,skip_taskbar,skip_pager',
+    out_to_x = true,
+    update_interval = 1.0,
+    use_xft = true,
+    lua_load = './mouse_events.lua',
+    lua_mouse_hook = 'conky_on_mouse_event',
+}
+
+conky.text = [[
+${color grey}Mouse Event Example$color
+$hr
+Move mouse over this window, click, or scroll.
+Watch the terminal for event output.
+]]

--- a/data/mouse_events.lua
+++ b/data/mouse_events.lua
@@ -1,0 +1,56 @@
+local function print_pos(event)
+    print(string.format("  pos: (%d, %d)  abs: (%d, %d)",
+        event.x, event.y, event.x_abs, event.y_abs))
+    print(string.format("  time: %d", event.time))
+end
+
+local function print_mods(mods)
+    local held = {}
+    for k, v in pairs(mods) do
+        if v then held[#held + 1] = k end
+    end
+    if #held > 0 then
+        print("  mods: " .. table.concat(held, ", "))
+    end
+end
+
+function conky_on_mouse_event(event)
+    if event.type == "button_down" then
+        print("[button_down]")
+        print_pos(event)
+        print("  button: " .. tostring(event.button)
+            .. " (code " .. tostring(event.button_code) .. ")")
+        print_mods(event.mods)
+        return true
+
+    elseif event.type == "button_up" then
+        print("[button_up]")
+        print_pos(event)
+        print("  button: " .. tostring(event.button)
+            .. " (code " .. tostring(event.button_code) .. ")")
+        print_mods(event.mods)
+        return true
+
+    elseif event.type == "mouse_scroll" then
+        print("[mouse_scroll]")
+        print_pos(event)
+        print("  direction: " .. tostring(event.direction))
+        print_mods(event.mods)
+        return true
+
+    elseif event.type == "mouse_move" then
+        -- Uncomment to log movement (will spam the terminal):
+        -- print(string.format("[mouse_move] (%d, %d)", event.x, event.y))
+        return false
+
+    elseif event.type == "mouse_enter" then
+        print("[mouse_enter]")
+        print_pos(event)
+
+    elseif event.type == "mouse_leave" then
+        print("[mouse_leave]")
+        print_pos(event)
+    end
+
+    return false
+end

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -356,10 +356,10 @@ if(BUILD_GUI)
   set(gui lua/fonts.cc lua/fonts.h output/gui.cc output/gui.h)
   set(optional_sources ${optional_sources} ${gui})
 
-  if(BUILD_MOUSE_EVENTS OR BUILD_XINPUT)
+  if(BUILD_MOUSE_EVENTS OR BUILD_X11)
     set(mouse_events mouse-events.cc mouse-events.h)
     set(optional_sources ${optional_sources} ${mouse_events})
-  endif(BUILD_MOUSE_EVENTS OR BUILD_XINPUT)
+  endif(BUILD_MOUSE_EVENTS OR BUILD_X11)
 endif(BUILD_GUI)
 
 if(BUILD_WAYLAND)

--- a/src/main.cc
+++ b/src/main.cc
@@ -192,9 +192,7 @@ static void print_version() {
 #ifdef BUILD_XFT
             << _("  * Xft\n")
 #endif /* BUILD_XFT */
-#ifdef BUILD_XINPUT
             << _("  * Xinput\n")
-#endif /* BUILD_XINPUT */
 #ifdef BUILD_ARGB
             << _("  * ARGB visual\n")
 #endif /* BUILD_ARGB */

--- a/src/mouse-events.cc
+++ b/src/mouse-events.cc
@@ -27,9 +27,7 @@
 
 #include "logging.h"
 
-#ifdef BUILD_XINPUT
 #include <cstring>
-#endif
 
 extern "C" {
 #include <lua.h>
@@ -216,7 +214,7 @@ void mouse_button_event::push_lua_data(lua_State *L) const {
 }
 #endif /* BUILD_MOUSE_EVENTS */
 
-#ifdef BUILD_XINPUT
+#ifdef BUILD_X11
 /// Last global device id.
 size_t last_device_id = 0;
 
@@ -668,6 +666,6 @@ std::vector<std::tuple<int, XEvent *>> xi_event_data::generate_events(
 
   return result;
 }
-#endif /* BUILD_XINPUT */
+#endif /* BUILD_X11 */
 
 }  // namespace conky

--- a/src/mouse-events.cc
+++ b/src/mouse-events.cc
@@ -532,6 +532,8 @@ std::optional<double> xi_event_data::valuator_value(valuator_t valuator) const {
 
 std::optional<double> xi_event_data::valuator_relative_value(
     valuator_t valuator) const {
+  auto &info = this->device->valuator(valuator);
+  if (this->valuators.count(info.index) == 0) return std::nullopt;
   return this->valuators_relative.at(*valuator);
 }
 
@@ -568,10 +570,7 @@ std::vector<std::tuple<int, XEvent *>> xi_event_data::generate_events(
       result.emplace_back(std::make_tuple(PointerMotionMask, produced));
     }
     if (is_scroll) {
-      XEvent *produced = new XEvent;
-      std::memset(produced, 0, sizeof(XEvent));
-
-      uint scroll_direction = 4;
+      uint scroll_direction = 0;
       auto vertical = this->valuator_relative_value(valuator_t::SCROLL_Y);
       double vertical_value = vertical.value_or(0.0);
 
@@ -590,27 +589,32 @@ std::vector<std::tuple<int, XEvent *>> xi_event_data::generate_events(
         }
       }
 
-      XButtonEvent *e = &produced->xbutton;
-      e->display = display;
-      e->root = this->root;
-      e->window = target;
-      e->subwindow = child;
-      e->time = CurrentTime;
-      e->x = static_cast<int>(target_pos.x());
-      e->y = static_cast<int>(target_pos.y());
-      e->x_root = static_cast<int>(this->pos_absolute.x());
-      e->y_root = static_cast<int>(this->pos_absolute.y());
-      e->state = this->mods.effective;
-      e->button = scroll_direction;
-      e->same_screen = True;
+      if (scroll_direction != 0) {
+        XEvent *produced = new XEvent;
+        std::memset(produced, 0, sizeof(XEvent));
 
-      XEvent *press = new XEvent;
-      e->type = ButtonPress;
-      std::memcpy(press, produced, sizeof(XEvent));
-      result.emplace_back(std::make_tuple(ButtonPressMask, press));
+        XButtonEvent *e = &produced->xbutton;
+        e->display = display;
+        e->root = this->root;
+        e->window = target;
+        e->subwindow = child;
+        e->time = CurrentTime;
+        e->x = static_cast<int>(target_pos.x());
+        e->y = static_cast<int>(target_pos.y());
+        e->x_root = static_cast<int>(this->pos_absolute.x());
+        e->y_root = static_cast<int>(this->pos_absolute.y());
+        e->state = this->mods.effective;
+        e->button = scroll_direction;
+        e->same_screen = True;
 
-      e->type = ButtonRelease;
-      result.emplace_back(std::make_tuple(ButtonReleaseMask, produced));
+        XEvent *press = new XEvent;
+        e->type = ButtonPress;
+        std::memcpy(press, produced, sizeof(XEvent));
+        result.emplace_back(std::make_tuple(ButtonPressMask, press));
+
+        e->type = ButtonRelease;
+        result.emplace_back(std::make_tuple(ButtonReleaseMask, produced));
+      }
     }
   } else {
     XEvent *produced = new XEvent;

--- a/src/mouse-events.cc
+++ b/src/mouse-events.cc
@@ -389,6 +389,29 @@ void device_info::init_xi_device(
         fixed_valuator_index(display, device, static_cast<valuator_t>(i));
   }
 
+  // Discover scroll valuator indices and increments from XIScrollClass.
+  // These are authoritative for scroll axis mapping and direction convention.
+  std::map<size_t, double> scroll_increments;
+  for (int i = 0; i < device->num_classes; i++) {
+    if (device->classes[i]->type != XIScrollClass) continue;
+    auto *si = reinterpret_cast<XIScrollClassInfo *>(device->classes[i]);
+    scroll_increments[si->number] = si->increment;
+
+    valuator_t target = valuator_t::UNKNOWN;
+    if (si->scroll_type == XIScrollTypeVertical)
+      target = valuator_t::SCROLL_Y;
+    else if (si->scroll_type == XIScrollTypeHorizontal)
+      target = valuator_t::SCROLL_X;
+
+    if (target != valuator_t::UNKNOWN) {
+      // Override hardcoded ordinal default, but respect user overrides.
+      // If fixed_valuator_index returned the ordinal default, replace it.
+      if (valuator_indices[*target] == *target) {
+        valuator_indices[*target] = si->number;
+      }
+    }
+  }
+
   // class order is undefined!
   for (int i = 0; i < device->num_classes; i++) {
     if (device->classes[i]->type != XIValuatorClass) continue;
@@ -412,6 +435,10 @@ void device_info::init_xi_device(
         .relative =
             fixed_valuator_relative(display, device, valuator, class_info),
     };
+
+    // Store scroll increment if this valuator has an associated XIScrollClass.
+    auto it = scroll_increments.find(class_info->number);
+    if (it != scroll_increments.end()) { info.increment = it->second; }
 
     this->valuators[*valuator] = info;
   }
@@ -479,9 +506,8 @@ xi_event_data *xi_event_data::read_cookie(Display *display, const void *data) {
     if (valuator_info.relative) {
       result->valuators_relative[v] = current;
     } else {
-      // XXX these doubles come from int values and might wrap around though
-      // it's hard to tell what int type is the source as it depends on the
-      // device/driver.
+      // Source int width is driver-dependent; wraparound is theoretically
+      // possible but unrealistic with 32-bit values.
       result->valuators_relative[v] = current - valuator_info.value;
     }
     valuator_info.value = current;
@@ -550,12 +576,17 @@ std::vector<std::tuple<int, XEvent *>> xi_event_data::generate_events(
       double vertical_value = vertical.value_or(0.0);
 
       if (vertical_value != 0.0) {
-        scroll_direction = vertical_value < 0.0 ? Button4 : Button5;
+        double increment =
+            this->device->valuator(valuator_t::SCROLL_Y).increment;
+        scroll_direction =
+            (vertical_value * increment) < 0.0 ? Button4 : Button5;
       } else {
         auto horizontal = this->valuator_relative_value(valuator_t::SCROLL_X);
         double horizontal_value = horizontal.value_or(0.0);
         if (horizontal_value != 0.0) {
-          scroll_direction = horizontal_value < 0.0 ? 6 : 7;
+          double increment =
+              this->device->valuator(valuator_t::SCROLL_X).increment;
+          scroll_direction = (horizontal_value * increment) < 0.0 ? 6 : 7;
         }
       }
 

--- a/src/mouse-events.cc
+++ b/src/mouse-events.cc
@@ -387,9 +387,16 @@ void device_info::init_xi_device(
         fixed_valuator_index(display, device, static_cast<valuator_t>(i));
   }
 
-  // Discover scroll valuator indices and increments from XIScrollClass.
-  // These are authoritative for scroll axis mapping and direction convention.
+  // XIScrollClass is the authoritative source for scroll valuator mapping.
+  // Per the spec, each XIScrollClassInfo::number corresponds to an
+  // XIValuatorClassInfo with the same number. Don't guess from ordinals.
+  // Devices without XIScrollClass entries have no scroll valuators; scroll
+  // is handled via button 4-7 events instead.
   std::map<size_t, double> scroll_increments;
+  // Invalidate ordinal defaults; keep user overrides from fixed_valuator_index.
+  for (auto sv : {valuator_t::SCROLL_X, valuator_t::SCROLL_Y}) {
+    if (valuator_indices[*sv] == *sv) { valuator_indices[*sv] = SIZE_MAX; }
+  }
   for (int i = 0; i < device->num_classes; i++) {
     if (device->classes[i]->type != XIScrollClass) continue;
     auto *si = reinterpret_cast<XIScrollClassInfo *>(device->classes[i]);
@@ -401,12 +408,14 @@ void device_info::init_xi_device(
     else if (si->scroll_type == XIScrollTypeHorizontal)
       target = valuator_t::SCROLL_X;
 
-    if (target != valuator_t::UNKNOWN) {
-      // Override hardcoded ordinal default, but respect user overrides.
-      // If fixed_valuator_index returned the ordinal default, replace it.
-      if (valuator_indices[*target] == *target) {
-        valuator_indices[*target] = si->number;
-      }
+    // Only set if not already claimed and doesn't conflict with a move axis.
+    // Some devices (e.g. Xephyr) alias scroll and move to the same valuator;
+    // movement deltas would be misinterpreted as scroll.
+    if (target != valuator_t::UNKNOWN &&
+        valuator_indices[*target] == SIZE_MAX &&
+        si->number != valuator_indices[*valuator_t::MOVE_X] &&
+        si->number != valuator_indices[*valuator_t::MOVE_Y]) {
+      valuator_indices[*target] = si->number;
     }
   }
 

--- a/src/mouse-events.h
+++ b/src/mouse-events.h
@@ -31,24 +31,20 @@
 #include "geometry.h"
 #include "logging.h"
 
-#ifdef BUILD_XINPUT
+#ifdef BUILD_X11
 #include <array>
 #include <map>
 #include <tuple>
 #include <variant>
 #include <vector>
-#endif /* BUILD_XINPUT */
+#endif /* BUILD_X11 */
 
 extern "C" {
 #ifdef BUILD_X11
 #include <X11/X.h>
-
-#ifdef BUILD_XINPUT
 #include <X11/extensions/XInput.h>
 #include <X11/extensions/XInput2.h>
 #undef COUNT  // define from X11/extensions/Xi.h
-
-#endif /* BUILD_XINPUT */
 #endif /* BUILD_X11 */
 
 #include <lua.h>
@@ -255,7 +251,7 @@ struct mouse_crossing_event : public mouse_positioned_event {
 };
 #endif /* BUILD_MOUSE_EVENTS */
 
-#ifdef BUILD_XINPUT
+#ifdef BUILD_X11
 typedef int xi_device_id;
 typedef int xi_event_type;
 
@@ -336,7 +332,7 @@ struct xi_event_data {
       Window target, Window child, conky::vec2d target_pos) const;
 };
 
-#endif /* BUILD_XINPUT */
+#endif /* BUILD_X11 */
 }  // namespace conky
 
 #endif /* MOUSE_EVENTS_H */

--- a/src/mouse-events.h
+++ b/src/mouse-events.h
@@ -277,6 +277,9 @@ struct conky_valuator_info {
   double max;
   double value;
   bool relative;
+  /// Scroll increment from XIScrollClassInfo; sign defines direction convention.
+  /// Positive means increasing valuator value = down/right.
+  double increment = 1.0;
 };
 
 struct device_info {

--- a/src/mouse-events.h
+++ b/src/mouse-events.h
@@ -262,11 +262,11 @@ constexpr uint8_t operator*(valuator_t index) {
 }
 
 struct conky_valuator_info {
-  size_t index;
-  double min;
-  double max;
-  double value;
-  bool relative;
+  size_t index = SIZE_MAX;
+  double min = 0.0;
+  double max = 0.0;
+  double value = 0.0;
+  bool relative = false;
   /// Scroll increment from XIScrollClassInfo; sign defines direction convention.
   /// Positive means increasing valuator value = down/right.
   double increment = 1.0;

--- a/src/mouse-events.h
+++ b/src/mouse-events.h
@@ -23,6 +23,7 @@
 
 #include <bitset>
 #include <cstdint>
+#include <optional>
 #include <string>
 
 #include "config.h"
@@ -33,7 +34,6 @@
 #ifdef BUILD_XINPUT
 #include <array>
 #include <map>
-#include <optional>
 #include <tuple>
 #include <variant>
 #include <vector>
@@ -106,29 +106,23 @@ constexpr uint32_t operator*(mouse_button_t index) {
 }
 
 #ifdef BUILD_X11
-inline mouse_button_t x11_mouse_button_code(unsigned int x11_mouse_button) {
-  mouse_button_t button;
+inline std::optional<mouse_button_t> x11_mouse_button_code(
+    unsigned int x11_mouse_button) {
   switch (x11_mouse_button) {
     case Button1:
-      button = mouse_button_t::LEFT;
-      break;
+      return mouse_button_t::LEFT;
     case Button2:
-      button = mouse_button_t::MIDDLE;
-      break;
+      return mouse_button_t::MIDDLE;
     case Button3:
-      button = mouse_button_t::RIGHT;
-      break;
+      return mouse_button_t::RIGHT;
     case 8:
-      button = mouse_button_t::BACK;
-      break;
+      return mouse_button_t::BACK;
     case 9:
-      button = mouse_button_t::FORWARD;
-      break;
+      return mouse_button_t::FORWARD;
     default:
       DBGP("X11 button %d is not mapped", x11_mouse_button);
-      break;
+      return std::nullopt;
   }
-  return button;
 }
 #endif /* BUILD_X11 */
 

--- a/src/output/display-x11.cc
+++ b/src/output/display-x11.cc
@@ -405,7 +405,6 @@ enum class x_event_handler {
   EXPOSE,
   REPARENT,
   CONFIGURE,
-  BORDER_CROSSING,
   DAMAGE,
 };
 
@@ -420,13 +419,10 @@ template <>
 bool handle_event<x_event_handler::MOUSE_INPUT>(
     conky::display_output_x11 *surface, Display *display, XEvent &ev,
     bool *consumed, void **cookie) {
-#ifdef BUILD_X11
   if (ev.type == ButtonPress || ev.type == ButtonRelease ||
       ev.type == MotionNotify) {
-    // destroy basic X11 events; and manufacture them later when trying to
-    // propagate XInput ones - this is required because there's no (simple) way
-    // of making sure the lua hook controls both when it only handles XInput
-    // ones.
+    // Consume basic X11 input events; XInput2 handles these and synthesizes
+    // legacy events for propagation when needed.
     *consumed = true;
     return true;
   }
@@ -577,58 +573,6 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
         type, data->pos, data->pos_absolute, button.value(), mods));
   }
 #endif /* BUILD_MOUSE_EVENTS */
-
-#else /* BUILD_X11 */
-  if (ev.type != ButtonPress && ev.type != ButtonRelease &&
-      ev.type != MotionNotify)
-    return false;
-  if (ev.xany.window != window.window) return true;  // Skip other windows
-
-#ifdef BUILD_MOUSE_EVENTS
-  switch (ev.type) {
-    case ButtonPress: {
-      modifier_state_t mods = x11_modifier_state(ev.xbutton.state);
-      if (ev.xbutton.button >= 4 &&
-          ev.xbutton.button <= 7) {  // scroll "buttons"
-        scroll_direction_t direction = x11_scroll_direction(ev.xbutton.button);
-        *consumed = llua_mouse_hook(mouse_scroll_event(
-            vec2i(ev.xbutton.x, ev.xbutton.y),
-            vec2i(ev.xbutton.x_root, ev.xbutton.y_root), direction, mods));
-      } else {
-        auto button = x11_mouse_button_code(ev.xbutton.button);
-        if (button.has_value()) {
-          *consumed = llua_mouse_hook(mouse_button_event(
-              mouse_event_t::PRESS, vec2i(ev.xbutton.x, ev.xbutton.y),
-              vec2i(ev.xbutton.x_root, ev.xbutton.y_root), button.value(),
-              mods));
-        }
-      }
-      break;
-    }
-    case ButtonRelease: {
-      /* don't report scroll release events */
-      if (ev.xbutton.button >= 4 && ev.xbutton.button <= 7) return true;
-
-      modifier_state_t mods = x11_modifier_state(ev.xbutton.state);
-      auto button = x11_mouse_button_code(ev.xbutton.button);
-      if (button.has_value()) {
-        *consumed = llua_mouse_hook(mouse_button_event(
-            mouse_event_t::RELEASE, vec2i(ev.xbutton.x, ev.xbutton.y),
-            vec2i(ev.xbutton.x_root, ev.xbutton.y_root), button.value(),
-            mods));
-      }
-      break;
-    }
-    case MotionNotify: {
-      modifier_state_t mods = x11_modifier_state(ev.xmotion.state);
-      *consumed = llua_mouse_hook(
-          mouse_move_event(vec2i(ev.xmotion.x, ev.xmotion.y),
-                           vec2i(ev.xmotion.x_root, ev.xmotion.y_root), mods));
-      break;
-    }
-  }
-#endif /* BUILD_MOUSE_EVENTS */
-#endif /* BUILD_X11 */
 #ifndef BUILD_MOUSE_EVENTS
   // always propagate mouse input if not handling mouse events
   *consumed = false;
@@ -710,29 +654,6 @@ bool handle_event<x_event_handler::CONFIGURE>(
 
   return true;
 }
-
-#ifdef BUILD_MOUSE_EVENTS
-template <>
-bool handle_event<x_event_handler::BORDER_CROSSING>(
-    conky::display_output_x11 *surface, Display *display, XEvent &ev,
-    bool *consumed, void **cookie) {
-  if (ev.type != EnterNotify && ev.type != LeaveNotify) return false;
-  if (window.xi_opcode != 0) return true;  // handled by mouse_input already
-
-  auto crossing_pos = vec2i(ev.xcrossing.x_root, ev.xcrossing.y_root);
-  bool over_conky = window.geometry.contains(crossing_pos);
-
-  if ((!over_conky && ev.xcrossing.type == LeaveNotify) ||
-      (over_conky && ev.xcrossing.type == EnterNotify)) {
-    llua_mouse_hook(mouse_crossing_event(
-        ev.xcrossing.type == EnterNotify ? mouse_event_t::AREA_ENTER
-                                         : mouse_event_t::AREA_LEAVE,
-        vec2i(ev.xcrossing.x, ev.xcrossing.y),
-        vec2i(ev.xcrossing.x_root, ev.xcrossing.y_root)));
-  }
-  return true;
-}
-#endif /* BUILD_MOUSE_EVENTS */
 #endif /* OWN_WINDOW */
 
 template <>
@@ -826,7 +747,6 @@ bool process_event(conky::display_output_x11 *surface, Display *display,
   HANDLE_EV(EXPOSE)
   HANDLE_EV(REPARENT)
   HANDLE_EV(CONFIGURE)
-  HANDLE_EV(BORDER_CROSSING)
   HANDLE_EV(DAMAGE)
 
 #undef HANDLE_EV

--- a/src/output/display-x11.cc
+++ b/src/output/display-x11.cc
@@ -397,6 +397,9 @@ bool display_output_x11::main_loop_wait(double t) {
   return true;
 }
 
+/// Cached top-level parent of conky's window; invalidated on ReparentNotify.
+static Window window_top_parent = None;
+
 enum class x_event_handler {
   XINPUT_MOTION,
   MOUSE_INPUT,
@@ -454,12 +457,22 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
   }
   *cookie = data;
 
-  Window event_window = query_x11_window_at_pos(display, data->pos_absolute, data->device->master);
-
-  bool same_window = query_x11_top_parent(display, event_window) ==
-                     query_x11_top_parent(display, window.window);
-  bool cursor_over_conky =
-      same_window && window.geometry.contains(data->pos_absolute);
+  // Fast reject: if cursor is outside our geometry, it's definitely not over
+  // this conky instance.  This avoids expensive X11 round-trips
+  // (XIQueryPointer + XQueryTree) for the vast majority of events when
+  // multiple conky instances are running.  See #1886.
+  bool inside_geometry = window.geometry.contains(data->pos_absolute);
+  bool cursor_over_conky = false;
+  if (inside_geometry) {
+    Window event_window = query_x11_window_at_pos(
+        display, data->pos_absolute, data->device->master);
+    if (window_top_parent == None) {
+      window_top_parent = query_x11_top_parent(display, window.window);
+    }
+    bool same_window =
+        query_x11_top_parent(display, event_window) == window_top_parent;
+    cursor_over_conky = same_window;
+  }
 
   // XInput reports events twice on some hardware (even by 'xinput --test-xi2')
   auto hash = std::make_tuple(data->serial, data->evtype, data->event);
@@ -649,6 +662,8 @@ bool handle_event<x_event_handler::REPARENT>(conky::display_output_x11 *surface,
   if (ev.type != ReparentNotify) return false;
 
   if (own_window.get(*state)) { set_transparent_background(window.window); }
+  // Invalidate cached top parent -- window tree changed.
+  window_top_parent = None;
   return true;
 }
 

--- a/src/output/display-x11.cc
+++ b/src/output/display-x11.cc
@@ -43,14 +43,12 @@
 #ifdef BUILD_IMLIB2
 #include "../conky-imlib2.h"
 #endif /* BUILD_IMLIB2 */
-#if defined(BUILD_MOUSE_EVENTS) || defined(BUILD_XINPUT)
+#ifdef BUILD_MOUSE_EVENTS
 #include "../mouse-events.h"
-#endif /* BUILD_MOUSE_EVENTS || BUILD_XINPUT */
-#ifdef BUILD_XINPUT
+#endif /* BUILD_MOUSE_EVENTS */
 #include <X11/extensions/XI2.h>
 #include <X11/extensions/XInput2.h>
 #undef COUNT
-#endif /* BUILD_XINPUT */
 #include <X11/Xresource.h>
 
 #include <cstdint>
@@ -422,7 +420,7 @@ template <>
 bool handle_event<x_event_handler::MOUSE_INPUT>(
     conky::display_output_x11 *surface, Display *display, XEvent &ev,
     bool *consumed, void **cookie) {
-#ifdef BUILD_XINPUT
+#ifdef BUILD_X11
   if (ev.type == ButtonPress || ev.type == ButtonRelease ||
       ev.type == MotionNotify) {
     // destroy basic X11 events; and manufacture them later when trying to
@@ -580,7 +578,7 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
   }
 #endif /* BUILD_MOUSE_EVENTS */
 
-#else /* BUILD_XINPUT */
+#else /* BUILD_X11 */
   if (ev.type != ButtonPress && ev.type != ButtonRelease &&
       ev.type != MotionNotify)
     return false;
@@ -630,7 +628,7 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
     }
   }
 #endif /* BUILD_MOUSE_EVENTS */
-#endif /* BUILD_XINPUT */
+#endif /* BUILD_X11 */
 #ifndef BUILD_MOUSE_EVENTS
   // always propagate mouse input if not handling mouse events
   *consumed = false;

--- a/src/output/display-x11.cc
+++ b/src/output/display-x11.cc
@@ -556,12 +556,14 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
       return true;
     }
 
+    auto button = x11_mouse_button_code(data->detail);
+    if (!button.has_value()) return true;
+
     mouse_event_t type = mouse_event_t::PRESS;
     if (data->evtype == XI_ButtonRelease) { type = mouse_event_t::RELEASE; }
 
-    mouse_button_t button = x11_mouse_button_code(data->detail);
-    *consumed = llua_mouse_hook(
-        mouse_button_event(type, data->pos, data->pos_absolute, button, mods));
+    *consumed = llua_mouse_hook(mouse_button_event(
+        type, data->pos, data->pos_absolute, button.value(), mods));
   }
 #endif /* BUILD_MOUSE_EVENTS */
 
@@ -582,10 +584,13 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
             vec2i(ev.xbutton.x, ev.xbutton.y),
             vec2i(ev.xbutton.x_root, ev.xbutton.y_root), direction, mods));
       } else {
-        mouse_button_t button = x11_mouse_button_code(ev.xbutton.button);
-        *consumed = llua_mouse_hook(mouse_button_event(
-            mouse_event_t::PRESS, vec2i(ev.xbutton.x, ev.xbutton.y),
-            vec2i(ev.xbutton.x_root, ev.xbutton.y_root), button, mods));
+        auto button = x11_mouse_button_code(ev.xbutton.button);
+        if (button.has_value()) {
+          *consumed = llua_mouse_hook(mouse_button_event(
+              mouse_event_t::PRESS, vec2i(ev.xbutton.x, ev.xbutton.y),
+              vec2i(ev.xbutton.x_root, ev.xbutton.y_root), button.value(),
+              mods));
+        }
       }
       break;
     }
@@ -594,10 +599,13 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
       if (ev.xbutton.button >= 4 && ev.xbutton.button <= 7) return true;
 
       modifier_state_t mods = x11_modifier_state(ev.xbutton.state);
-      mouse_button_t button = x11_mouse_button_code(ev.xbutton.button);
-      *consumed = llua_mouse_hook(mouse_button_event(
-          mouse_event_t::RELEASE, vec2i(ev.xbutton.x, ev.xbutton.y),
-          vec2i(ev.xbutton.x_root, ev.xbutton.y_root), button, mods));
+      auto button = x11_mouse_button_code(ev.xbutton.button);
+      if (button.has_value()) {
+        *consumed = llua_mouse_hook(mouse_button_event(
+            mouse_event_t::RELEASE, vec2i(ev.xbutton.x, ev.xbutton.y),
+            vec2i(ev.xbutton.x_root, ev.xbutton.y_root), button.value(),
+            mods));
+      }
       break;
     }
     case MotionNotify: {
@@ -837,7 +845,9 @@ void process_surface_events(conky::display_output_x11 *surface,
 
     if (!consumed) { propagate_x11_event(ev, cookie); }
 
-    if (cookie != nullptr) { free(cookie); }
+    if (cookie != nullptr) {
+      delete static_cast<conky::xi_event_data *>(cookie);
+    }
   }
 
   DBGP2("Done processing %d events.", pending);

--- a/src/output/display-x11.cc
+++ b/src/output/display-x11.cc
@@ -526,14 +526,20 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
       double vertical_value = vertical.value_or(0.0);
 
       if (vertical_value != 0.0) {
-        scroll_direction = vertical_value < 0.0 ? scroll_direction_t::UP
-                                                : scroll_direction_t::DOWN;
+        auto *info = data->valuator_info(valuator_t::SCROLL_Y);
+        double increment = (info != nullptr) ? info->increment : 1.0;
+        scroll_direction = (vertical_value * increment) < 0.0
+                               ? scroll_direction_t::UP
+                               : scroll_direction_t::DOWN;
       } else {
         auto horizontal = data->valuator_relative_value(valuator_t::SCROLL_X);
         double horizontal_value = horizontal.value_or(0.0);
         if (horizontal_value != 0.0) {
-          scroll_direction = horizontal_value < 0.0 ? scroll_direction_t::LEFT
-                                                    : scroll_direction_t::RIGHT;
+          auto *info = data->valuator_info(valuator_t::SCROLL_X);
+          double increment = (info != nullptr) ? info->increment : 1.0;
+          scroll_direction = (horizontal_value * increment) < 0.0
+                                 ? scroll_direction_t::LEFT
+                                 : scroll_direction_t::RIGHT;
         }
       }
 

--- a/src/output/display-x11.cc
+++ b/src/output/display-x11.cc
@@ -675,17 +675,16 @@ bool handle_event<x_event_handler::CONFIGURE>(
       if (mw > 0) { text_size.set_x(std::min(mw, text_size.x())); }
     }
 
-    /* if position isn't what expected, set fixed pos
-     * total_updates avoids setting fixed_pos when window
-     * is set to weird locations when started */
-    /* // this is broken
-    if (total_updates >= 2 && !fixed_pos
-        && (window.geometry.x != ev.xconfigure.x
-        || window.geometry.y != ev.xconfigure.y)
-        && (ev.xconfigure.x != 0
-        || ev.xconfigure.y != 0)) {
-      fixed_pos = 1;
-    } */
+    // Keep window.geometry.pos() in sync with the actual screen position.
+    // ev.xconfigure.x/y can't be used directly because for reparented windows
+    // they're relative to the WM's decoration frame, not the root.
+    {
+      int root_x, root_y;
+      Window child_return;
+      XTranslateCoordinates(display, window.window, window.root, 0, 0, &root_x,
+                            &root_y, &child_return);
+      window.geometry.set_pos(root_x, root_y);
+    }
   }
 
   return true;

--- a/src/output/display-x11.cc
+++ b/src/output/display-x11.cc
@@ -523,8 +523,9 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
 
       // generate movement events
       if (cursor_over_conky) {
+        auto window_pos = data->pos_absolute - window.geometry.pos();
         *consumed = llua_mouse_hook(
-            mouse_move_event(data->pos, data->pos_absolute, mods));
+            mouse_move_event(window_pos, data->pos_absolute, mods));
       }
     }
     if (is_scroll && cursor_over_conky) {
@@ -551,8 +552,9 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
       }
 
       if (scroll_direction != scroll_direction_t::UNKNOWN) {
+        auto window_pos = data->pos_absolute - window.geometry.pos();
         *consumed = llua_mouse_hook(mouse_scroll_event(
-            data->pos, data->pos_absolute, scroll_direction, mods));
+            window_pos, data->pos_absolute, scroll_direction, mods));
       }
     }
   } else if (cursor_over_conky && (data->evtype == XI_ButtonPress ||

--- a/src/output/display-x11.cc
+++ b/src/output/display-x11.cc
@@ -498,10 +498,12 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
   if (data->evtype == XI_Motion) {
     // TODO: Make valuator_index names configurable?
 
-    bool is_move = data->test_valuator(valuator_t::MOVE_X) ||
-                   data->test_valuator(valuator_t::MOVE_Y);
-    bool is_scroll = data->test_valuator(valuator_t::SCROLL_X) ||
-                     data->test_valuator(valuator_t::SCROLL_Y);
+    bool has_move_x = data->test_valuator(valuator_t::MOVE_X);
+    bool has_move_y = data->test_valuator(valuator_t::MOVE_Y);
+    bool has_scroll_x = data->test_valuator(valuator_t::SCROLL_X);
+    bool has_scroll_y = data->test_valuator(valuator_t::SCROLL_Y);
+    bool is_move = has_move_x || has_move_y;
+    bool is_scroll = has_scroll_x || has_scroll_y;
 
     if (is_move) {
       static bool cursor_inside = false;
@@ -529,7 +531,7 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
       }
     }
     if (is_scroll && cursor_over_conky) {
-      scroll_direction_t scroll_direction;
+      scroll_direction_t scroll_direction = scroll_direction_t::UNKNOWN;
       auto vertical = data->valuator_relative_value(valuator_t::SCROLL_Y);
       double vertical_value = vertical.value_or(0.0);
 
@@ -560,8 +562,18 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
   } else if (cursor_over_conky && (data->evtype == XI_ButtonPress ||
                                    data->evtype == XI_ButtonRelease)) {
     if (data->detail >= 4 && data->detail <= 7) {
-      // Handled via motion event valuators, ignoring "backward compatibility"
-      // ones.
+      // Fallback: use button 4-7 as scroll if this device has no independent
+      // scroll valuators (e.g. Xephyr aliases scroll and move axes).
+      // Devices with working scroll valuators handle scroll via XI_Motion.
+      bool has_scroll_valuators =
+          data->device->valuator(valuator_t::SCROLL_X).index != SIZE_MAX ||
+          data->device->valuator(valuator_t::SCROLL_Y).index != SIZE_MAX;
+      if (!has_scroll_valuators && data->evtype == XI_ButtonPress) {
+        scroll_direction_t direction = x11_scroll_direction(data->detail);
+        auto window_pos = data->pos_absolute - window.geometry.pos();
+        *consumed = llua_mouse_hook(mouse_scroll_event(
+            window_pos, data->pos_absolute, direction, mods));
+      }
       return true;
     }
 

--- a/src/output/x11.cc
+++ b/src/output/x11.cc
@@ -44,13 +44,10 @@
 #include "../logging.h"
 #include "gui.h"
 
-#ifdef BUILD_XINPUT
 #include "../mouse-events.h"
 
-#include <vector>
-#endif
-
 #include <algorithm>
+#include <vector>
 #include <array>
 #include <cstddef>
 #include <cstdio>
@@ -89,10 +86,8 @@ extern "C" {
 #ifdef BUILD_XFIXES
 #include <X11/extensions/Xfixes.h>
 #endif /* BUILD_XFIXES */
-#ifdef BUILD_XINPUT
 #include <X11/extensions/XInput.h>
 #include <X11/extensions/XInput2.h>
-#endif /* BUILD_XINPUT */
 #ifdef HAVE_XCB_ERRORS
 #include <xcb/xcb.h>
 #include <xcb/xcb_errors.h>
@@ -822,13 +817,8 @@ void x11_init_window(lua::state &l, bool own) {
 #ifdef OWN_WINDOW
   if (own_window.get(l)) {
     input_mask |= StructureNotifyMask;
-#if !defined(BUILD_XINPUT)
-    input_mask |= ButtonPressMask | ButtonReleaseMask;
-#endif
   }
-#if defined(BUILD_MOUSE_EVENTS) || defined(BUILD_XINPUT)
   bool xinput_ok = false;
-#ifdef BUILD_XINPUT
   // not a loop; substitutes goto with break - if checks fail
   do {
     int _ignored;  // segfault if NULL
@@ -886,7 +876,6 @@ void x11_init_window(lua::state &l, bool own) {
 
     xinput_ok = true;
   } while (false);
-#endif /* BUILD_XINPUT */
   // Fallback to basic X11 enter/leave events if xinput fails to init.
   // It's not recommended to add event masks to special windows in X; causes a
   // crash (thus own_window_type != TYPE_DESKTOP)
@@ -895,7 +884,6 @@ void x11_init_window(lua::state &l, bool own) {
     input_mask |= PointerMotionMask | EnterWindowMask | LeaveWindowMask;
   }
 #endif /* BUILD_MOUSE_EVENTS */
-#endif /* BUILD_MOUSE_EVENTS || BUILD_XINPUT */
 #endif /* OWN_WINDOW */
   window.event_mask = input_mask;
   XSelectInput(display, window.window, input_mask);
@@ -1498,7 +1486,6 @@ int ev_to_mask(int event_type, int button) {
   }
 }
 
-#ifdef BUILD_XINPUT
 void propagate_xinput_event(const conky::xi_event_data *ev) {
   if (ev->evtype != XI_Motion && ev->evtype != XI_ButtonPress &&
       ev->evtype != XI_ButtonRelease) {
@@ -1538,19 +1525,16 @@ void propagate_xinput_event(const conky::xi_event_data *ev) {
 
   XFlush(display);
 }
-#endif
 
 void propagate_x11_event(XEvent &ev, const void *cookie) {
   bool focus = ev.type == ButtonPress;
 
   // cookie must be allocated before propagation, and freed after
-#ifdef BUILD_XINPUT
   if (ev.type == GenericEvent && ev.xgeneric.extension == window.xi_opcode) {
     if (cookie == nullptr) { return; }
     return propagate_xinput_event(
         reinterpret_cast<const conky::xi_event_data *>(cookie));
   }
-#endif
 
   if (!(ev.type == KeyPress || ev.type == KeyRelease ||
         ev.type == ButtonPress || ev.type == ButtonRelease ||
@@ -1698,24 +1682,15 @@ Window query_x11_window_at_pos(Display *display, conky::vec2i pos, int device_id
   Window root_return;
   Window last = None;
 
-  #ifdef BUILD_XINPUT
   // these values are ignored but NULL can't be passed to XIQueryPointer.
   double root_x_return, root_y_return, win_x_return, win_y_return;
   XIButtonState buttons_return;
   XIModifierState modifiers_return;
   XIGroupState group_return;
 
-  
-  XIQueryPointer(display,device_id, window.root, &root_return, &last, &root_x_return,
-                &root_y_return, &win_x_return, &win_y_return, &buttons_return, &modifiers_return, &group_return);
-  #else
-  // these values are ignored but NULL can't be passed to XQueryPointer.
-  int root_x_return, root_y_return, win_x_return, win_y_return;
-  unsigned int mask_return;
-
-  XQueryPointer(display, window.root, &root_return, &last, &root_x_return,
-                &root_y_return, &win_x_return, &win_y_return, &mask_return);
-  #endif
+  XIQueryPointer(display, device_id, window.root, &root_return, &last,
+                 &root_x_return, &root_y_return, &win_x_return, &win_y_return,
+                 &buttons_return, &modifiers_return, &group_return);
 
   if (last == 0) return root;
   return last;

--- a/src/output/x11.cc
+++ b/src/output/x11.cc
@@ -1533,7 +1533,7 @@ void propagate_xinput_event(const conky::xi_event_data *ev) {
   for (auto it : events) {
     auto ev = std::get<1>(it);
     XSendEvent(display, target, True, std::get<0>(it), ev);
-    free(ev);
+    delete ev;
   }
 
   XFlush(display);

--- a/src/output/x11.h
+++ b/src/output/x11.h
@@ -87,10 +87,8 @@ struct conky_x11_window {
 #ifdef BUILD_XFT
   XftDraw *xftdraw;
 #endif /*BUILD_XFT*/
-#if defined(BUILD_MOUSE_EVENTS) || defined(BUILD_XINPUT)
-  // Don't feature gate with BUILD_XINPUT; controls fallback.
+  /// XInput2 extension opcode; 0 if unavailable.
   std::int32_t xi_opcode;
-#endif /* BUILD_MOUSE_EVENTS || BUILD_XINPUT */
 
   /// @brief Window geometry in screen coordinate space
   conky::rect<int> geometry;
@@ -162,7 +160,7 @@ Window query_x11_top_parent(Display *display, Window child);
 /// @param display display of parent
 /// @param x screen X position contained by window
 /// @param y screen Y position contained by window
-/// @param device_id pointer device id to be queried (will be ignored if BUILD_XINPUT is disabled)
+/// @param device_id pointer device id to be queried
 /// @return a top-most window at provided screen coordinates, or root
 Window query_x11_window_at_pos(Display *display, conky::vec2i pos, int device_id);
 


### PR DESCRIPTION
## Scroll direction always reports DOWN (#2288)

Old code never read `XIScrollClassInfo`:

1. Scroll valuator indices hardcoded as enum ordinals (2, 3). Real indices come from `XIScrollClassInfo::number` and vary by device.
2. Direction sign depends on `XIScrollClassInfo::increment`. Code assumed positive delta = down/right, wrong for negative-increment drivers.

We now scan `XIScrollClass` entries in `init_xi_device` to discover actual indices and store `increment` in `conky_valuator_info`. Direction = `sign(delta * increment)`. Applied in both Lua hook and propagation paths.

## Clicks near window edges dropped (closes #2288)

`window.geometry.pos()` went stale after WM repositions (decoration frames, strut adjustments). Only updated on window creation and `move_win()`.

The `ConfigureNotify` handler originally had position-tracking code that compared `window.x/y` against `ev.xconfigure.x/y` to detect WM-forced repositions and set `fixed_pos`. @brndnmtthws disabled it in 7bdb0501 because `ev.xconfigure.x/y` is frame-relative for reparented windows, which made the comparison invalid and broke window alignment by setting `fixed_pos` spuriously.

It's now replaced with `XTranslateCoordinates(window.window, root, 0, 0)` on every `ConfigureNotify`, which gives correct screen coordinates regardless of reparenting. This avoids the original problem because we never read `ev.xconfigure.x/y` and don't touch `fixed_pos` at all. The updated position gets overwritten by `update_text_area()` next cycle; it only needs to be accurate for mouse hit testing between events.

## Additional correctness fixes

- `x11_mouse_button_code` returned uninitialized `mouse_button_t` for unmapped buttons. Now returns `std::optional`, callers skip on nullopt.
- `valuator_relative_value` returned `std::optional<double>` that was never empty (indexed a zero-initialized fixed array). Now checks the valuator map first so callers can distinguish "no data" from "zero".
- `generate_events` defaulted `scroll_direction` to `Button4`, producing a phantom scroll-up on zero-delta events. Now defaults to `0` and skips generation when no direction is determined.
- `process_surface_events` used `free()` on `new`-allocated `xi_event_data` (UB, skips destructors). Changed to `delete`.
- `propagate_xinput_event` used `free()` on `new`-allocated XEvents. Changed to `delete`.

## Mouse input performance with multiple instances (closes #1886)

Every conky instance receives all root mouse events via XInput2. Each event triggered 3+ sync X11 round-trips (`XIQueryPointer`, `XQueryTree` x2) just to check if the cursor was over this instance. With many (20+) instances, we overwhelmed the X server.

We now check `window.geometry.contains(pos_absolute)` first (pure arithmetic, no X11 calls). If outside bounds, skip everything. Also cache `query_x11_top_parent(window.window)` since it only changes on reparent (invalidated in `ReparentNotify` handler). Common case goes from 3+ round-trips to zero.

**Depends on:** `ConfigureNotify` tracking position again.

## Example configuration for mouse events (closes #2066)

Added `data/conky_mouse_events.conf`. Self-contained, handler defined inline (no `lua_load`), logs all fields for all event types. Based on the exhaustive handler from PR #955.

## BUILD_XINPUT option removed, legacy fallback dropped

`BUILD_XINPUT` was an experimental flag to disable buggy XInput2 code and provide a way for users to keep using the stable base.

With the above fixes, there's no reason to keep it separate. `libXi` is a core X11 component available in all modern environments. XInput2 (or X11) code is now guarded by `BUILD_X11` directly where needed.

The legacy non-XInput2 mouse input fallback (`#else` path in MOUSE_INPUT handler) and the BORDER_CROSSING handler are removed. BORDER_CROSSING was the non-XInput fallback for EnterNotify/LeaveNotify; crossing events are already synthesized from XI_Motion in the XInput2 path.

This **removes the basic X11 mouse input fallback**, which was in principle obsolete since XInput2 shipped in 2009 - though it would've just been bloat at that point since conky had no mouse handling. My 2023 implementation could've used XInput2 exclusively, but I was cautious (and rightly so) not to introduce code I couldn't verify worked well for all users. With more users adopting mouse events and the bug reports that followed, we now have a much better understanding of the edge cases. This removal simplifies the X11 mouse handling and keeps the implementation compact for users that haven't transitioned to Wayland yet.
