### PR TITLE
fix: execp storing hash in left-behind field on text_object

### DIFF
--- a/src/content/text_object.h
+++ b/src/content/text_object.h
@@ -122,7 +122,6 @@ struct text_object {
 
   void *special_data;
 
-  size_t last_execp_hash; /* caching-hash for execp content*/
   long line;
   bool parse;  /* if true then data.s should still be parsed */
   bool thread; /* if true then data.s should be set by a separate thread */

--- a/src/data/exec.cc
+++ b/src/data/exec.cc
@@ -243,7 +243,7 @@ void fill_p(const char *buffer, struct text_object *obj, char *p,
       if (obj->sub) { memset(obj->sub, 0, sizeof(struct text_object)); }
       if (obj->sub) { extract_variable_text_internal(obj->sub, buffer); }
 
-      obj->last_execp_hash = current_hash;
+      ed->last_execp_hash = current_hash;
     }
 
     if (obj->sub) { generate_text_internal(p, p_max_size, *obj->sub); }


### PR DESCRIPTION
In my cfad8668 commit from #2348 I accidentally forgot to rename a field. It built so I assumed it worked, but it just disables the fix from the commit before it. Thankfully, it just means the hash is never updated and behaves the same as before 746ae138.

This PR contains a followup commit that fixes this omission.

Closes #2333.