### PR TITLE
Update stale width and height values

### DIFF
--- a/src/lua/llua.cc
+++ b/src/lua/llua.cc
@@ -745,6 +745,9 @@ void llua_update_window_table(conky::vec2i window_size,
   }
 #endif
 
+  llua_set_number("width", window_size.x());
+  llua_set_number("height", window_size.y());
+
   lua_newtable(lua_L);
   llua_set_number("x", static_cast<int>(window_size.x() * scale_x));
   llua_set_number("y", static_cast<int>(window_size.y() * scale_y));


### PR DESCRIPTION
Follow-up on #2342. I forgot to add updates to `width` and `height` so they stay in sync with window geometry.

These can change on resize (normal window) or DPI change.

Closes #2271.
