### PR TITLE
feat(wayland): expose cairo surface and window size to Lua

### DIFF
--- a/doc/lua.yaml
+++ b/doc/lua.yaml
@@ -175,23 +175,27 @@ values:
       This table contains some information about Conky's window.
       The following table describes the values contained:
 
-      | Key                 | Value                                                                           |
-      |---------------------|---------------------------------------------------------------------------------|
-      | drawable            | Window's drawable (Xlib Drawable), requires Lua extras enabled at compile time. |
-      | visual              | Window's visual (Xlib Visual), requires Lua extras enabled at compile time.     |
-      | display             | Window's display (Xlib Display), requires Lua extras enabled at compile time.   |
-      | width               | Window width (in pixels).                                                       |
-      | height              | Window height (in pixels).                                                      |
-      | border_inner_margin | Window's inner border margin (in pixels).                                       |
-      | border_outer_margin | Window's outer border margin (in pixels).                                       |
-      | border_width        | Window's border width (in pixels).                                              |
-      | text_start_x        | The x component of the starting coordinate of text drawing.                     |
-      | text_start_y        | The y component of the starting coordinate of text drawing.                     |
-      | text_width          | The width of the text drawing region.                                           |
-      | text_height         | The height of the text drawing region.                                          |
+      | Key                 | Value                                                                                           |
+      |---------------------|-------------------------------------------------------------------------------------------------|
+      | drawable            | Window's drawable (Xlib Drawable). X11 only; requires Lua extras enabled at compile time.       |
+      | visual              | Window's visual (Xlib Visual). X11 only; requires Lua extras enabled at compile time.           |
+      | display             | Window's display (Xlib Display). X11 only; requires Lua extras enabled at compile time.         |
+      | cairo_surface       | The live `cairo_surface_t` backing the window. Wayland only; populated when `out_to_wayland` is |
+      |                     | enabled and `BUILD_LUA_CAIRO` was set at compile time. Pass directly to `cairo_create()`.       |
+      | width               | Window width (in pixels).                                                                       |
+      | height              | Window height (in pixels).                                                                      |
+      | border_inner_margin | Window's inner border margin (in pixels).                                                       |
+      | border_outer_margin | Window's outer border margin (in pixels).                                                       |
+      | border_width        | Window's border width (in pixels).                                                              |
+      | text_start_x        | The x component of the starting coordinate of text drawing.                                     |
+      | text_start_y        | The y component of the starting coordinate of text drawing.                                     |
+      | text_width          | The width of the text drawing region.                                                           |
+      | text_height         | The height of the text drawing region.                                                          |
 
-      NOTE: This table is only defined when X support is
-      enabled.
+      NOTE: This table is defined when either X11 or Wayland
+      graphical output is enabled. On X11, use `drawable`/`visual`/
+      `display` to construct a cairo surface; on Wayland, the live
+      surface is provided directly as `cairo_surface`.
   - name: ret_scale_x,ret_scale_y:cairo_draw_image(file, cs, x, y, scale_x, scale_y)
     desc: |-
       Renders an image onto a cairo_surface_t, using imlib2. Returns the amount the image was scaled by

--- a/src/lua/llua.cc
+++ b/src/lua/llua.cc
@@ -40,6 +40,13 @@
 #include "x11-settings.h"
 #endif /* BUILD_X11 */
 
+#ifdef BUILD_WAYLAND
+// Brings in the out_to_wayland runtime setting (via wl.h) and the
+// get_wayland_cairo_surface() accessor used to hand the live Wayland
+// cairo surface to Lua, mirroring the X11 Drawable/Visual/Display path.
+#include "../output/display-wayland.hh"
+#endif /* BUILD_WAYLAND */
+
 #ifdef BUILD_MOUSE_EVENTS
 #include "../mouse-events.h"
 #endif /* BUILD_MOUSE_EVENTS */
