### PR TITLE
Fix journal.cc issues

### DIFF
--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -1111,13 +1111,15 @@ values:
       - (max_msg_lines)
   - name: journal
     desc: |-
-      Displays last N lines of the systemd journal. The optional
-      type can be 'user' or 'system' which will show only the user or system
-      journal respectively. By default, all journal lines visible to the
-      user are shown. A maximum of 200 lines can be displayed, or until the
-      text buffer is filled.
+      Displays last N lines of the systemd journal. N defaults to 1 if
+      omitted. Use 0 to display all available lines. Negative values are
+      clamped to 1. The optional type filters which journal is read:
+      'system' shows only the system journal, 'user' shows only the current
+      user's journal, 'runtime' shows only the runtime journal, 'local'
+      shows all local journals (the default, same as omitting the type).
+      Output is limited by the text buffer size.
     args:
-      - lines
+      - (lines)
       - (type)
   - name: kernel
     desc: Kernel version.

--- a/src/buffer.hh
+++ b/src/buffer.hh
@@ -1,0 +1,109 @@
+#ifndef CONKY_BUFFER_HH
+#define CONKY_BUFFER_HH
+
+#include <cstring>
+#include <memory>
+#include <string_view>
+#include <utility>
+#include <spdlog/fmt/fmt.h>
+#include "logging.h"
+
+namespace conky {
+
+/// Bounds-checked sequential writer into a fixed-capacity char buffer.
+///
+/// Two modes:
+///   buffer_writer w(cap);           — allocates its own buffer; use release() to
+///                                  transfer ownership as a unique_ptr
+///   buffer_writer w(cap, buf);      — writes into caller-owned buf; use
+///                                  terminate() to null-terminate in place
+class buffer_writer {
+ public:
+  buffer_writer(size_t cap, char *buf = nullptr)
+      : m_cap(cap), m_owned(buf == nullptr) {
+    m_buf = m_owned ? new char[cap] : buf;
+  }
+
+  ~buffer_writer() {
+    if (m_owned) delete[] m_buf;
+  }
+
+  buffer_writer(const buffer_writer &) = delete;
+  buffer_writer &operator=(const buffer_writer &) = delete;
+
+  buffer_writer(buffer_writer &&o) noexcept
+      : m_buf(o.m_buf), m_pos(o.m_pos), m_cap(o.m_cap), m_owned(o.m_owned) {
+    o.m_buf = nullptr;
+    o.m_owned = false;
+  }
+
+  // Append a single character. Returns false if the buffer is full.
+  constexpr bool append(char c) {
+    if (m_pos >= m_cap) return false;
+    m_buf[m_pos++] = c;
+    return true;
+  }
+
+  // Append a byte range. Returns false if it does not fit entirely.
+  bool append(const char *s, size_t len) {
+    if (m_pos + len > m_cap) return false;
+    memcpy(m_buf + m_pos, s, len);
+    m_pos += len;
+    return true;
+  }
+
+  bool append(std::string_view sv) { return append(sv.data(), sv.size()); }
+
+  template <typename T,
+            typename = std::enable_if_t<fmt::is_formattable<T>::value>>
+  bool append(const T &value) {
+    size_t rem = remaining();
+    auto result = fmt::format_to_n(cursor(), rem, "{}", value);
+    m_pos += std::min(result.size, rem);
+    return result.size <= rem;
+  }
+
+  // Pointer to the next write position, for use with C APIs like strftime that
+  // write directly into a buffer. Call advance() afterwards.
+  constexpr char *cursor() { return m_buf + m_pos; }
+
+  // Advance the write position by n bytes after a direct write via cursor().
+  // Clamps to capacity.
+  constexpr void advance(size_t n) { m_pos = std::min(m_pos + n, m_cap); }
+
+  constexpr size_t size() const { return m_pos; }
+  constexpr size_t capacity() const { return m_cap; }
+  constexpr size_t remaining() const { return m_cap - m_pos; }
+  constexpr bool full() const { return m_pos >= m_cap; }
+
+  // View of the bytes written so far (not null-terminated).
+  constexpr std::string_view view() const { return {m_buf, m_pos}; }
+
+  // Null-terminate in place. Safe to call on non-owning writers before
+  // handing p back to the caller (cap must be > 0).
+  constexpr void terminate() {
+    if (m_cap > 0) m_buf[m_pos < m_cap ? m_pos : m_cap - 1] = '\0';
+  }
+
+  // Null-terminate and transfer ownership of the buffer to the caller.
+  // Terminates if called on a non-owning writer — the caller does not own the
+  // buffer and taking it would allow use-after-free.
+  std::unique_ptr<char[]> take() {
+    if (!m_owned)
+      CRIT_ERR("take() called on a non-owning buffer_writer; "
+               "the buffer belongs to the caller and cannot be transferred");
+    terminate();
+    m_owned = false;
+    return std::unique_ptr<char[]>(std::exchange(m_buf, nullptr));
+  }
+
+ private:
+  char *m_buf;
+  size_t m_pos = 0;
+  size_t m_cap;
+  bool m_owned;
+};
+
+}  // namespace conky
+
+#endif /* CONKY_BUFFER_HH */

