### PR TITLE
fix: various tiny followups

### DIFF
--- a/src/content/text_object.h
+++ b/src/content/text_object.h
@@ -122,7 +122,6 @@ struct text_object {
 
   void *special_data;
 
-  size_t last_execp_hash; /* caching-hash for execp content*/
   long line;
   bool parse;  /* if true then data.s should still be parsed */
   bool thread; /* if true then data.s should be set by a separate thread */

--- a/src/data/exec.cc
+++ b/src/data/exec.cc
@@ -243,7 +243,7 @@ void fill_p(const char *buffer, struct text_object *obj, char *p,
       if (obj->sub) { memset(obj->sub, 0, sizeof(struct text_object)); }
       if (obj->sub) { extract_variable_text_internal(obj->sub, buffer); }
 
-      obj->last_execp_hash = current_hash;
+      ed->last_execp_hash = current_hash;
     }
 
     if (obj->sub) { generate_text_internal(p, p_max_size, *obj->sub); }

--- a/src/logging.h
+++ b/src/logging.h
@@ -74,7 +74,7 @@ struct attribute {
   template <typename T,
             typename = std::enable_if_t<fmt::is_formattable<T>::value>>
   attribute(std::string_view k, const T &v)
-      : key(k), value(fmt::to_string(v)) {}
+      : key(k), value(fmt::format("{}", v)) {}
 };
 
 using attribute_list = std::vector<attribute>;
@@ -150,11 +150,12 @@ void clear_msg_attrs();
 #define LOG_ERROR(...) SPDLOG_ERROR(__VA_ARGS__)
 #define LOG_CRITICAL(...) SPDLOG_CRITICAL(__VA_ARGS__)
 
+#define _LOG_STRIP_PARENS(...) __VA_ARGS__
 #define _LOG_MESSAGE_LEVEL_WITH_ATTRIBUTES_IMPLEMENTATION(spdlog_macro, attrs, ...) \
   do {                                                  \
     if (spdlog::default_logger()->should_log(           \
             spdlog::level::trace)) {                    \
-      conky::log::push_msg_attrs(attrs);                \
+      conky::log::push_msg_attrs({_LOG_STRIP_PARENS attrs}); \
       spdlog_macro(__VA_ARGS__);                        \
       conky::log::clear_msg_attrs();                    \
     } else {                                            \

--- a/src/lua/x11-settings.cc
+++ b/src/lua/x11-settings.cc
@@ -76,9 +76,11 @@ bool use_xpmdb_setting::set_up(lua::state &l) {
   // double_buffer makes no sense when not drawing to X
   if (!out_to_x.get(l)) return false;
 
+  unsigned int depth = window.color_depth != 0 ? window.color_depth
+                                                : DefaultDepth(display, screen);
   window.back_buffer =
-      XCreatePixmap(display, window.window, window.geometry.width() + 1, window.geometry.height() + 1,
-                    DefaultDepth(display, screen));
+      XCreatePixmap(display, window.window, window.geometry.width() + 1,
+                    window.geometry.height() + 1, depth);
   if (window.back_buffer != None) {
     window.drawable = window.back_buffer;
   } else {

--- a/src/mouse-events.cc
+++ b/src/mouse-events.cc
@@ -232,7 +232,7 @@ device_info *device_info::from_xi_id(xi_device_id device_id, Display *display) {
   if (num_devices == 0) return nullptr;
 
   int master;
-  
+
   if(device->use == XIMasterPointer){
     master = device->deviceid;
   }
@@ -309,11 +309,17 @@ size_t fixed_valuator_index(Display *display, XIDeviceInfo *device,
   return *valuator;
 }
 
-/// Allows override of valuator value type in `xorg.conf` in case they're wrong
-/// for some device (happens with VMs and some devices/setups).
+/// Allows override of valuator value type via X device properties in case
+/// they're wrong for some device (happens with VMs and some devices/setups).
+///
+/// Scroll valuators always accumulate regardless of XIValuatorClassInfo::mode,
+/// so they default to absolute.
+/// See: https://www.x.org/releases/X11R7.7/doc/inputproto/XI2proto.txt
+/// (section "XIScrollClass")
 bool fixed_valuator_relative(Display *display, XIDeviceInfo *device,
                              valuator_t valuator,
-                             XIValuatorClassInfo *class_info) {
+                             XIValuatorClassInfo *class_info,
+                             bool is_scroll) {
   const std::array<const char *, 2> atom_names = {
       "ConkyValuatorMoveMode",
       "ConkyValuatorScrollMode",
@@ -358,6 +364,12 @@ bool fixed_valuator_relative(Display *display, XIDeviceInfo *device,
       return relative;
     }
   } while (true);
+
+  // Scroll valuators accumulate; XIValuatorClassInfo::mode is unreliable
+  // for them (libinput reports XIModeRelative despite absolute values).
+  // This is because X11 was designed from ground up to make relative sense.
+  if (is_scroll) return false;
+
   return class_info->mode == XIModeRelative;
 }
 
@@ -401,6 +413,11 @@ void device_info::init_xi_device(
     else if (si->scroll_type == XIScrollTypeHorizontal)
       target = valuator_t::SCROLL_X;
 
+    LOG_DEBUG("xi scroll class: number={} type={} increment={}",
+              si->number,
+              si->scroll_type == XIScrollTypeVertical ? "vertical" : "horizontal",
+              si->increment);
+
     // Only set if not already claimed and doesn't conflict with a move axis.
     // Some devices (e.g. Xephyr) alias scroll and move to the same valuator;
     // movement deltas would be misinterpreted as scroll.
@@ -427,21 +444,36 @@ void device_info::init_xi_device(
     }
     if (valuator == valuator_t::UNKNOWN) { continue; }
 
+    // Scroll valuators with XIScrollClassInfo always accumulate — scroll
+    // is derived from value deltas divided by increment.
+    // See: https://www.x.org/releases/X11R7.7/doc/inputproto/XI2proto.txt
+    // (section "XIScrollClass")
+    // Only consult fixed_valuator_relative for non-scroll axes.
+    auto it = scroll_increments.find(class_info->number);
+    bool is_scroll = it != scroll_increments.end();
+
     auto info = conky_valuator_info{
         .index = static_cast<size_t>(class_info->number),
         .min = class_info->min,
         .max = class_info->max,
         .value = class_info->value,
-        .relative =
-            fixed_valuator_relative(display, device, valuator, class_info),
+        .relative = fixed_valuator_relative(display, device, valuator,
+                                             class_info, is_scroll),
     };
 
-    // Store scroll increment if this valuator has an associated XIScrollClass.
-    auto it = scroll_increments.find(class_info->number);
-    if (it != scroll_increments.end()) { info.increment = it->second; }
+    if (is_scroll) { info.increment = it->second; }
 
     this->valuators[*valuator] = info;
   }
+
+  LOG_DEBUG("xi device '{}' valuators: move_x={} move_y={} scroll_x={} "
+            "scroll_y={} scroll_y_increment={}",
+            device->name,
+            this->valuators[*valuator_t::MOVE_X].index,
+            this->valuators[*valuator_t::MOVE_Y].index,
+            this->valuators[*valuator_t::SCROLL_X].index,
+            this->valuators[*valuator_t::SCROLL_Y].index,
+            this->valuators[*valuator_t::SCROLL_Y].increment);
 
   if (std::holds_alternative<xi_device_id>(source)) {
     XIFreeDeviceInfo(device);
@@ -510,6 +542,12 @@ xi_event_data *xi_event_data::read_cookie(Display *display, const void *data) {
       // possible but unrealistic with 32-bit values.
       result->valuators_relative[v] = current - valuator_info.value;
     }
+    LOG_TRACE_WITH(({"index", valuator_info.index},
+                    {"current", current},
+                    {"prev", valuator_info.value},
+                    {"relative", valuator_info.relative}),
+                   "xi valuator[{}] delta={}", v,
+                   result->valuators_relative[v]);
     valuator_info.value = current;
   }
 

--- a/src/output/display-x11.cc
+++ b/src/output/display-x11.cc
@@ -310,9 +310,12 @@ bool display_output_x11::main_loop_wait(double t) {
 #else
         if (use_xpmdb.get(*state)) {
           XFreePixmap(display, window.back_buffer);
+          unsigned int depth = window.color_depth != 0
+                                  ? window.color_depth
+                                  : DefaultDepth(display, screen);
           window.back_buffer = XCreatePixmap(
               display, window.window, window.geometry.width(),
-              window.geometry.height(), DefaultDepth(display, screen));
+              window.geometry.height(), depth);
 
           if (window.back_buffer != None) {
             window.drawable = window.back_buffer;
@@ -321,7 +324,12 @@ bool display_output_x11::main_loop_wait(double t) {
             LOG_ERROR("failed to allocate back buffer for window {:#x} ({}x{})",
                       window.window, window.geometry.width(), window.geometry.height());
           }
-          XSetForeground(display, window.gc, 0);
+          unsigned long bg = 0;
+          if (window.color_depth == argb8888_color_depth) {
+            Colour c = get_background_colour_preference(*state);
+            bg = c.to_x11_color(display, screen, window.opacity < 0xff, true);
+          }
+          XSetForeground(display, window.gc, bg);
           XFillRectangle(display, window.drawable, window.gc, 0, 0,
                          window.geometry.width(), window.geometry.height());
         }

--- a/src/output/display-x11.cc
+++ b/src/output/display-x11.cc
@@ -481,6 +481,9 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
         query_x11_top_parent(display, event_window) == window_top_parent;
     cursor_over_conky = same_window;
   }
+  LOG_TRACE_WITH(({"pos", data->pos_absolute}, {"geom", window.geometry}),
+                 "xi event: type={} inside_geom={} over_conky={}",
+                 data->evtype, inside_geometry, cursor_over_conky);
 
   // XInput reports events twice on some hardware (even by 'xinput --test-xi2')
   auto hash = std::make_tuple(data->serial, data->evtype, data->event);
@@ -506,6 +509,9 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
   }
 
 #ifdef BUILD_MOUSE_EVENTS
+  // Events not over conky should always propagate to underlying windows.
+  if (!cursor_over_conky) { *consumed = false; }
+
   // query_result is not window.window in some cases.
   modifier_state_t mods = x11_modifier_state(data->mods.effective);
 
@@ -518,6 +524,9 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
     bool has_scroll_y = data->test_valuator(valuator_t::SCROLL_Y);
     bool is_move = has_move_x || has_move_y;
     bool is_scroll = has_scroll_x || has_scroll_y;
+    LOG_TRACE_WITH(({"move_x", has_move_x}, {"move_y", has_move_y},
+                    {"scroll_x", has_scroll_x}, {"scroll_y", has_scroll_y}),
+                   "xi motion: is_move={} is_scroll={}", is_move, is_scroll);
 
     if (is_move) {
       static bool cursor_inside = false;
@@ -555,6 +564,12 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
         scroll_direction = (vertical_value * increment) < 0.0
                                ? scroll_direction_t::UP
                                : scroll_direction_t::DOWN;
+        LOG_TRACE_WITH(({"vertical", vertical_value},
+                        {"increment", increment},
+                        {"product", vertical_value * increment}),
+                       "xi scroll dir={}",
+                       scroll_direction == scroll_direction_t::UP ? "UP"
+                                                                  : "DOWN");
       } else {
         auto horizontal = data->valuator_relative_value(valuator_t::SCROLL_X);
         double horizontal_value = horizontal.value_or(0.0);
@@ -575,6 +590,8 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
     }
   } else if (cursor_over_conky && (data->evtype == XI_ButtonPress ||
                                    data->evtype == XI_ButtonRelease)) {
+    LOG_TRACE("xi button: detail={} type={}",
+              data->detail, data->evtype == XI_ButtonPress ? "press" : "release");
     if (data->detail >= 4 && data->detail <= 7) {
       // Fallback: use button 4-7 as scroll if this device has no independent
       // scroll valuators (e.g. Xephyr aliases scroll and move axes).
@@ -582,6 +599,8 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
       bool has_scroll_valuators =
           data->device->valuator(valuator_t::SCROLL_X).index != SIZE_MAX ||
           data->device->valuator(valuator_t::SCROLL_Y).index != SIZE_MAX;
+      LOG_TRACE("xi button 4-7 fallback: has_scroll_valuators={}",
+                has_scroll_valuators);
       if (!has_scroll_valuators && data->evtype == XI_ButtonPress) {
         scroll_direction_t direction = x11_scroll_direction(data->detail);
         auto window_pos = data->pos_absolute - window.geometry.pos();
@@ -606,22 +625,27 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
   *consumed = false;
 #endif /* BUILD_MOUSE_EVENTS */
 
+  LOG_TRACE("xi event pre-window-type: consumed={}", *consumed);
   if (!own_window.get(*state)) return true;
-  switch (own_window_type.get(*state)) {
-    case window_type::NORMAL:
-    case window_type::UTILITY:
-      // decorated normal windows always consume events
-      if (!TEST_HINT(own_window_hints.get(*state), window_hints::UNDECORATED)) {
+  if (cursor_over_conky) {
+    switch (own_window_type.get(*state)) {
+      case window_type::NORMAL:
+      case window_type::UTILITY:
+        // decorated normal windows always consume events
+        if (!TEST_HINT(own_window_hints.get(*state),
+                       window_hints::UNDECORATED)) {
+          *consumed = true;
+        }
+        break;
+      case window_type::DESKTOP:
+        // assume conky is always on bottom; nothing to propagate events to
         *consumed = true;
-      }
-      break;
-    case window_type::DESKTOP:
-      // assume conky is always on bottom; nothing to propagate events to
-      *consumed = true;
-    default:
-      break;
+      default:
+        break;
+    }
   }
 
+  LOG_TRACE("xi event final: consumed={}", *consumed);
   return true;
 }
 

--- a/src/output/x11.cc
+++ b/src/output/x11.cc
@@ -379,8 +379,6 @@ static Window find_desktop_window(Window root) {
   return desktop;
 }
 
-const int argb8888_color_depth = 32;
-
 #ifdef OWN_WINDOW
 /* if no argb visual is configured sets background to ParentRelative for the
    Window and all parents, else real transparency is used */
@@ -392,6 +390,10 @@ void set_transparent_background(conky_x11_window *window) {
     Colour colour = get_background_colour_preference(*state);
     unsigned long xcolor =
         colour.to_x11_color(display, screen, window->opacity < 0xff, true);
+    LOG_DEBUG("ARGB background: colour=({},{},{},{}) xcolor=0x{:08x} "
+              "opacity={}",
+              colour.red, colour.green, colour.blue, colour.alpha, xcolor,
+              window->opacity);
     XSetWindowBackground(display, window->window, xcolor);
     return;
   }
@@ -421,12 +423,18 @@ static bool has_compositor() {
   char atom_name[32];
   snprintf(atom_name, sizeof(atom_name), "_NET_WM_CM_S%d", screen);
   Atom cm_atom = XInternAtom(display, atom_name, False);
-  return XGetSelectionOwner(display, cm_atom) != None;
+  Window owner = XGetSelectionOwner(display, cm_atom);
+  bool found = owner != None;
+  LOG_DEBUG("compositor {}", found ? "detected" : "not detected");
+  return found;
 }
 
 static bool try_set_argb_visual(conky_x11_window *window) {
   // ARGB visuals are useless without a compositor to blend the alpha.
-  if (!has_compositor()) { return false; }
+  if (!has_compositor()) {
+    LOG_DEBUG("skipping ARGB visual: no compositor");
+    return false;
+  }
 
   /* code from gtk project, gdk_screen_get_rgba_visual */
   XVisualInfo visual_template;
@@ -445,11 +453,14 @@ static bool try_set_argb_visual(conky_x11_window *window) {
       window->color_depth = argb8888_color_depth;
       window->colourmap = XCreateColormap(display, DefaultRootWindow(display),
                                           window->visual, AllocNone);
+      LOG_DEBUG("using ARGB visual (depth=32, id=0x{:x})",
+                visual_list[i].visualid);
       XFree(visual_list);
       return true;
     }
   }
   // no argb visual available
+  LOG_DEBUG("no ARGB visual found ({} visuals checked)", nxvisuals);
 
   XFree(visual_list);
   return false;
@@ -486,6 +497,8 @@ void x11_init_window(lua::state &l, bool own) {
 
     uint8_t background_alpha = get_background_alpha_preference(l);
     bool wants_alpha = background_alpha < 0xff;
+    LOG_DEBUG("background alpha={:#x} wants_alpha={}", background_alpha,
+              wants_alpha);
 
     if (wants_alpha && try_set_argb_visual(&window)) {
       window.opacity = background_alpha;
@@ -1378,9 +1391,14 @@ void xpmdb_swap_buffers(void) {
   if (use_xpmdb.get(*state)) {
     XCopyArea(display, window.back_buffer, window.window, window.gc, 0, 0,
               window.geometry.width(), window.geometry.height(), 0, 0);
-    XSetForeground(display, window.gc, 0);
-    XFillRectangle(display, window.drawable, window.gc, 0, 0, window.geometry.width(),
-                   window.geometry.height());
+    unsigned long bg = 0;
+    if (window.color_depth == argb8888_color_depth) {
+      Colour c = get_background_colour_preference(*state);
+      bg = c.to_x11_color(display, screen, window.opacity < 0xff, true);
+    }
+    XSetForeground(display, window.gc, bg);
+    XFillRectangle(display, window.drawable, window.gc, 0, 0,
+                   window.geometry.width(), window.geometry.height());
     XFlush(display);
   }
 }

--- a/src/output/x11.h
+++ b/src/output/x11.h
@@ -61,6 +61,8 @@ extern Display *display;
 /// @brief Screen with conky
 extern int screen;
 
+constexpr int argb8888_color_depth = 32;
+
 struct conky_x11_window {
   /// XID of x11 root window
   Window root;


### PR DESCRIPTION
This PR adds a bunch of cleanup commits.that fix some quirks and edge cases I left behind in my previous commits.

## fix: execp storing hash in left-behind field on text_object

In my cfad8668 commit from #2348 I accidentally forgot to rename a field. It built so I assumed it worked, but it just disables the fix from the commit before it. Thankfully, it just means the hash is never updated and behaves the same as before 746ae138.

- [x] This commit fixes this omission and closes #2333.
  - Confirmed by @Lowrida

## fix: better logging attribute handling

Better handling of logging attributes added in #1899. They now use formatters for printing - didn't know `fmt::to_string` from spdlog would fail for some values that have formatters before d1449778b07480f60dd46bf233a0b09c75f2fd35.

This is lifting a limitation (not a bug).

- [x] Code that didn't compile before now compiles, tested via:

## fix(x11): scroll direction and event propagation

Closes #2288, addressing:
- conky window capturing too many events after #2337 (this would be blocking a stable release)
- scroll defaulting to `up` in Lua because `XIValuatorClassInfo::mode == XIModeRelative` means that scroll event values are still, in fact, absolute in X11. Yes.

- [x] Tested on fluxbox
  - openbox on xephyr already worked previously (don't know how)

## fix(x11): xpmdb back buffer depth and clear color for ARGB visuals

I recently removed a bunch of `*argb*` settings and `BUILD_ARGB`, updated the appropriate functions, but didn't check the `xpmdb` implementation which manages its own copy of the back buffer and clears is manually. This meant that `xpmdb` wasn't using the correct color depth and clear color anymore - some of this might've been the case before my changes.

LLM used to figure out why window was not showing in fluxbox. Not reported in issues (yet).

- [x] Tested on fluxbox