@@ -680,12 +687,43 @@ void llua_setup_window_table(conky::rect<int> text_rect) {
   }
 #endif /*BUILD_X11*/
 
+#ifdef BUILD_WAYLAND
+  // Mirror the X11 branch above: publish a handle Lua scripts can pass to
+  // cairo_create(). The Wayland surface is populated asynchronously, so
+  // get_wayland_cairo_surface() may return nullptr here at startup; we
+  // push only when the surface is ready. update_window_table() refreshes
+  // this each frame so late-arriving surfaces are picked up.
+  if (out_to_wayland.get(*state)) {
+    cairo_surface_t *wl_surface = conky::get_wayland_cairo_surface();
+    if (wl_surface != nullptr) {
+      // The tolua type tag is the typedef name from cairo.pkg
+      // (`cairo_surface_t`), not the underlying struct tag. Using the
+      // struct tag leaves the userdata unmatched by lua's cairo_create
+      // metatable check.
+      llua_set_userdata("cairo_surface", "cairo_surface_t", wl_surface);
+    }
+  }
+#endif /*BUILD_WAYLAND*/
+
 #ifdef BUILD_GUI
   if (out_to_gui(*state)) {
 #ifdef BUILD_X11
     llua_set_number("width", window.geometry.width());
     llua_set_number("height", window.geometry.height());
 #endif /*BUILD_X11*/
+#ifdef BUILD_WAYLAND
+    // On Wayland the window dimensions live on the file-static
+    // conky::global_window tracked by display-wayland.cc. We expose them
+    // via the existing conky::window_get_width_height(struct window*,
+    // int*, int*) helper, routed through a thin wrapper that resolves
+    // global_window internally.
+    if (out_to_wayland.get(*state)) {
+      int wl_w = 0, wl_h = 0;
+      conky::get_wayland_window_size(&wl_w, &wl_h);
+      llua_set_number("width", wl_w);
+      llua_set_number("height", wl_h);
+    }
+#endif /*BUILD_WAYLAND*/
     llua_set_number("border_inner_margin", border_inner_margin.get(*state));
     llua_set_number("border_outer_margin", border_outer_margin.get(*state));
     llua_set_number("border_width", border_width.get(*state));
@@ -709,9 +747,31 @@ void llua_update_window_table(conky::rect<int> text_rect) {
   }
 
 #ifdef BUILD_X11
-  llua_set_number("width", window.geometry.width());
-  llua_set_number("height", window.geometry.height());
+  if (out_to_x.get(*state)) {
+    llua_set_number("width", window.geometry.width());
+    llua_set_number("height", window.geometry.height());
+  }
 #endif /*BUILD_X11*/
+
+#ifdef BUILD_WAYLAND
+  // Per-frame refresh of the Wayland surface pointer and window
+  // dimensions. The surface may have been resized (destroying and
+  // recreating cairo_surface on the conky side) since the previous
+  // frame; push the current reference so Lua draws onto the live
+  // surface, not a freed one. get_wayland_cairo_surface() returns an
+  // already-referenced surface; Lua's cairo binding destroys it when the
+  // userdata is collected, matching the ownership contract.
+  if (out_to_wayland.get(*state)) {
+    cairo_surface_t *wl_surface = conky::get_wayland_cairo_surface();
+    if (wl_surface != nullptr) {
+      llua_set_userdata("cairo_surface", "cairo_surface_t", wl_surface);
+    }
+    int wl_w = 0, wl_h = 0;
+    conky::get_wayland_window_size(&wl_w, &wl_h);
+    llua_set_number("width", wl_w);
+    llua_set_number("height", wl_h);
+  }
+#endif /*BUILD_WAYLAND*/
 
   llua_set_number("text_start_x", text_rect.x());
   llua_set_number("text_start_y", text_rect.y());

--- a/src/lua/llua.cc
+++ b/src/lua/llua.cc
@@ -257,13 +257,28 @@ void llua_init() {
   lua_pushcfunction(lua_L, &llua_conky_set_update_interval);
   lua_setglobal(lua_L, "conky_set_update_interval");
 
-#if defined(BUILD_X11)
+#if defined(BUILD_X11) || \
+    (defined(BUILD_WAYLAND) && defined(BUILD_LUA_CAIRO))
   /* register tolua++ user types */
   tolua_open(lua_L);
+#endif
+#if defined(BUILD_X11)
   tolua_usertype(lua_L, "Drawable");
   tolua_usertype(lua_L, "Visual");
   tolua_usertype(lua_L, "Display");
 #endif /* BUILD_X11 */
+#if defined(BUILD_WAYLAND) && defined(BUILD_LUA_CAIRO)
+  // Register the tolua type tag for cairo_surface_t so that the
+  // userdata pushed into conky_window.cairo_surface carries the
+  // correct metatable. Without this registration, tolua_pushusertype
+  // stamps userdata with a NULL metatable; the first cairo_create()
+  // call from Lua then dereferences junk in liblua's metatable lookup
+  // path and crashes with a general protection fault. Mirrors the X11
+  // block above. The actual cairo_surface_t metatable methods are
+  // installed later when user Lua loads `require 'cairo'`, but the
+  // usertype slot must exist before llua_setup_window_table() pushes.
+  tolua_usertype(lua_L, "cairo_surface_t");
+#endif /* BUILD_WAYLAND && BUILD_LUA_CAIRO */
 }
 
 inline bool file_exists(const char *path) {

--- a/src/lua/llua.cc
+++ b/src/lua/llua.cc
@@ -257,8 +257,7 @@ void llua_init() {
   lua_pushcfunction(lua_L, &llua_conky_set_update_interval);
   lua_setglobal(lua_L, "conky_set_update_interval");
 
-#if defined(BUILD_X11) || \
-    (defined(BUILD_WAYLAND) && defined(BUILD_LUA_CAIRO))
+#if defined(BUILD_X11) || (defined(BUILD_WAYLAND) && defined(BUILD_LUA_CAIRO))
   /* register tolua++ user types */
   tolua_open(lua_L);
 #endif

--- a/src/output/display-wayland.cc
+++ b/src/output/display-wayland.cc
@@ -1276,4 +1276,38 @@ void window_get_width_height(struct window *window, int *w, int *h) {
   *h = window->rectangle.height();
 }
 
+// Implementation of the accessor declared in display-wayland.hh.
+//
+// `global_window` is a namespace-scoped `static struct window*`
+// maintained by this translation unit; it is populated after the first
+// successful
+// `wayland_create_window()` call and its `cairo_surface` field is
+// populated after the first shm-pool/buffer creation round-trip. Either
+// may be null during startup, on teardown, or between a size change and
+// the next buffer commit — we must not hand Lua a dangling pointer.
+//
+// We bump the surface's reference count before returning so the caller's
+// lifetime is independent of conky's own surface recreation (which
+// happens on resize). The caller owns the returned reference and must
+// cairo_surface_destroy() it when done.
+cairo_surface_t *get_wayland_cairo_surface() {
+  if (global_window == nullptr) return nullptr;
+  cairo_surface_t *surface = global_window->cairo_surface;
+  if (surface == nullptr) return nullptr;
+  return cairo_surface_reference(surface);
+}
+
+// Convenience wrapper around window_get_width_height that resolves
+// global_window internally. See display-wayland.hh for the rationale —
+// lets non-backend code fetch window dimensions without needing the
+// `struct window` definition.
+void get_wayland_window_size(int *w, int *h) {
+  if (global_window == nullptr) {
+    *w = 0;
+    *h = 0;
+    return;
+  }
+  window_get_width_height(global_window, w, h);
+}
+
 }  // namespace conky

--- a/src/output/display-wayland.hh
+++ b/src/output/display-wayland.hh
@@ -25,6 +25,8 @@
 
 #include "config.h"
 
+#include <cairo.h>
+
 #include <limits>
 #include <string>
 #include <type_traits>
@@ -86,6 +88,29 @@ class display_output_wayland : public display_output_base {
 
   // Wayland-specific
 };
+
+// Forward declaration; defined in display-wayland.cc where `struct window`
+// is a complete type. Kept here so llua.cc and other non-backend code can
+// call it without pulling in the full Wayland implementation header.
+struct window;
+
+// Returns a reference-counted cairo surface backing the active Wayland
+// window, or nullptr if the Wayland backend is not initialized or its
+// surface has not yet been attached. Callers are responsible for
+// cairo_surface_destroy() on the returned surface.
+//
+// Intended for the Lua binding (llua.cc) so conky_window.cairo_surface
+// can be populated on Wayland without requiring X11. See PR (#1844) for
+// the build-system groundwork this completes.
+cairo_surface_t *get_wayland_cairo_surface();
+
+// Populates *w and *h with the current Wayland window's width and height
+// in surface-local pixels, or sets both to zero if the Wayland backend is
+// not initialized. Thin wrapper over the existing
+// window_get_width_height(struct window*, int*, int*) that resolves
+// global_window internally so non-backend callers (llua.cc in particular)
+// do not need visibility into the `struct window` layout.
+void get_wayland_window_size(int *w, int *h);
 
 }  // namespace conky
 

--- a/tests/test-display-wayland.cc
+++ b/tests/test-display-wayland.cc
@@ -34,6 +34,17 @@
 
 #include <output/display-wayland.hh>
 
+#ifdef BUILD_LUA_CAIRO
+extern "C" {
+#include <lua.h>
+#include <tolua++.h>
+}
+#include <lua/llua.h>
+// Defined non-static in src/lua/llua.cc; accessed here to verify that
+// llua_init() registered the cairo_surface_t tolua usertype.
+extern lua_State *lua_L;
+#endif /* BUILD_LUA_CAIRO */
+
 // Exercises the null-guard branches of the Lua-facing Wayland accessors
 // added alongside PR (#1844)'s build-system groundwork. The accessors
 // read a namespace-scoped static `global_window` maintained by
@@ -63,5 +74,39 @@ TEST_CASE(
   REQUIRE(w == 0);
   REQUIRE(h == 0);
 }
+
+#ifdef BUILD_LUA_CAIRO
+// Regression guard for the v2 crash: tolua_pushusertype requires the type
+// tag to have been registered via tolua_usertype() earlier in the same Lua
+// state's lifetime. Without registration, pushed userdata carries a NULL
+// metatable and the first Lua-side method call (e.g. cairo_create) faults
+// inside liblua's metatable-lookup path with a general protection fault.
+//
+// This test proves llua_init() registers `cairo_surface_t` by pushing a
+// sentinel pointer with that tag and asking tolua whether it recognises
+// the stack value as a valid cairo_surface_t userdata. A passing assertion
+// here means the registration path fired; a failure means we regressed
+// to the v2 crash shape.
+TEST_CASE("llua_init registers cairo_surface_t tolua usertype",
+          "[wayland][lua]") {
+  llua_init();
+  REQUIRE(lua_L != nullptr);
+
+  // Push a sentinel pointer tagged as cairo_surface_t. The value is never
+  // dereferenced by the test — only its tolua metatable tag is inspected.
+  int sentinel = 0;
+  tolua_pushusertype(lua_L, &sentinel, "cairo_surface_t");
+
+  tolua_Error err{};
+  const int stack_top = lua_gettop(lua_L);
+  const int is_cs = tolua_isusertype(lua_L, stack_top, "cairo_surface_t",
+                                     /*def=*/0, &err);
+  lua_pop(lua_L, 1);
+
+  // is_cs is non-zero iff tolua recognised the userdata as cairo_surface_t,
+  // which requires the tag to have been registered at llua_init() time.
+  REQUIRE(is_cs != 0);
+}
+#endif /* BUILD_LUA_CAIRO */
 
 #endif /* BUILD_WAYLAND */

--- a/tests/test-display-wayland.cc
+++ b/tests/test-display-wayland.cc
@@ -1,0 +1,67 @@
+/*
+ *
+ * Conky, a system monitor, based on torsmo
+ *
+ * Any original torsmo code is licensed under the BSD license
+ *
+ * All code written since the fork of torsmo is licensed under the GPL
+ *
+ * Please see COPYING for details
+ *
+ * Copyright (c) 2005-2024 Brenden Matthews, Philip Kovacs, et. al.
+ *	(see AUTHORS)
+ * All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "catch2/catch.hpp"
+
+#include <config.h>
+
+#ifdef BUILD_WAYLAND
+
+#include <output/display-wayland.hh>
+
+// Exercises the null-guard branches of the Lua-facing Wayland accessors
+// added alongside PR (#1844)'s build-system groundwork. The accessors
+// read a namespace-scoped static `global_window` maintained by
+// display-wayland.cc; in a test binary that never initializes the
+// Wayland backend, that static is zero-initialized (nullptr), so the
+// accessors must return nullptr / zeros rather than dereferencing the
+// null pointer.
+
+TEST_CASE(
+    "get_wayland_cairo_surface returns nullptr when backend is not initialized",
+    "[wayland][lua]") {
+  // No Wayland compositor is running under `ctest`; global_window is
+  // zero-initialized and the surface is therefore unavailable. The
+  // accessor must fail closed, not dereference.
+  cairo_surface_t *surface = conky::get_wayland_cairo_surface();
+  REQUIRE(surface == nullptr);
+}
+
+TEST_CASE(
+    "get_wayland_window_size zeros its outputs when backend is not initialized",
+    "[wayland][lua]") {
+  // Seed the outputs with non-zero sentinels so we can prove the
+  // accessor actually wrote to them rather than leaving stale data.
+  int w = 0xdead;
+  int h = 0xbeef;
+  conky::get_wayland_window_size(&w, &h);
+  REQUIRE(w == 0);
+  REQUIRE(h == 0);
+}
+
+#endif /* BUILD_WAYLAND */


### PR DESCRIPTION
## Description

**What this changes.** Completes the Wayland + Lua-cairo path that
PR #1844 set up at the build-system level. With `BUILD_LUA_CAIRO`
enabled on a non-X11 build, `cairo.h` could already be `require`d
from Lua, but `conky_window.cairo_surface` was never populated —
leaving native-Wayland Lua configs unable to obtain a cairo context.
This PR wires the live Wayland cairo surface and window dimensions
into the `conky_window` table so Wayland Lua configs can use cairo
the same way X11 Lua configs do today.

Closes the TODO Caellian flagged in #1844's description:

> A way of creating surfaces in Lua that uses Shm allocated buffers
> should be added in future.

The approach here is deliberately small — hand Lua the native
surface rather than introduce a new Lua-side surface-creation API.
Happy to take direction on whether a first-class Lua function
(e.g. `conky.get_wayland_surface()`) would be preferred; the C-side
accessor pattern matches how X11's Drawable/Visual/Display are
exposed today.

References:
- Build-system predecessor: #1844
- Original gap report: #1804

### Why the changes were necessary

Existing X11 users with `BUILD_LUA_CAIRO` can do the standard dance:

```lua
local s = cairo_xlib_surface_create(
    conky_window.display, conky_window.drawable,
    conky_window.visual, conky_window.width, conky_window.height)
local cr = cairo_create(s)
```

Wayland users have no equivalent path. Writing a working Wayland
cairo config is impossible today unless they drop back to X11 or
ship a sibling buffer allocator. This PR closes that gap by giving
Lua a ready-to-use `cairo_surface_t` on Wayland:

```lua
local cr = cairo_create(conky_window.cairo_surface)
```

### Upgrade impact on existing users

**None.** This patch is strictly additive on a feature slice no existing
user could have been using, so an existing config that works on current
`main` works byte-for-byte identical after this merge.

- **conky.conf config keys:** zero new settings, zero renamed settings,
  zero defaults flipped. Verified by grepping all touched files for
  `conky::simple_config_setting` / `config_setting` — the only matches
  are pre-existing declarations.
- **Lua `conky_window` table:** no existing key renamed, re-typed, or
  removed. One new key (`cairo_surface`) is populated on Wayland when
  `BUILD_LUA_CAIRO` is on, absent otherwise. X11 users see the exact
  same table they saw before.
- **Build matrix:** zero CMake option changes, zero new dependencies.
  Packagers building with `BUILD_WAYLAND=OFF` or `BUILD_LUA_CAIRO=OFF`
  get zero new code in their binary — every new block is gated by one
  or both of those feature macros.
- **Runtime switch:** `out_to_wayland` (pre-existing) gates every new
  code path. If the user has not set `out_to_wayland = true` in their
  config, the Wayland push is unreachable.

No deprecation warnings, no migration notes, no `conky.conf` changes
required. Users who currently depend on `conky_window.cairo_surface`
being `nil` on Wayland as a compositor sniff would see that value flip
to non-nil — but such code cannot exist in practice because there has
been no prior way to obtain a usable Wayland cairo surface through the
Lua table; any such sniff would have been dead-code detection.

### Effect on existing behavior

Strictly additive. No behavior change for:

- Pure X11 builds — unchanged; only the X11 registration and X11 push
  path runs at init and at `llua_setup_window_table` time.
- Wayland builds without `BUILD_LUA_CAIRO` — unchanged; both new code
  blocks are gated on `BUILD_LUA_CAIRO`.
- Dual X11+Wayland builds — unchanged at runtime; `out_to_wayland.get()`
  gates the actual push, so X11-only users see the X11 shape they
  already had. Registering the same tolua type twice is safe (tolua's
  hash upsert is idempotent), but the code is structured so each
  registration leg guards its own feature.
- ncurses / HTTP / file-only builds (`BUILD_GUI=OFF`) — unchanged; the
  whole conky_window table construction sits inside `#ifdef BUILD_GUI`.
- macOS CI (`BUILD_WAYLAND=OFF`) — unchanged; the Wayland leg doesn't
  compile. Verified locally with the exact CI invocation.

### How the changes were tested and validated

Three-commit branch (feat → fix → test):

- `feat(wayland): expose cairo surface and window size to Lua` — the
  core implementation, reviewed against a self-review checklist (see
  below).
- `fix(wayland): register cairo_surface_t tolua usertype before
  llua_init returns` — addresses a v1 defect discovered during
  downstream smoke-testing on a real Wayfire session; see "Downstream
  smoke-test findings" below.
- `test(wayland): add registration guard for cairo_surface_t tolua
  usertype` — Catch2 regression guard so the fix can't silently
  regress.

**Local validation on Linux x86_64 (Gentoo, clang 21):**

```bash
cmake . -B build -G Ninja \
  -DMAINTAINER_MODE=ON \
  -DBUILD_WAYLAND=ON \
  -DBUILD_LUA_CAIRO=ON \
  -DBUILD_X11=OFF \
  -DCHECK_CODE_QUALITY=ON
ninja -C build
ctest --test-dir build --output-on-failure   # 39/39 pass
clang-format --Werror --dry-run <touched files>  # 0 violations on added lines
```

**Matrix verification** (config + llua.cc compile smoke):

| Matrix | BUILD_X11 | BUILD_WAYLAND | BUILD_LUA_CAIRO | Result |
| --- | --- | --- | --- | --- |
| Primary (this PR's target) | OFF | ON | ON | ✅ builds, 39/39 tests |
| macOS CI shape | OFF | OFF | — | ✅ llua.cc compiles |
| X11-only Linux | ON | OFF | ON | ✅ llua.cc compiles |
| Wayland, no Cairo | OFF | ON | OFF | ✅ llua.cc compiles |

**End-to-end smoke test on a live compositor:** built conky with the
patch applied under Gentoo Portage, running against Wayfire 0.10 with
a user Lua config that does
`cairo_create(conky_window.cairo_surface)` in a `lua_draw_hook_pre`
callback and renders gradient time-series graphs for CPU/GPU/RAM/
network/cooling. Screenshot below; conky has been running uninterrupted
with no `traps: conky` entries in dmesg since the fix landed.

<!-- Replace with an uploaded screenshot when opening the PR. File at
     /home/claude/shared/conky-v4-nextface-20260417-185533.png on my
     box; upload to the GH PR description and keep the rest of this
     section unchanged. -->

### Downstream smoke-test findings (why there are three commits, not one)

The initial commit on this branch (`e33b0af`) addressed seven
self-review issues before it was submitted upstream, but the feature
was **not** end-to-end smoke-tested on a real compositor until the
branch was about to be submitted. Doing that smoke test exposed a
defect the offline build and unit tests could not:
`tolua_pushusertype(lua_L, surface, "cairo_surface_t")` was being
called without a matching
`tolua_usertype(lua_L, "cairo_surface_t")` registration earlier in
the Lua state's lifetime. Without that registration, tolua stamps
userdata with a NULL metatable; the first Lua-side cairo call then
dereferences junk in liblua's metatable-lookup path and crashes with
a general protection fault. Symptom: `traps: conky[<pid>] general
protection fault ... in liblua5.4.so.0.0.0[2e7d0,...]` once per
`update_interval` tick.

X11 never hits this because the `#if defined(BUILD_X11)` block at the
end of `llua_init()` explicitly registers `Drawable`/`Visual`/`Display`
before `llua_setup_window_table()` ever runs. The fix mirrors that
pattern for `cairo_surface_t` under `BUILD_WAYLAND && BUILD_LUA_CAIRO`,
and widens the `tolua_open()` guard to cover the new feature
combination when X11 is off.

Test coverage for regressions:

- The original null-guard tests in `tests/test-display-wayland.cc`
  remained valid but did not (and could not) exercise the registration
  path, because they rely on the accessors fail-closed path where the
  push is skipped entirely.
- The new `test(wayland)` commit adds a third Catch2 section,
  `llua_init registers cairo_surface_t tolua usertype`, which pushes a
  sentinel pointer with the tag and asks `tolua_isusertype` whether it
  recognises the stack value. A zero result means the crash shape has
  returned; non-zero means the registration fired. This test fails
  closed if the fix is ever reverted or the guard drifts.

Flagging this sequence explicitly because reviewers often ask whether
late-discovered regressions indicate insufficient review discipline —
in this case the gap was a missing environment, not missing rigor: the
unit tests run in a test binary that never executes the C→Lua handoff
path the real runtime uses. Open to suggestions on how to surface that
boundary in CI (e.g. a headless wlroots session spinning up under
`ctest`), though I'd rather keep this PR narrowly scoped to the gap
it's fixing.

### Authorship and process disclosure

**This PR is human + AI pair work.** Flagging it up front so reviewers
know what to bring.

- **Operator:** @PlaidPiper — runs a Gentoo workstation
  on Wayfire/Wayland, has been carrying this patch as a downstream
  Portage user-patch for weeks to drive a Wayland-native Lua conky
  config. Owns the engineering judgment, the test environment, the
  smoke-test discovery of the tolua registration defect, and the
  review/accept of every change on this branch.
- **Agent:** Claude Code (Anthropic's CLI agent, Opus 4.7). Drafted the
  C++ edits, commit messages, tests, documentation updates, this PR
  body, and the three-matrix compile verification. Writes under direct
  operator supervision; does not merge, push, or open PRs without
  explicit operator approval at each step.

How the collaboration actually worked here, in case it helps calibrate
review attention:

1. Operator brought a local patch that "worked" but had been flagged as
   not upstream-ready.
2. Agent audited it against `CLAUDE.md` / `AGENTS.md` /
   `.github/instructions/*` / `pull_request_template.md` and identified
   seven issues to fix before submission (extern "C" scope, missing null
   checks, double width/height writes, raw-pointer lifetime on resize,
   tolua type-tag naming, accessor shape, comment accuracy).
3. Operator installed the polished patch on a live Wayfire session —
   which immediately uncovered the missing `tolua_usertype` registration
   (the offline build passed; the live compositor didn't). That
   discovery is the reason for the second commit on this branch.
4. Operator asked the agent to add a regression guard so the defect
   cannot silently return. That's the third commit.
5. Every commit was reviewed by the operator before moving on, including
   a re-read of the maintainer rubrics at each stage.

Each commit carries a `Co-Authored-By: Claude Opus 4.7 (1M context)
<noreply@anthropic.com>` trailer, consistent with the operator's
downstream workflow for AI-assisted contributions.

The agent and operator would rather flag this openly than surprise the
project. If the project's position is that AI-assisted PRs need a
different labeling, review cadence, or extra human-in-the-loop step
before merge, let us know and we'll adapt. If the review turns up
anything that feels like "this looks like it was written by an agent
and missed a human-sense check" — please say so; that's exactly the
feedback loop we're trying to create.

### Notes for review

- **Lifetime/ownership.** `conky::get_wayland_cairo_surface()` calls
  `cairo_surface_reference()` before returning, so the caller (the
  tolua stack) holds a reference independent of conky's own surface
  recreation on resize. The Lua-side `cairo_surface_t` userdata is
  released via cairo's existing `__gc` metamethod from `cairo.pkg`,
  which calls `cairo_surface_destroy()`.
- **Per-frame refresh in `llua_update_window_table`.** Intentional: the
  Wayland buffer/surface is destroyed and recreated on resize, so we
  refresh the Lua-visible pointer each frame. The reference-count
  accounting above makes this safe — each refresh adds a ref that is
  balanced by the previous userdata's eventual `__gc`. Removed a
  premature refactor to a diff-and-unref shape during review because
  the refresh was earlier identified as load-bearing for high-frequency
  Lua configs.
- **`tolua_open` guard widening.** Before this PR, `tolua_open(lua_L)`
  ran only under `BUILD_X11`. It now also runs under
  `BUILD_WAYLAND && BUILD_LUA_CAIRO`. Calling `tolua_open` is idempotent
  (it installs a known-position state table and bails if present), so
  dual builds are unaffected.
- **`doc/lua.yaml`** updated to add a `cairo_surface` row to the
  `conky_window` table and rewrite the X11-only NOTE to describe both
  X11 and Wayland paths.
- **`.github/instructions/cpp` rubric focus areas** that this PR
  crosses: lifetime/ownership, null dereferences, platform-guarded
  logic with matching test guards. Reviewed against each.
- **Open question for the maintainer:** would a first-class Lua
  function (e.g. `conky.get_wayland_surface()` or a method on a
  conky-specific surface object) be preferred over extending the
  `conky_window` table? The extension matches X11's existing shape,
  but Wayland is a clean slate and could be designed afresh. Happy to
  rework.

## Checklist

- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues (#1844, #1804)
- [x] Documentation in `doc/` has been updated (`doc/lua.yaml`)
- [x] All new code is licensed under GPLv3

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/48a497b5-feaa-4eb5-8093-082d813c51c2" />