--- a/src/data/os/journal.cc
+++ b/src/data/os/journal.cc
@@ -27,43 +27,40 @@
  *
  */
 
-#include <string.h>
 #include <systemd/sd-journal.h>
-#include <time.h>
-#include <unistd.h>
+#include <chrono>
+#include <cstring>
+#include <ctime>
 #include <memory>
 #include "../../buffer.hh"
-#include "config.h"
 #include "../../conky.h"
 #include "../../logging.h"
 #include "../../content/text_object.h"
 
-#define MAX_JOURNAL_LINES 200
+constexpr int MAX_JOURNAL_LINES = 200;
 
 class journal {
  public:
-  int wantedlines;
+  int wanted_lines;
   int flags;
 
-  journal() : wantedlines(0), flags(SD_JOURNAL_LOCAL_ONLY) {}
+  journal() : wanted_lines(0), flags(SD_JOURNAL_LOCAL_ONLY) {}
 };
 
 void free_journal(struct text_object *obj) {
-  journal *j = (journal *)obj->data.opaque;
+  journal *conf = static_cast<journal *>(obj->data.opaque);
   obj->data.opaque = nullptr;
-  delete j;
+  delete conf;
 }
 
 void init_journal(const char *type, const char *arg, struct text_object *obj,
                   void *free_at_crash) {
-  unsigned int args;
-  journal *j = new journal;
+  unsigned int argc;
+  journal *options = new journal;
 
-  std::unique_ptr<char[]> tmp(new char[DEFAULT_TEXT_BUFFER_SIZE]);
-  memset(tmp.get(), 0, DEFAULT_TEXT_BUFFER_SIZE);
-
-  args = sscanf(arg, "%d %6s", &j->wantedlines, tmp.get());
-  if (args < 1 || args > 2) {
+  char type_arg[7] = {};
+  argc = sscanf(arg, "%d %6s", &options->wanted_lines, type_arg);
+  if (argc < 1 || argc > 2) {
     free_journal(obj);
     free(obj);
     free(free_at_crash);
@@ -72,24 +69,8 @@ void init_journal(const char *type, const char *arg, struct text_object *obj,
         "type as 2nd argument",
         type);
   }
-  if (j->wantedlines > 0 && j->wantedlines <= MAX_JOURNAL_LINES) {
-    if (args > 1) {
-      if (strcmp(tmp.get(), "system") == 0) {
-        j->flags |= SD_JOURNAL_SYSTEM;
-      } else if (strcmp(tmp.get(), "user") == 0) {
-        j->flags |= SD_JOURNAL_CURRENT_USER;
-      } else {
-        free_journal(obj);
-        free(obj);
-        free(free_at_crash);
-        COMMAND_ARG_ERR(type, "invalid arg for {}, type must be 'system' or 'user'",
-                 type);
-      }
-    } else {
-      LOG_WARNING("you should specify 'user' or 'system' as an argument");
-    }
-
-  } else {
+  
+  if (options->wanted_lines <= 0 || options->wanted_lines > MAX_JOURNAL_LINES) {
     free_journal(obj);
     free(obj);
     free(free_at_crash);
@@ -97,76 +78,88 @@ void init_journal(const char *type, const char *arg, struct text_object *obj,
         "invalid arg for {}, number of lines must be between 1 and {}", type,
         MAX_JOURNAL_LINES);
   }
-  obj->data.opaque = j;
+
+  if (argc >= 2) {
+    if (strcmp(type_arg, "system") == 0) {
+      options->flags |= SD_JOURNAL_SYSTEM;
+    }  else if (strcmp(type_arg, "user") == 0) {
+      options->flags |= SD_JOURNAL_CURRENT_USER;
+    } else {
+      free_journal(obj);
+      free(obj);
+      free(free_at_crash);
+      COMMAND_ARG_ERR(type, "invalid arg for {}, type must be 'system' or 'user'",
+                      type);
+    }
+  }
+
+  obj->data.opaque = options;
 }
 
-static int print_field(sd_journal *jh, const char *field, char spacer,
-                       conky::buffer_writer &out) {
-  const void *get;
+static bool print_field(sd_journal *handle, const char *field, char spacer,
+                        conky::buffer_writer &out) {
+  const void *data;
   size_t length;
   size_t fieldlen = strlen(field) + 1;
 
-  int ret = sd_journal_get_data(jh, field, &get, &length);
-  if (ret == -ENOENT) goto out;
+  int ret = sd_journal_get_data(handle, field, &data, &length);
+  if (ret >= 0) {
+    if (length - fieldlen > out.remaining()) return false;
+    out.append(static_cast<const char *>(data) + fieldlen, length - fieldlen);
+  } else if (ret != -ENOENT) {
+    return false;
+  }
 
-  if (ret < 0 || length - fieldlen > out.remaining()) return -1;
-
-  out.append((const char *)get + fieldlen, length - fieldlen);
-
-out:
-  if (spacer && !out.append(spacer)) return -1;
-  return length ? length - fieldlen : 0;
+  return !spacer || out.append(spacer);
 }
 
-bool read_log(sd_journal *jh, conky::buffer_writer &out) {
-  struct tm tm;
-  uint64_t timestamp;
-  time_t time;
-  size_t length;
+bool read_log(sd_journal *handle, conky::buffer_writer &out) {
+  uint64_t usec;
+  if (sd_journal_get_realtime_usec(handle, &usec) < 0) return false;
 
-  if (sd_journal_get_realtime_usec(jh, &timestamp) < 0) return false;
-  time = timestamp / 1000000;
-  localtime_r(&time, &tm);
+  auto tp = std::chrono::system_clock::time_point{
+      std::chrono::microseconds{usec}};
+  std::time_t epoch = std::chrono::system_clock::to_time_t(tp);
+  std::tm local_tm{};
+  localtime_r(&epoch, &local_tm);
 
-  if ((length = strftime(out.cursor(), out.remaining(), "%b %d %H:%M:%S",
-                         &tm)) <= 0)
-    return false;
+  size_t length = strftime(out.cursor(), out.remaining(), "%b %d %H:%M:%S", &local_tm);
+  if (length == 0) return false;
   out.advance(length);
 
   if (!out.append(' ')) return false;
-
-  if (print_field(jh, "_HOSTNAME", ' ', out) < 0) return false;
-  if (print_field(jh, "SYSLOG_IDENTIFIER", '[', out) < 0) return false;
-  if (print_field(jh, "_PID", ']', out) < 0) return false;
+  if (!print_field(handle, "_HOSTNAME", ' ', out)) return false;
+  if (!print_field(handle, "SYSLOG_IDENTIFIER", '[', out)) return false;
+  if (!print_field(handle, "_PID", ']', out)) return false;
   if (!out.append(':')) return false;
   if (!out.append(' ')) return false;
-  if (print_field(jh, "MESSAGE", '\n', out) < 0) return false;
+  if (!print_field(handle, "MESSAGE", '\n', out)) return false;
   return true;
 }
 
 void print_journal(struct text_object *obj, char *p, unsigned int p_max_size) {
-  journal *j = (journal *)obj->data.opaque;
-  sd_journal *jh = nullptr;
+  journal *conf = static_cast<journal *>(obj->data.opaque);
   conky::buffer_writer out(p_max_size, p);
+  out.terminate();
 
-  if (sd_journal_open(&jh, j->flags) != 0) {
+  sd_journal *raw = nullptr;
+  if (sd_journal_open(&raw, conf->flags) != 0) {
     LOG_ERROR("unable to open journal");
-    goto done;
+    return;
   }
+  auto handle = std::unique_ptr<sd_journal, decltype(&sd_journal_close)>(
+      raw, sd_journal_close);
 
-  if (sd_journal_seek_tail(jh) < 0) {
+  if (sd_journal_seek_tail(handle.get()) < 0) {
     LOG_ERROR("unable to seek to end of journal");
-    goto done;
+    return;
   }
-  if (sd_journal_previous_skip(jh, j->wantedlines) < 0) {
-    LOG_ERROR("unable to seek back {} lines", j->wantedlines);
-    goto done;
+  if (sd_journal_previous_skip(handle.get(), conf->wanted_lines) < 0) {
+    LOG_ERROR("unable to seek back {} lines", conf->wanted_lines);
+    return;
   }
 
-  while (read_log(jh, out) && sd_journal_next(jh))
+  while (read_log(handle.get(), out) && sd_journal_next(handle.get()))
     ;
-
-done:
-  if (jh) sd_journal_close(jh);
   out.terminate();
 }

--- a/src/data/os/journal.cc
+++ b/src/data/os/journal.cc
@@ -27,13 +27,12 @@
  *
  */
 
-#include <ctype.h>
 #include <string.h>
 #include <systemd/sd-journal.h>
 #include <time.h>
 #include <unistd.h>
 #include <memory>
-#include "../../common.h"
+#include "../../buffer.hh"
 #include "config.h"
 #include "../../conky.h"
 #include "../../logging.h"
@@ -102,7 +101,7 @@ void init_journal(const char *type, const char *arg, struct text_object *obj,
 }
 
 static int print_field(sd_journal *jh, const char *field, char spacer,
-                       size_t *read, char *p, unsigned int p_max_size) {
+                       conky::buffer_writer &out) {
   const void *get;
   size_t length;
   size_t fieldlen = strlen(field) + 1;
@@ -110,90 +109,64 @@ static int print_field(sd_journal *jh, const char *field, char spacer,
   int ret = sd_journal_get_data(jh, field, &get, &length);
   if (ret == -ENOENT) goto out;
 
-  if (ret < 0 || length + *read > p_max_size) return -1;
+  if (ret < 0 || length - fieldlen > out.remaining()) return -1;
 
-  memcpy(p + *read, (const char *)get + fieldlen, length - fieldlen);
-  *read += length - fieldlen;
+  out.append((const char *)get + fieldlen, length - fieldlen);
 
 out:
-  if (spacer) {
-    if (p_max_size < *read) {
-      *read = p_max_size - 1;
-    } else {
-      p[(*read)++] = spacer;
-    }
-  }
+  if (spacer && !out.append(spacer)) return -1;
   return length ? length - fieldlen : 0;
 }
 
-bool read_log(size_t *read, size_t *length, time_t *time, uint64_t *timestamp,
-              sd_journal *jh, char *p, unsigned int p_max_size) {
+bool read_log(sd_journal *jh, conky::buffer_writer &out) {
   struct tm tm;
-  if (sd_journal_get_realtime_usec(jh, timestamp) < 0) return false;
-  *time = *timestamp / 1000000;
-  localtime_r(time, &tm);
+  uint64_t timestamp;
+  time_t time;
+  size_t length;
 
-  if ((*length =
-           strftime(p + *read, p_max_size - *read, "%b %d %H:%M:%S", &tm)) <= 0)
+  if (sd_journal_get_realtime_usec(jh, &timestamp) < 0) return false;
+  time = timestamp / 1000000;
+  localtime_r(&time, &tm);
+
+  if ((length = strftime(out.cursor(), out.remaining(), "%b %d %H:%M:%S",
+                         &tm)) <= 0)
     return false;
-  *read += *length;
+  out.advance(length);
 
-  if (p_max_size < *read) {
-    *read = p_max_size - 1;
-    return false;
-  }
-  p[(*read)++] = ' ';
+  if (!out.append(' ')) return false;
 
-  if (print_field(jh, "_HOSTNAME", ' ', read, p, p_max_size) < 0) return false;
-
-  if (print_field(jh, "SYSLOG_IDENTIFIER", '[', read, p, p_max_size) < 0)
-    return false;
-
-  if (print_field(jh, "_PID", ']', read, p, p_max_size) < 0) return false;
-
-  if (p_max_size < *read) {
-    *read = p_max_size - 1;
-    return false;
-  }
-  p[(*read)++] = ':';
-
-  if (p_max_size < *read) {
-    *read = p_max_size - 1;
-    return false;
-  }
-  p[(*read)++] = ' ';
-
-  if (print_field(jh, "MESSAGE", '\n', read, p, p_max_size) < 0) return false;
+  if (print_field(jh, "_HOSTNAME", ' ', out) < 0) return false;
+  if (print_field(jh, "SYSLOG_IDENTIFIER", '[', out) < 0) return false;
+  if (print_field(jh, "_PID", ']', out) < 0) return false;
+  if (!out.append(':')) return false;
+  if (!out.append(' ')) return false;
+  if (print_field(jh, "MESSAGE", '\n', out) < 0) return false;
   return true;
 }
 
 void print_journal(struct text_object *obj, char *p, unsigned int p_max_size) {
   journal *j = (journal *)obj->data.opaque;
   sd_journal *jh = nullptr;
-  size_t read = 0;
-  size_t length;
-  time_t time;
-  uint64_t timestamp;
+  conky::buffer_writer out(p_max_size, p);
 
   if (sd_journal_open(&jh, j->flags) != 0) {
     LOG_ERROR("unable to open journal");
-    goto out;
+    goto done;
   }
 
   if (sd_journal_seek_tail(jh) < 0) {
     LOG_ERROR("unable to seek to end of journal");
-    goto out;
+    goto done;
   }
   if (sd_journal_previous_skip(jh, j->wantedlines) < 0) {
     LOG_ERROR("unable to seek back {} lines", j->wantedlines);
-    goto out;
+    goto done;
   }
 
-  while (read_log(&read, &length, &time, &timestamp, jh, p, p_max_size) &&
-         sd_journal_next(jh))
+  while (read_log(jh, out) && sd_journal_next(jh))
     ;
 
-out:
+done:
   if (jh) sd_journal_close(jh);
-  p[read] = '\0';
+  out.terminate();
 }

--- a/src/data/os/journal.cc
+++ b/src/data/os/journal.cc
@@ -37,14 +37,11 @@
 #include "../../logging.h"
 #include "../../content/text_object.h"
 
-constexpr int MAX_JOURNAL_LINES = 200;
-
-class journal {
- public:
+struct journal {
   int wanted_lines;
   int flags;
 
-  journal() : wanted_lines(0), flags(SD_JOURNAL_LOCAL_ONLY) {}
+  journal() : wanted_lines(1), flags(SD_JOURNAL_LOCAL_ONLY) {}
 };
 
 void free_journal(struct text_object *obj) {
@@ -56,40 +53,38 @@ void free_journal(struct text_object *obj) {
 void init_journal(const char *type, const char *arg, struct text_object *obj,
                   void *free_at_crash) {
   unsigned int argc;
-  journal *options = new journal;
+  journal *options = new journal();
 
-  char type_arg[7] = {};
-  argc = sscanf(arg, "%d %6s", &options->wanted_lines, type_arg);
-  if (argc < 1 || argc > 2) {
+  char type_arg[8] = {};
+  char ignored[2] = {};
+  argc = sscanf(arg, "%d %7s %1s", &options->wanted_lines, type_arg, ignored);
+  if (argc > 2) {
     free_journal(obj);
     free(obj);
     free(free_at_crash);
     COMMAND_ARG_ERR(type,
-        "{} needs a number of lines as 1st argument and optionally a journal "
-        "type as 2nd argument",
-        type);
+        "too many arguments provided; expected: [line_count=1] [type='local']");
   }
-  
-  if (options->wanted_lines <= 0 || options->wanted_lines > MAX_JOURNAL_LINES) {
-    free_journal(obj);
-    free(obj);
-    free(free_at_crash);
-    COMMAND_ARG_ERR(type,
-        "invalid arg for {}, number of lines must be between 1 and {}", type,
-        MAX_JOURNAL_LINES);
+
+  if (options->wanted_lines < 0) {
+    LOG_WARNING("invalid line count {}; clamping to 1", options->wanted_lines);
+    options->wanted_lines = 1;
   }
 
   if (argc >= 2) {
-    if (strcmp(type_arg, "system") == 0) {
+    if (strcmp(type_arg, "local") == 0) {
+      options->flags |= SD_JOURNAL_LOCAL_ONLY; /* no-op */
+    } else if (strcmp(type_arg, "runtime") == 0) {
+      options->flags |= SD_JOURNAL_RUNTIME_ONLY;
+    } else if (strcmp(type_arg, "system") == 0) {
       options->flags |= SD_JOURNAL_SYSTEM;
-    }  else if (strcmp(type_arg, "user") == 0) {
+    } else if (strcmp(type_arg, "user") == 0) {
       options->flags |= SD_JOURNAL_CURRENT_USER;
     } else {
       free_journal(obj);
       free(obj);
       free(free_at_crash);
-      COMMAND_ARG_ERR(type, "invalid arg for {}, type must be 'system' or 'user'",
-                      type);
+      COMMAND_ARG_ERR(type, "type must be one of: 'local', 'runtime', 'system', 'user'");
     }
   }
 
@@ -147,16 +142,25 @@ void print_journal(struct text_object *obj, char *p, unsigned int p_max_size) {
     LOG_ERROR("unable to open journal");
     return;
   }
-  auto handle = std::unique_ptr<sd_journal, decltype(&sd_journal_close)>(
-      raw, sd_journal_close);
+  auto handle = std::unique_ptr<sd_journal, decltype(&sd_journal_close)>(raw, sd_journal_close);
 
-  if (sd_journal_seek_tail(handle.get()) < 0) {
-    LOG_ERROR("unable to seek to end of journal");
-    return;
-  }
-  if (sd_journal_previous_skip(handle.get(), conf->wanted_lines) < 0) {
-    LOG_ERROR("unable to seek back {} lines", conf->wanted_lines);
-    return;
+  if (conf->wanted_lines == 0) {
+    if (sd_journal_seek_head(handle.get()) < 0) {
+      LOG_ERROR("unable to seek to start of journal");
+      return;
+    }
+    if (sd_journal_next(handle.get()) <= 0) {
+      return;
+    }
+  } else {
+    if (sd_journal_seek_tail(handle.get()) < 0) {
+      LOG_ERROR("unable to seek to end of journal");
+      return;
+    }
+    if (sd_journal_previous_skip(handle.get(), conf->wanted_lines) < 0) {
+      LOG_ERROR("unable to seek back {} lines", conf->wanted_lines);
+      return;
+    }
   }
 
   while (read_log(handle.get(), out) && sd_journal_next(handle.get()))

--- a/src/data/os/journal.cc
+++ b/src/data/os/journal.cc
@@ -77,10 +77,8 @@ void init_journal(const char *type, const char *arg, struct text_object *obj,
     if (args > 1) {
       if (strcmp(tmp.get(), "system") == 0) {
         j->flags |= SD_JOURNAL_SYSTEM;
-#ifdef SD_JOURNAL_CURRENT_USER  // not present in older version of systemd
       } else if (strcmp(tmp.get(), "user") == 0) {
         j->flags |= SD_JOURNAL_CURRENT_USER;
-#endif /* SD_JOURNAL_CURRENT_USER */
       } else {
         free_journal(obj);
         free(obj);
@@ -144,7 +142,7 @@ bool read_log(size_t *read, size_t *length, time_t *time, uint64_t *timestamp,
     *read = p_max_size - 1;
     return false;
   }
-  p[*read++] = ' ';
+  p[(*read)++] = ' ';
 
   if (print_field(jh, "_HOSTNAME", ' ', read, p, p_max_size) < 0) return false;
 
@@ -157,13 +155,13 @@ bool read_log(size_t *read, size_t *length, time_t *time, uint64_t *timestamp,
     *read = p_max_size - 1;
     return false;
   }
-  p[*read++] = ':';
+  p[(*read)++] = ':';
 
   if (p_max_size < *read) {
     *read = p_max_size - 1;
     return false;
   }
-  p[*read++] = ' ';
+  p[(*read)++] = ' ';
 
   if (print_field(jh, "MESSAGE", '\n', read, p, p_max_size) < 0) return false;
   return true;


### PR DESCRIPTION
This PR fixes issues described in #388 and #565.

I then went onto cleaning up the journal.cc file to prevent #388 re-appearing there or elsewhere. Replaced old C code with C++ and untangled control flow.

Finally, I tweaked argument handling so they're way more relaxed and not as eager to throw:
- 1 line assumption if argument missing is sane, shows something, and it's a mistake not really worth raising an exception over.
- negative values can just warn and fall back to 1.
- source I kept throwing - maybe some information leak is possible in some cases (e.g. someone making a YT video) and so it's better to be careful, but really I was just lazy :smile:

- [x] Tested locally
- [x] User confirmed fix
- [x] Verified `#ifdef` is no longer needed with Ubuntu LTS 22.04

Closes #388 and #565.