### PR TITLE
fix(settings): simplify background alpha settings (#2109)

### DIFF
--- a/cmake/ConkyBuildOptions.cmake
+++ b/cmake/ConkyBuildOptions.cmake
@@ -205,9 +205,6 @@ else()
     "Xfixes support requires X11")
 endif(OS_DARWIN)
 
-dependent_option(BUILD_ARGB "Build ARGB (real transparency) support" true
-  "BUILD_X11;OWN_WINDOW" false
-  "ARGB support requires X11 and OWN_WINDOW enabled, not needed on Wayland")
 dependent_option(BUILD_XINERAMA "Build Xinerama support" true
   "BUILD_X11" false
   "Xinerama support requires X11")

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -64,8 +64,6 @@
 
 #cmakedefine BUILD_XFIXES 1
 
-#cmakedefine BUILD_ARGB 1
-
 #cmakedefine BUILD_XDBE 1
 
 #cmakedefine BUILD_PORT_MONITORS 1

--- a/doc/config_settings.yaml
+++ b/doc/config_settings.yaml
@@ -410,17 +410,6 @@ values:
     desc: Overwrite the file given as argument.
   - name: own_window
     desc: Boolean, draw conky in own window instead of drawing on root window.
-  - name: own_window_argb_value
-    desc: |-
-      **Deprecated.** Use [`own_window_colour`](#own_window_colour) with an alpha
-      channel instead (e.g. `'#8000'` for 50% opacity).
-
-      Sets the background opacity. Valid range is 0-255, where 0 is fully
-      transparent and 255 is fully opaque. Overrides the alpha channel of
-      `own_window_colour` when set to a value below 255.
-    default: 255
-    args:
-      - integer_number
   - name: own_window_class
     desc: Manually set the WM_CLASS name.
     default: Conky
@@ -463,13 +452,6 @@ values:
     desc: |-
       Allows overriding conky window name.
     default: 'conky (<hostname>)'
-  - name: own_window_transparent
-    desc: |-
-      **Deprecated.** Use [`own_window_colour`](#own_window_colour) with alpha 0
-      instead (e.g. `'#0000'`).
-
-      Sets background opacity to 0%, making the background fully transparent.
-    default: 'false'
   - name: own_window_type
     desc: |-
       If `own_window` is set, under X11 you can specify type of window conky

--- a/doc/config_settings.yaml
+++ b/doc/config_settings.yaml
@@ -412,27 +412,27 @@ values:
     desc: Boolean, draw conky in own window instead of drawing on root window.
   - name: own_window_argb_value
     desc: |-
-      When ARGB visuals are enabled, this use this to modify the
-      alpha value used. Valid range is 0-255, where 0 is 0% opacity, and 255
-      is 100% opacity.
+      **Deprecated.** Use [`own_window_colour`](#own_window_colour) with an alpha
+      channel instead (e.g. `'#8000'` for 50% opacity).
+
+      Sets the background opacity. Valid range is 0-255, where 0 is fully
+      transparent and 255 is fully opaque. Overrides the alpha channel of
+      `own_window_colour` when set to a value below 255.
     default: 255
     args:
       - integer_number
-  - name: own_window_argb_visual
-    desc: |-
-      Boolean, use ARGB visual? ARGB can be used for real transparency, note
-      that a composite manager is required on X11.
-      This option will not work as desired (in most cases) in conjunction with
-      ['own_window_type override'](#own_window_type).
   - name: own_window_class
     desc: Manually set the WM_CLASS name.
     default: Conky
   - name: own_window_colour
     desc: |-
-      If [own_window_transparent](#own_window_transparent) no, set a specified background
-      colour. Takes either a hex value (e.g. '#ffffff'),
-      a shorthand hex value (e.g. '#fff'), or a valid RGB name
-      (see `/usr/lib/X11/rgb.txt`).
+      Set the background colour of the window. Takes a hex value with
+      optional alpha (e.g. `'#fff'`, `'#8000'`, `'#8fff'`), or a valid
+      RGB name (see `/usr/lib/X11/rgb.txt`).
+
+      The alpha channel controls background opacity. For example, `'#0000'`
+      is fully transparent and `'#f000'` is fully opaque black.
+      Semi-transparent backgrounds require a compositor on X11.
     default: black
     args:
       - color
@@ -465,8 +465,10 @@ values:
     default: 'conky (<hostname>)'
   - name: own_window_transparent
     desc: |-
-      Make conky window transparent. If [`own_window_argb_visual`](#own_window_argb_visual) is enabled,
-      sets background opacity to 0%.
+      **Deprecated.** Use [`own_window_colour`](#own_window_colour) with alpha 0
+      instead (e.g. `'#0000'`).
+
+      Sets background opacity to 0%, making the background fully transparent.
     default: 'false'
   - name: own_window_type
     desc: |-
@@ -500,6 +502,9 @@ values:
         will not work with DEs which draw desktop icons via custom
         panels/windows as those will cover conky.
         [`own_window_hints`](#own_window_hints) are ignored for `override` windows.
+        Semi-transparent backgrounds do not work with `override` windows
+        because compositors typically do not composite override-redirect
+        windows. Full transparency (alpha 0) may work via pseudo-transparency.
 
       To make conky mount on root window, set [`own_window`](#own_window) to `false`.
     default: normal

--- a/src/lua/setting.cc
+++ b/src/lua/setting.cc
@@ -115,7 +115,6 @@ const std::vector<std::string> settings_ordering{
     "own_window_title",
     "own_window_type",
     "own_window_hints",
-    "own_window_argb_value",
     "own_window_colour",
     "own_window",
     "double_buffer",

--- a/src/lua/setting.cc
+++ b/src/lua/setting.cc
@@ -45,6 +45,11 @@ using settings_vector = std::vector<priv::config_setting_base *>;
  */
 settings_map *settings;
 
+/// Settings that have been removed. Maps old name to an explanation message.
+const std::unordered_map<std::string, std::string> removed_settings = {
+    {"own_window_argb_visual", "ARGB is now always enabled when available. Control opacity with `own_window_colour` (e.g. '#8000')."},
+};
+
 /*
  * Returns the setting record corresponding to the value at the specified index.
  * If the value is not valid, returns nullptr and prints an error.
@@ -59,7 +64,13 @@ priv::config_setting_base *get_setting(lua::state &l, int index) {
   const std::string &name = l.tostring(index);
   auto iter = settings->find(name);
   if (iter == settings->end()) {
-    NORM_ERR("Unknown setting '%s'", name.c_str());
+    auto removed = removed_settings.find(name);
+    if (removed != removed_settings.end()) {
+      NORM_ERR("Setting '%s' has been removed. %s", name.c_str(),
+               removed->second.c_str());
+    } else {
+      NORM_ERR("Unknown setting '%s'", name.c_str());
+    }
     return nullptr;
   }
 
@@ -105,7 +116,6 @@ const std::vector<std::string> settings_ordering{
     "own_window_type",
     "own_window_hints",
     "own_window_argb_value",
-    "own_window_argb_visual",
     "own_window_colour",
     "own_window",
     "double_buffer",

--- a/src/lua/setting.cc
+++ b/src/lua/setting.cc
@@ -169,6 +169,13 @@ config_setting_base::config_setting_base(std::string name_)
   }
 }
 
+config_setting_base::config_setting_base(config_setting_base &&other) noexcept
+    : name(std::move(other.name)),
+      seq_no(other.seq_no),
+      deprecation_msg(std::move(other.deprecation_msg)) {
+  (*settings)[name] = this;
+}
+
 void config_setting_base::lua_set(lua::state &l) {
   std::lock_guard<lua::state> guard(l);
   lua::stack_sentry s(l, -1);
@@ -193,6 +200,12 @@ void config_setting_base::process_setting(lua::state &l, bool init) {
 
   config_setting_base *ptr = get_setting(l, -3);
   if (ptr == nullptr) { return; }
+
+  if (init && ptr->deprecation_msg.has_value() && !l.isnil(-2)) {
+    NORM_ERR("WARNING: '%s' is deprecated and will be removed in a future "
+             "release. %s",
+             ptr->name.c_str(), ptr->deprecation_msg->c_str());
+  }
 
   ptr->lua_setter(l, init);
   l.pushvalue(-2);

--- a/src/lua/setting.hh
+++ b/src/lua/setting.hh
@@ -24,6 +24,7 @@
 #define SETTING_HH
 
 #include <limits>
+#include <optional>
 #include <string>
 #include <type_traits>
 
@@ -145,11 +146,11 @@ class config_setting_base {
   static int config__newindex(lua::state *l);
   static void make_conky_config(lua::state &l);
 
-  // copying is a REALLY bad idea
   config_setting_base(const config_setting_base &) = delete;
   config_setting_base &operator=(const config_setting_base &) = delete;
 
  protected:
+  config_setting_base(config_setting_base &&other) noexcept;
   /*
    * Set the setting, if the value is sane
    * stack on entry: | ... potential_new_value old_value |
@@ -168,6 +169,7 @@ class config_setting_base {
  public:
   const std::string name;
   const size_t seq_no;
+  std::optional<std::string> deprecation_msg;
 
   static bool seq_compare(const config_setting_base *a,
                           const config_setting_base *b) {
@@ -189,6 +191,13 @@ class config_setting_base {
 };
 }  // namespace priv
 
+/// Mark a config setting as deprecated. Returns the setting by move.
+template <typename T>
+T deprecated(T setting, const char *msg) {
+  setting.deprecation_msg = msg;
+  return setting;
+}
+
 // If you need some very exotic setting, derive it from this class. Otherwise,
 // scroll down.
 template <typename T>
@@ -196,6 +205,7 @@ class config_setting_template : public priv::config_setting_base {
  public:
   explicit config_setting_template(const std::string &name_)
       : config_setting_base(name_) {}
+  config_setting_template(config_setting_template &&) = default;
 
   // get the value of the setting as a C++ type
   T get(lua::state &l);
@@ -253,6 +263,7 @@ class simple_config_setting : public config_setting_template<T> {
       : Base(std::string(name_)),
         default_value(default_value_),
         modifiable(modifiable_) {}
+  simple_config_setting(simple_config_setting &&) = default;
 
  protected:
   const T default_value;
@@ -344,6 +355,7 @@ class range_config_setting : public simple_config_setting<T, Traits> {
       : Base(name_, default_value_, modifiable_), min(min_), max(max_) {
     assert(min <= Base::default_value && Base::default_value <= max);
   }
+  range_config_setting(range_config_setting &&) = default;
 
  protected:
   virtual std::pair<typename Traits::Type, bool> do_convert(lua::state &l,

--- a/src/main.cc
+++ b/src/main.cc
@@ -193,9 +193,7 @@ static void print_version() {
             << _("  * Xft\n")
 #endif /* BUILD_XFT */
             << _("  * Xinput\n")
-#ifdef BUILD_ARGB
             << _("  * ARGB visual\n")
-#endif /* BUILD_ARGB */
 #ifdef OWN_WINDOW
             << _("  * Own window\n")
 #endif
@@ -205,9 +203,6 @@ static void print_version() {
 #endif /* BUILD_X11 */
 #ifdef BUILD_WAYLAND
             << _(" Wayland:\n")
-#ifdef BUILD_ARGB
-            << _("  * ARGB visual\n")
-#endif /* BUILD_ARGB */
 #ifdef BUILD_MOUSE_EVENTS
             << _("  * Mouse events\n")
 #endif /* BUILD_MOUSE_EVENTS */

--- a/src/output/display-wayland.cc
+++ b/src/output/display-wayland.cc
@@ -945,13 +945,7 @@ void display_output_wayland::clear_text(int exposures) {
   auto cr = window->cr.get();
   cairo_save(cr);
 
-  Colour color;
-  if (set_transparent.get(*state)) {
-    color.alpha = 0;
-  } else {
-    color = background_colour.get(*state);
-    color.alpha = own_window_argb_value.get(*state);
-  }
+  Colour color = get_background_colour_preference(*state);
 
   cairo_set_operator(cr, CAIRO_OPERATOR_CLEAR);
   cairo_paint(cr);

--- a/src/output/display-x11.cc
+++ b/src/output/display-x11.cc
@@ -191,7 +191,7 @@ static void X11_create_window() {
                   window.geometry.y());
     }
 
-    set_transparent_background(window.window);
+    set_transparent_background(&window);
   }
 #endif
 
@@ -303,7 +303,7 @@ bool display_output_x11::main_loop_wait(double t) {
         draw_stuff(); /* redraw everything in our newly sized window */
         XResizeWindow(display, window.window, window.geometry.width(),
                       window.geometry.height()); /* resize window */
-        set_transparent_background(window.window);
+        set_transparent_background(&window);
 #ifdef BUILD_XDBE
         /* swap buffers */
         xdbe_swap_buffers();
@@ -630,7 +630,7 @@ bool handle_event<x_event_handler::REPARENT>(conky::display_output_x11 *surface,
                                              bool *consumed, void **cookie) {
   if (ev.type != ReparentNotify) return false;
 
-  if (own_window.get(*state)) { set_transparent_background(window.window); }
+  if (own_window.get(*state)) { set_transparent_background(&window); }
   // Invalidate cached top parent -- window tree changed.
   window_top_parent = None;
   return true;
@@ -703,7 +703,7 @@ bool handle_event<x_event_handler::PROPERTY_NOTIFY>(
     return true;
   }
 
-  if (!have_argb_visual) {
+  if (window.opacity == 0xff) {
     Atom _XROOTPMAP_ID = XInternAtom(display, "_XROOTPMAP_ID", True);
     Atom _XROOTMAP_ID = XInternAtom(display, "_XROOTMAP_ID", True);
     if (ev.xproperty.atom == _XROOTPMAP_ID ||
@@ -844,12 +844,10 @@ void display_output_x11::cleanup() {
 void display_output_x11::set_foreground_color(Colour c) {
   current_color = c;
 #ifdef BUILD_ARGB
-  if (have_argb_visual) {
-    current_color.alpha = own_window_argb_value.get(*state);
-  }
+  current_color.alpha = window.opacity;
 #endif /* BUILD_ARGB */
   XSetForeground(display, window.gc,
-                 current_color.to_x11_color(display, screen, have_argb_visual));
+                 current_color.to_x11_color(display, screen, window.opacity < 0xff));
 }
 
 int display_output_x11::calc_text_width(const char *s) {
@@ -878,7 +876,7 @@ void display_output_x11::draw_string_at(int x, int y, const char *s, int w) {
     XColor c{};
     XftColor c2{};
 
-    c.pixel = current_color.to_x11_color(display, screen, have_argb_visual);
+    c.pixel = current_color.to_x11_color(display, screen, window.opacity < 0xff);
     // query color on custom colormap
     XQueryColor(display, window.colourmap, &c);
 

--- a/src/output/display-x11.cc
+++ b/src/output/display-x11.cc
@@ -843,9 +843,7 @@ void display_output_x11::cleanup() {
 
 void display_output_x11::set_foreground_color(Colour c) {
   current_color = c;
-#ifdef BUILD_ARGB
   current_color.alpha = window.opacity;
-#endif /* BUILD_ARGB */
   XSetForeground(display, window.gc,
                  current_color.to_x11_color(display, screen, window.opacity < 0xff));
 }

--- a/src/output/gui.cc
+++ b/src/output/gui.cc
@@ -224,15 +224,19 @@ conky::simple_config_setting<uint16_t, window_hints_traits> own_window_hints(
 
 #if defined(OWN_WINDOW) || defined(BUILD_WAYLAND)
 priv::colour_setting background_colour("own_window_colour", 0);
-conky::simple_config_setting<bool> set_transparent("own_window_transparent",
-                                                   false, false);
+conky::simple_config_setting<bool> set_transparent = conky::deprecated(
+    conky::simple_config_setting<bool>("own_window_transparent", false, false),
+    "Use own_window_colour with alpha instead (e.g. '#00000000').");
 #endif /* OWN_WINDOW || BUILD_WAYLAND */
 
 #if defined(BUILD_ARGB) || defined(BUILD_WAYLAND)
-conky::simple_config_setting<bool> use_argb_visual("own_window_argb_visual",
-                                                   false, false);
-conky::range_config_setting<int> own_window_argb_value("own_window_argb_value",
-                                                       0, 255, 255, false);
+conky::simple_config_setting<bool> use_argb_visual = conky::deprecated(
+    conky::simple_config_setting<bool>("own_window_argb_visual", false, false),
+    "ARGB is now always enabled when available.");
+conky::range_config_setting<int> own_window_argb_value = conky::deprecated(
+    conky::range_config_setting<int>("own_window_argb_value", 0, 255, 255,
+                                     false),
+    "Use own_window_colour with alpha instead (e.g. '#80000000').");
 #endif /* BUILD_ARGB || BUILD_WAYLAND */
 priv::own_window_setting own_window;
 

--- a/src/output/gui.cc
+++ b/src/output/gui.cc
@@ -230,9 +230,6 @@ conky::simple_config_setting<bool> set_transparent = conky::deprecated(
 #endif /* OWN_WINDOW || BUILD_WAYLAND */
 
 #if defined(BUILD_ARGB) || defined(BUILD_WAYLAND)
-conky::simple_config_setting<bool> use_argb_visual = conky::deprecated(
-    conky::simple_config_setting<bool>("own_window_argb_visual", false, false),
-    "ARGB is now always enabled when available.");
 conky::range_config_setting<int> own_window_argb_value = conky::deprecated(
     conky::range_config_setting<int>("own_window_argb_value", 0, 255, 255,
                                      false),

--- a/src/output/gui.cc
+++ b/src/output/gui.cc
@@ -234,7 +234,24 @@ conky::range_config_setting<int> own_window_argb_value = conky::deprecated(
     conky::range_config_setting<int>("own_window_argb_value", 0, 255, 255,
                                      false),
     "Use own_window_colour with alpha instead (e.g. '#80000000').");
-#endif /* BUILD_ARGB || BUILD_WAYLAND */
+
+Colour get_background_colour_preference(lua::state &l) {
+  // TODO: anything other than background_colour is deprecated.
+  // Simplify this dance in 5 years and remove other options completely.
+  Colour background = background_colour.get(l);
+#ifdef BUILD_ARGB
+  if (own_window_argb_value.get(l) < 0xff) {
+    background.alpha = own_window_argb_value.get(l);
+  }
+#endif /* BUILD_ARGB */
+  if (set_transparent.get(l)) {
+    background.alpha = 0;
+  }
+
+  return background;
+}
+#endif /* OWN_WINDOW || BUILD_WAYLAND */
+
 priv::own_window_setting own_window;
 
 /******************** </SETTINGS> ************************/

--- a/src/output/gui.cc
+++ b/src/output/gui.cc
@@ -227,9 +227,7 @@ priv::colour_setting background_colour("own_window_colour", 0);
 conky::simple_config_setting<bool> set_transparent = conky::deprecated(
     conky::simple_config_setting<bool>("own_window_transparent", false, false),
     "Use own_window_colour with alpha instead (e.g. '#00000000').");
-#endif /* OWN_WINDOW || BUILD_WAYLAND */
 
-#if defined(BUILD_ARGB) || defined(BUILD_WAYLAND)
 conky::range_config_setting<int> own_window_argb_value = conky::deprecated(
     conky::range_config_setting<int>("own_window_argb_value", 0, 255, 255,
                                      false),
@@ -239,11 +237,9 @@ Colour get_background_colour_preference(lua::state &l) {
   // TODO: anything other than background_colour is deprecated.
   // Simplify this dance in 5 years and remove other options completely.
   Colour background = background_colour.get(l);
-#ifdef BUILD_ARGB
   if (own_window_argb_value.get(l) < 0xff) {
     background.alpha = own_window_argb_value.get(l);
   }
-#endif /* BUILD_ARGB */
   if (set_transparent.get(l)) {
     background.alpha = 0;
   }

--- a/src/output/gui.h
+++ b/src/output/gui.h
@@ -238,7 +238,6 @@ extern conky::simple_config_setting<bool> set_transparent;
 #endif /* OWN_WINDOW || BUILD_WAYLAND */
 
 #if defined(BUILD_ARGB) || defined(BUILD_WAYLAND)
-extern conky::simple_config_setting<bool> use_argb_visual;
 extern conky::range_config_setting<int> own_window_argb_value;
 #endif /* BUILD_ARGB || BUILD_WAYLAND */
 

--- a/src/output/gui.h
+++ b/src/output/gui.h
@@ -234,11 +234,12 @@ extern conky::simple_config_setting<uint16_t, window_hints_traits>
 
 #if defined(OWN_WINDOW) || defined(BUILD_WAYLAND)
 extern priv::colour_setting background_colour;
-extern conky::simple_config_setting<bool> set_transparent;
-#endif /* OWN_WINDOW || BUILD_WAYLAND */
 
-#if defined(BUILD_ARGB) || defined(BUILD_WAYLAND)
-extern conky::range_config_setting<int> own_window_argb_value;
-#endif /* BUILD_ARGB || BUILD_WAYLAND */
+Colour get_background_colour_preference(lua::state &l);
+
+inline uint8_t get_background_alpha_preference(lua::state &l) {
+  return get_background_colour_preference(l).alpha;
+}
+#endif /* OWN_WINDOW || BUILD_WAYLAND */
 
 #endif /* _CONKY_GUI_H_ */

--- a/src/output/x11-color.cc
+++ b/src/output/x11-color.cc
@@ -33,13 +33,14 @@ unsigned long Colour::to_x11_color(Display *display, int screen,
   }
 
   pixel &= 0xffffff;
-#ifdef BUILD_ARGB
+
   if (transparency) {
-    if (premultiply)
+    if (premultiply) {
       pixel = (red * alpha / 255) << 16 | (green * alpha / 255) << 8 |
               (blue * alpha / 255);
+    }
     pixel |= ((unsigned long)alpha << 24);
   }
-#endif /* BUILD_ARGB */
+
   return pixel;
 }

--- a/src/output/x11.cc
+++ b/src/output/x11.cc
@@ -423,7 +423,19 @@ void set_transparent_background(conky_x11_window *window) {
 }
 #endif /* OWN_WINDOW */
 
+static bool has_compositor() {
+  // Check for a running compositor via the ICCCM _NET_WM_CM_Sn selection.
+  // A compositor owns this selection on the screen it manages.
+  char atom_name[32];
+  snprintf(atom_name, sizeof(atom_name), "_NET_WM_CM_S%d", screen);
+  Atom cm_atom = XInternAtom(display, atom_name, False);
+  return XGetSelectionOwner(display, cm_atom) != None;
+}
+
 static bool try_set_argb_visual(conky_x11_window *window) {
+  // ARGB visuals are useless without a compositor to blend the alpha.
+  if (!has_compositor()) { return false; }
+
   /* code from gtk project, gdk_screen_get_rgba_visual */
   XVisualInfo visual_template;
   XVisualInfo *visual_list;

--- a/src/output/x11.cc
+++ b/src/output/x11.cc
@@ -394,7 +394,7 @@ const int argb8888_color_depth = 32;
    Window and all parents, else real transparency is used */
 void set_transparent_background(conky_x11_window *window) {
   Window win = window->window;
-#ifdef BUILD_ARGB
+
   if (window->opacity < 0xff && window->color_depth == argb8888_color_depth) {
     // real transparency
     Colour colour = get_background_colour_preference(*state);
@@ -403,7 +403,7 @@ void set_transparent_background(conky_x11_window *window) {
     XSetWindowBackground(display, window->window, xcolor);
     return;
   }
-#endif /* BUILD_ARGB */
+
   // pseudo transparency
   if (window->opacity == 0) {
     Window parent = win;
@@ -422,8 +422,6 @@ void set_transparent_background(conky_x11_window *window) {
   }
 }
 #endif /* OWN_WINDOW */
-
-#ifdef BUILD_ARGB
 
 static bool try_set_argb_visual(conky_x11_window *window) {
   /* code from gtk project, gdk_screen_get_rgba_visual */
@@ -452,7 +450,6 @@ static bool try_set_argb_visual(conky_x11_window *window) {
   XFree(visual_list);
   return false;
 }
-#endif /* BUILD_ARGB */
 
 void destroy_window() {
 #ifdef BUILD_XFT
@@ -484,12 +481,8 @@ void x11_init_window(lua::state &l, bool own) {
     window.color_depth = CopyFromParent;
 
     uint8_t background_alpha = get_background_alpha_preference(l);
-    if (background_alpha == 0) {
-        window.opacity = 0;
-    }
-
-#ifdef BUILD_ARGB
     bool wants_alpha = background_alpha < 0xff;
+
     if (wants_alpha && try_set_argb_visual(&window)) {
       window.opacity = background_alpha;
     } else if (wants_alpha) {
@@ -500,7 +493,6 @@ void x11_init_window(lua::state &l, bool own) {
         NORM_ERR("ARGB visual not supported (no compositor?); window will use fallback");
       }
     }
-#endif /* BUILD_ARGB */
 
     int b = border_inner_margin.get(l) + border_width.get(l) +
             border_outer_margin.get(l);

--- a/src/output/x11.cc
+++ b/src/output/x11.cc
@@ -390,19 +390,6 @@ static Window find_desktop_window(Window root) {
 const int argb8888_color_depth = 32;
 
 #ifdef OWN_WINDOW
-#ifdef BUILD_ARGB
-namespace {
-/* helper function for set_transparent_background() */
-void do_set_background_alpha(conky_x11_window *window, uint8_t alpha) {
-  Colour colour = background_colour.get(*state);
-  colour.alpha = alpha;
-  unsigned long xcolor =
-      colour.to_x11_color(display, screen, window->opacity < 0xff, true);
-  XSetWindowBackground(display, window->window, xcolor);
-}
-}  // namespace
-#endif /* BUILD_ARGB */
-
 /* if no argb visual is configured sets background to ParentRelative for the
    Window and all parents, else real transparency is used */
 void set_transparent_background(conky_x11_window *window) {
@@ -410,7 +397,10 @@ void set_transparent_background(conky_x11_window *window) {
 #ifdef BUILD_ARGB
   if (window->opacity < 0xff && window->color_depth == argb8888_color_depth) {
     // real transparency
-    do_set_background_alpha(window, window->opacity);
+    Colour colour = get_background_colour_preference(*state);
+    unsigned long xcolor =
+        colour.to_x11_color(display, screen, window->opacity < 0xff, true);
+    XSetWindowBackground(display, window->window, xcolor);
     return;
   }
 #endif /* BUILD_ARGB */
@@ -493,17 +483,9 @@ void x11_init_window(lua::state &l, bool own) {
     int flags = CWOverrideRedirect | CWBackingStore;
     window.color_depth = CopyFromParent;
 
-    // TODO: anything other than background_colour is deprecated.
-    // Simplify this dance in 5 years and remove other options completely.
-    uint8_t background_alpha = background_colour.get(l).alpha;
-#ifdef BUILD_ARGB
-    if (own_window_argb_value.get(l) < 0xff) {
-      background_alpha = own_window_argb_value.get(l);
-    }
-#endif /* BUILD_ARGB */
-    if (set_transparent.get(l)) {
-      background_alpha = 0;
-      window.opacity = 0;
+    uint8_t background_alpha = get_background_alpha_preference(l);
+    if (background_alpha == 0) {
+        window.opacity = 0;
     }
 
 #ifdef BUILD_ARGB

--- a/src/output/x11.cc
+++ b/src/output/x11.cc
@@ -106,8 +106,6 @@ xcb_errors_context_t *xcb_errors_ctx;
 /* Window stuff */
 struct conky_x11_window window;
 
-bool have_argb_visual = false;
-
 /* local prototypes */
 static Window find_desktop_window(Window *p_root, Window *p_desktop);
 static Window find_desktop_window_impl(Window win, int w, int h);
@@ -389,35 +387,35 @@ static Window find_desktop_window(Window root) {
   return desktop;
 }
 
+const int argb8888_color_depth = 32;
+
 #ifdef OWN_WINDOW
 #ifdef BUILD_ARGB
 namespace {
 /* helper function for set_transparent_background() */
-void do_set_background(Window win, uint8_t alpha) {
+void do_set_background_alpha(conky_x11_window *window, uint8_t alpha) {
   Colour colour = background_colour.get(*state);
   colour.alpha = alpha;
   unsigned long xcolor =
-      colour.to_x11_color(display, screen, have_argb_visual, true);
-  XSetWindowBackground(display, win, xcolor);
+      colour.to_x11_color(display, screen, window->opacity < 0xff, true);
+  XSetWindowBackground(display, window->window, xcolor);
 }
 }  // namespace
 #endif /* BUILD_ARGB */
 
 /* if no argb visual is configured sets background to ParentRelative for the
    Window and all parents, else real transparency is used */
-void set_transparent_background(Window win) {
+void set_transparent_background(conky_x11_window *window) {
+  Window win = window->window;
 #ifdef BUILD_ARGB
-  if (have_argb_visual) {
+  if (window->opacity < 0xff && window->color_depth == argb8888_color_depth) {
     // real transparency
-    do_set_background(win, set_transparent.get(*state)
-                               ? 0
-                               : own_window_argb_value.get(*state));
+    do_set_background_alpha(window, window->opacity);
     return;
   }
 #endif /* BUILD_ARGB */
-
   // pseudo transparency
-  if (set_transparent.get(*state)) {
+  if (window->opacity == 0) {
     Window parent = win;
     unsigned int i;
 
@@ -432,15 +430,12 @@ void set_transparent_background(Window win) {
     }
     return;
   }
-
-#ifdef BUILD_ARGB
-  do_set_background(win, 0);
-#endif /* BUILD_ARGB */
 }
 #endif /* OWN_WINDOW */
 
 #ifdef BUILD_ARGB
-static int get_argb_visual(Visual **visual, int *depth) {
+
+static bool try_set_argb_visual(conky_x11_window *window) {
   /* code from gtk project, gdk_screen_get_rgba_visual */
   XVisualInfo visual_template;
   XVisualInfo *visual_list;
@@ -450,22 +445,22 @@ static int get_argb_visual(Visual **visual, int *depth) {
   visual_list =
       XGetVisualInfo(display, VisualScreenMask, &visual_template, &nxvisuals);
   for (i = 0; i < nxvisuals; i++) {
-    if (visual_list[i].depth == 32 && (visual_list[i].red_mask == 0xff0000 &&
-                                       visual_list[i].green_mask == 0x00ff00 &&
-                                       visual_list[i].blue_mask == 0x0000ff)) {
-      *visual = visual_list[i].visual;
-      *depth = visual_list[i].depth;
-      DBGP("Found ARGB Visual");
+    if (visual_list[i].depth == argb8888_color_depth &&
+        (visual_list[i].red_mask == 0xff0000 &&
+         visual_list[i].green_mask == 0x00ff00 &&
+         visual_list[i].blue_mask == 0x0000ff)) {
+      window->visual = visual_list[i].visual;
+      window->color_depth = argb8888_color_depth;
+      window->colourmap = XCreateColormap(display, DefaultRootWindow(display),
+                                          window->visual, AllocNone);
       XFree(visual_list);
-      return 1;
+      return true;
     }
   }
-
   // no argb visual available
-  DBGP("No ARGB Visual found");
-  XFree(visual_list);
 
-  return 0;
+  XFree(visual_list);
+  return false;
 }
 #endif /* BUILD_ARGB */
 
@@ -490,21 +485,38 @@ void x11_init_window(lua::state &l, bool own) {
   window.desktop = find_desktop_window(window.root);
 
   window.visual = DefaultVisual(display, screen);
+  window.opacity = 0xff;
   window.colourmap = DefaultColormap(display, screen);
 
 #ifdef OWN_WINDOW
   if (own) {
-    int depth = 0, flags = CWOverrideRedirect | CWBackingStore;
-    Visual *visual = nullptr;
+    int flags = CWOverrideRedirect | CWBackingStore;
+    window.color_depth = CopyFromParent;
 
-    depth = CopyFromParent;
-    visual = CopyFromParent;
+    // TODO: anything other than background_colour is deprecated.
+    // Simplify this dance in 5 years and remove other options completely.
+    uint8_t background_alpha = background_colour.get(l).alpha;
 #ifdef BUILD_ARGB
-    if (use_argb_visual.get(l) && (get_argb_visual(&visual, &depth) != 0)) {
-      have_argb_visual = true;
-      window.visual = visual;
-      window.colourmap = XCreateColormap(display, DefaultRootWindow(display),
-                                         window.visual, AllocNone);
+    if (own_window_argb_value.get(l) < 0xff) {
+      background_alpha = own_window_argb_value.get(l);
+    }
+#endif /* BUILD_ARGB */
+    if (set_transparent.get(l)) {
+      background_alpha = 0;
+      window.opacity = 0;
+    }
+
+#ifdef BUILD_ARGB
+    bool wants_alpha = background_alpha < 0xff;
+    if (wants_alpha && try_set_argb_visual(&window)) {
+      window.opacity = background_alpha;
+    } else if (wants_alpha) {
+      if (background_alpha != 0) {
+        NORM_ERR("ARGB visual not supported (no compositor?); only full background transparency is supported: window will be opaque");
+      } else {
+        window.opacity = 0;
+        NORM_ERR("ARGB visual not supported (no compositor?); window will use fallback");
+      }
     }
 #endif /* BUILD_ARGB */
 
@@ -546,7 +558,7 @@ void x11_init_window(lua::state &l, bool own) {
                                     0,
                                     0};
       flags |= CWBackPixel;
-      if (have_argb_visual) {
+      if (window.opacity < 0xff) {
         attrs.colormap = window.colourmap;
         flags &= ~CWBackPixel;
         flags |= CWBorderPixel | CWColormap;
@@ -555,7 +567,7 @@ void x11_init_window(lua::state &l, bool own) {
       /* Parent is desktop window (which might be a child of root) */
       window.window = XCreateWindow(
           display, window.desktop, window.geometry.x(), window.geometry.y(), b,
-          b, 0, depth, InputOutput, visual, flags, &attrs);
+          b, 0, window.color_depth, InputOutput, window.visual, flags, &attrs);
 
       XLowerWindow(display, window.window);
       XSetClassHint(display, window.window, &classHint);
@@ -587,7 +599,7 @@ void x11_init_window(lua::state &l, bool own) {
       Atom xa;
 
       flags |= CWBackPixel;
-      if (have_argb_visual) {
+      if (window.opacity < 0xff) {
         attrs.colormap = window.colourmap;
         flags &= ~CWBackPixel;
         flags |= CWBorderPixel | CWColormap;
@@ -598,8 +610,8 @@ void x11_init_window(lua::state &l, bool own) {
       }
       /* Parent is root window so WM can take control */
       window.window = XCreateWindow(display, window.root, window.geometry.x(),
-                                    window.geometry.y(), b, b, 0, depth,
-                                    InputOutput, visual, flags, &attrs);
+                                    window.geometry.y(), b, b, 0, window.color_depth,
+                                    InputOutput, window.visual, flags, &attrs);
 
       uint16_t hints = own_window_hints.get(l);
 

--- a/src/output/x11.h
+++ b/src/output/x11.h
@@ -54,9 +54,6 @@
 #include "../geometry.h"
 #include "gui.h"
 
-/* true if use_argb_visual=true and argb visual was found*/
-extern bool have_argb_visual;
-
 #define ATOM(a) XInternAtom(display, #a, False)
 
 /// @brief Display where conky is placed
@@ -75,6 +72,21 @@ struct conky_x11_window {
   Visual *visual;
   Colormap colourmap;
   GC gc;
+  
+  /// Background opacity of the window (0-255).
+  /// 
+  /// This is set directly by lua settings - read them directly from
+  /// backend-agnostic code.
+  uint8_t opacity;
+  /// Window buffer color depth.
+  /// 
+  /// Value `32` means X11 supports ARGB8888 (has a compositor).
+  /// Value `24` means only full background transparency is supported (no compositor).
+  /// Value `0` means `CopyFromParent`, i.e. default value, which is always `24`.
+  /// 
+  /// It can be something other than those 3 values (e.g. monochrome displays),
+  /// but that's exceedingly rare.
+  uint8_t color_depth;
 
   // Mask containing all events captured by conky
   int64_t event_mask;
@@ -101,7 +113,7 @@ void update_x11_workarea();
 void init_x11();
 void destroy_window(void);
 void create_gc(void);
-void set_transparent_background(Window win);
+void set_transparent_background(conky_x11_window *win);
 void get_x11_desktop_info(Display *current_display, Atom atom);
 /// @brief Sets reserved area atoms for the conky window to avoid other windows
 /// covering it.


### PR DESCRIPTION
This PR deprecates:
- `own_window_argb_visual` - just set the color to opaque
- `own_window_argb_value` - just set the alpha on the color
- `own_window_transparent` - just set the alpha=0 on the color

It removes `BUILD_ARGB` flag - it's been supported by X11 for quite some time.

It's backwards compatible: using old settings will result in same behavior as before (ignoring the fixed bugs), only difference is that `own_window_argb_visual = false` won't make the window opaque (ignoring other alpha settings), but this could also confuse some users.

16 value combinations are now resolved by specificity, which should be the most intuitive option for users.

## Testing
- [x] Closes #2301: overwrote bg alpha unconditionally with `own_window_argb_value`.
- [x] Closes #2015: fallback (without compositor) in X11 code always set the transparent color when built with `BUILD_ARGB`, without compositor running this means black.
- [x] Closes #2109: asks for this fix directly.

**LLM use:** rubber ducky and looking through ancient git history to figure out rationale behind each option.