### PR TITLE
Fix double free; coalesce free(obj/free_at_crash) into core.cc; fix graph leak

### DIFF
--- a/doc/config_settings.yaml
+++ b/doc/config_settings.yaml
@@ -520,13 +520,6 @@ values:
     desc: Shows the maximum value in scaled graphs.
   - name: stippled_borders
     desc: Border stippling (dashing) in pixels.
-  - name: store_graph_data_explicitly
-    desc: |-
-      Enable storing graph data explicitly by ID. This avoids resets while
-      using conditional colors. This option should be disabled while using
-      graphs indirectly e.g. via execpi or lua_parse. Otherwise the graph
-      stays emtpy.
-    default: 'true'
   - name: temperature_unit
     desc: |-
       Desired output unit of all objects displaying a temperature.

--- a/src/common.cc
+++ b/src/common.cc
@@ -495,7 +495,7 @@ void print_no_update(struct text_object *obj, char *p,
 
 #ifdef BUILD_GUI
 void scan_loadgraph_arg(struct text_object *obj, const char *arg) {
-  scan_graph(obj, arg, 0, FALSE);
+  scan_graph(obj, arg, 0, FALSE, "load");
 }
 
 double loadgraphval(struct text_object *obj) {

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -996,16 +996,16 @@ static inline void set_foreground_color(Colour c) {
 static inline void draw_graph_bars(special_node *current, std::unique_ptr<Colour[]>& tmpcolour, 
                             conky::vec2i& text_offset, int i, int &j, int w, 
                             int &colour_idx, int cur_x, int by, int h) {
-  double graphheight = current->graph[j] * (h - 1) / current->scale;
+  double graphheight = current->graph_data[j] * (h - 1) / current->scale;
   /* Check if graphheight is less than the minheight threshold, if so we must change it to the threshold */
   if(graphheight > 0 && current->minheight - graphheight > 0) {
-    current->graph[j] = current->minheight * current->scale / (h - 1);
+    current->graph_data[j] = current->minheight * current->scale / (h - 1);
   }
   if (current->colours_set) {
     if (current->tempgrad != 0) {
       set_foreground_color(tmpcolour[static_cast<int>(
           static_cast<float>(w - 2) -
-          current->graph[j] * (w - 2) /
+          current->graph_data[j] * (w - 2) /
               std::max(static_cast<float>(current->scale),
                         1.0F))]);
     } else {
@@ -1014,9 +1014,9 @@ static inline void draw_graph_bars(special_node *current, std::unique_ptr<Colour
   }
   /* Handle the case where y axis is to be inverted */
   int offsety1 = current->inverty ? by : by + h;
-  int offsety2 = current->inverty ? by +  current->graph[j] * (h - 1) / current->scale
+  int offsety2 = current->inverty ? by +  current->graph_data[j] * (h - 1) / current->scale
                           : round_to_positive_int(static_cast<double>(by) + h -
-                          current->graph[j] * (h - 1) /
+                          current->graph_data[j] * (h - 1) /
                           current->scale);
   /* this is mugfugly, but it works */
   if (display_output()) {
@@ -1300,8 +1300,8 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
             if (w == 0) {
               w = text_start.x() + text_size.x() - cur_x - 1;
               current->graph_width = std::max(w - 1, 0);
-              if (current->graph_width != current->graph_allocated) {
-                w = current->graph_allocated + 1;
+              if (current->graph_width != static_cast<int>(current->graph_data.size())) {
+                w = static_cast<int>(current->graph_data.size()) + 1;
               }
             }
             if (w < 0) { w = 0; }
@@ -1315,7 +1315,7 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
             if (display_output()) display_output()->set_line_style(1, true);
 
             /* in case we don't have a graph yet */
-            if (current->graph != nullptr) {
+            if (!current->graph_data.empty()) {
               std::unique_ptr<Colour[]> tmpcolour;
 
               if (current->colours_set) {
@@ -2000,12 +2000,9 @@ static void reload_config() {
 void free_specials(special_node *&current) {
   if (current != nullptr) {
     free_specials(current->next);
-    if (current->type == text_node_t::GRAPH) { free(current->graph); }
     delete current;
     current = nullptr;
   }
-
-  clear_stored_graphs();
 }
 
 void clean_up(void) {

--- a/src/content/scroll.cc
+++ b/src/content/scroll.cc
@@ -159,9 +159,6 @@ void parse_scroll_arg(struct text_object *obj, const char *arg,
 #ifdef BUILD_GUI
     free(obj->next);
 #endif
-    free(free_at_crash2);
-    free(obj);
-    free(free_at_crash);
     COMMAND_ARG_ERR("scroll", "scroll needs arguments: [left|right|wait] <length> [<step>] "
              "[interval] <text>");
   }

--- a/src/content/specials.cc
+++ b/src/content/specials.cc
@@ -39,7 +39,6 @@
 #include <sys/param.h>
 #endif /* HAVE_SYS_PARAM_H */
 #include <algorithm>
-#include <map>
 #include <sstream>
 #include "../common.h"
 #include "../conky.h"
@@ -49,10 +48,7 @@
 struct special_node *specials = nullptr;
 
 int special_count;
-int graph_count = 0;
 double maxspeedval = 1e-47; /* The maximum value among the speed graphs */
-
-std::map<int, double *> graphs;
 
 namespace {
 conky::range_config_setting<int> default_bar_width(
@@ -71,8 +67,6 @@ conky::range_config_setting<int> default_gauge_width(
 conky::range_config_setting<int> default_gauge_height(
     "default_gauge_height", 0, std::numeric_limits<int>::max(), 25, false);
 
-conky::simple_config_setting<bool> store_graph_data_explicitly(
-    "store_graph_data_explicitly", true, true);
 #endif /* BUILD_GUI */
 
 conky::simple_config_setting<std::string> console_graph_ticks(
@@ -104,7 +98,6 @@ struct gauge {
 };
 
 struct graph {
-  int id;
   char flags;
   int width, height;
   bool colours_set;
@@ -114,6 +107,7 @@ struct graph {
   char speedgraph;  /* If the current graph is a speed graph */
   char invertflag;  /* If the axis needs to be inverted */
   int minheight;    /* Clamp values below this threshold to this threshold */
+  std::vector<double> history; /* pre-allocated at scan time when width known */
 };
 
 struct stippled_hr {
@@ -246,6 +240,11 @@ std::pair<char *, size_t> scan_command(const char *s) {
   }
 }
 
+static void free_graph(struct text_object *obj) {
+  delete static_cast<struct graph *>(obj->special_data);
+  obj->special_data = nullptr;
+}
+
 /**
  * parses for [height,width] [color1 color2] [scale] [-t] [-l] [-m value]
  *
@@ -265,11 +264,9 @@ bool scan_graph(struct text_object *obj, const char *argstr, double defscale, ch
   char first_colour_name[1024] = {'\0'};
   char last_colour_name[1024] = {'\0'};
 
-  auto *g = static_cast<struct graph *>(malloc(sizeof(struct graph)));
-  memset(g, 0, sizeof(struct graph));
+  auto *g = new graph{};
   obj->special_data = g;
-
-  g->id = ++graph_count;
+  obj->callbacks.free = &free_graph;
   /* zero width means all space that is available */
   g->width = default_graph_width.get(*state);
   g->height = default_graph_height.get(*state);
@@ -348,7 +345,7 @@ bool scan_graph(struct text_object *obj, const char *argstr, double defscale, ch
   if (sscanf(argstr, "%d,%d %s %s %lf", &g->height, &g->width,
              first_colour_name, last_colour_name, &g->scale) == 5) {
     apply_graph_colours(g, first_colour_name, last_colour_name);
-    return true;
+    goto done;
   }
   g->height = default_graph_height.get(*state);
   g->width = default_graph_width.get(*state);
@@ -363,7 +360,7 @@ bool scan_graph(struct text_object *obj, const char *argstr, double defscale, ch
              last_colour_name) == 4 && 
              strchr(last_colour_name,'-') == NULL) {
     apply_graph_colours(g, first_colour_name, last_colour_name);
-    return true;
+    goto done;
   }
   g->height = default_graph_height.get(*state);
   g->width = default_graph_width.get(*state);
@@ -372,27 +369,27 @@ bool scan_graph(struct text_object *obj, const char *argstr, double defscale, ch
 
   /* [height],[width] [scale] */
   if (sscanf(argstr, "%d,%d %lf", &g->height, &g->width, &g->scale) == 3) {
-    return true;
+    goto done;
   }
   g->height = default_graph_height.get(*state);
   g->width = default_graph_width.get(*state);
   g->scale = defscale;
 
   /* [height],[width] */
-  if (sscanf(argstr, "%d,%d", &g->height, &g->width) == 2) { return true; }
+  if (sscanf(argstr, "%d,%d", &g->height, &g->width) == 2) { goto done; }
   g->height = default_graph_height.get(*state);
   g->width = default_graph_width.get(*state);
 
   /* [height], */
   char comma;
-  if (sscanf(argstr, "%d%[,]", &g->height, &comma) == 2) { return true; }
+  if (sscanf(argstr, "%d%[,]", &g->height, &comma) == 2) { goto done; }
   g->height = default_graph_height.get(*state);
 
   /* [color1] [color2] [scale] */
   if (sscanf(argstr, "%s %s %lf", first_colour_name, last_colour_name,
              &g->scale) == 3) {
     apply_graph_colours(g, first_colour_name, last_colour_name);
-    return true;
+    goto done;
   }
   first_colour_name[0] = '\0';
   last_colour_name[0] = '\0';
@@ -404,14 +401,20 @@ bool scan_graph(struct text_object *obj, const char *argstr, double defscale, ch
   if (sscanf(argstr, "%s %s", first_colour_name, last_colour_name) == 2 &&
              strchr(last_colour_name,'-') == NULL) { 
     apply_graph_colours(g, first_colour_name, last_colour_name);
-    return true;
+    goto done;
   }
   first_colour_name[0] = '\0';
   last_colour_name[0] = '\0';
 
   /* [scale] */
-  if (sscanf(argstr, "%lf", &g->scale) == 1) { return true; }
+  sscanf(argstr, "%lf", &g->scale);
 
+done:
+  /* pre-allocate history at scan time when width is known to avoid
+   * reallocation on first draw */
+  if (g->width > 0) {
+    g->history.resize(dpi_scale(g->width), 0.0);
+  }
   return true;
 }
 #endif /* BUILD_GUI */
@@ -421,10 +424,7 @@ bool scan_graph(struct text_object *obj, const char *argstr, double defscale, ch
  */
 
 struct special_node *new_special_t_node() {
-  auto *newnode = new special_node;
-
-  memset(newnode, 0, sizeof *newnode);
-  return newnode;
+  return new special_node{};
 }
 
 /**
@@ -530,10 +530,8 @@ void new_font(struct text_object *obj, char *p, unsigned int p_max_size) {
  * Adds value f to graph possibly truncating and scaling the graph
  **/
 static void graph_append(struct special_node *graph, double f, char showaslog) {
-  int i;
-
   /* do nothing if we don't even have a graph yet */
-  if (graph->graph == nullptr) { return; }
+  if (graph->graph_data.empty()) { return; }
 
   if (showaslog != 0) {
 #ifdef BUILD_MATH
@@ -544,15 +542,14 @@ static void graph_append(struct special_node *graph, double f, char showaslog) {
   if ((graph->scaled == 0) && f > graph->scale) { f = graph->scale; }
 
   /* shift all the data by 1 */
-  for (i = graph->graph_allocated - 1; i > 0; i--) {
-    graph->graph[i] = graph->graph[i - 1];
+  for (int i = static_cast<int>(graph->graph_data.size()) - 1; i > 0; i--) {
+    graph->graph_data[i] = graph->graph_data[i - 1];
   }
-  graph->graph[0] = f; /* add new data */
+  graph->graph_data[0] = f; /* add new data */
 
   if (graph->scaled != 0) {
-    /* Get the location of the currentmax in the graph */
-    double* currentmax =
-        std::max_element(graph->graph + 0, graph->graph + graph->graph_width);
+    double* currentmax = std::max_element(
+        graph->graph_data.data(), graph->graph_data.data() + graph->graph_data.size());
     graph->scale = *currentmax;
     if (graph->speedgraph) {
         if(maxspeedval < graph->scale){
@@ -562,7 +559,7 @@ static void graph_append(struct special_node *graph, double f, char showaslog) {
         /* If the currentmax is the maxspeedval and 
          * currentmax location is at the last position
          * Then we reset our maxspeedval */
-        if(*currentmax == maxspeedval && currentmax == (graph->graph + graph->width - 1)){
+        if(*currentmax == maxspeedval && currentmax == (graph->graph_data.data() + graph->graph_data.size() - 1)) {
           maxspeedval = 1e-47;
         }
     }
@@ -587,8 +584,8 @@ void new_graph_in_shell(struct special_node *s, char *buf, int buf_max_size) {
   char *p = buf;
   char *buf_max = buf + (sizeof(char) * buf_max_size);
   double scale = (tickitems.size() - 1) / s->scale;
-  for (int i = s->graph_allocated - 1; i >= 0; i--) {
-    const unsigned int v = round_to_positive_int(s->graph[i] * scale);
+  for (int i = static_cast<int>(s->graph_data.size()) - 1; i >= 0; i--) {
+    const unsigned int v = round_to_positive_int(s->graph_data[i] * scale);
     const char *tick = tickitems[v].c_str();
     size_t itemlen = tickitems[v].size();
     for (unsigned int j = 0; j < itemlen; j++) {
@@ -598,32 +595,6 @@ void new_graph_in_shell(struct special_node *s, char *buf, int buf_max_size) {
   }
 graph_buf_end:
   *p = '\0';
-}
-
-double *copy_graph(double *original_graph, int graph_width) {
-  double *new_graph =
-      static_cast<double *>(malloc(graph_width * sizeof(double)));
-
-  memcpy(new_graph, original_graph, graph_width * sizeof(double));
-
-  return new_graph;
-}
-
-double *retrieve_graph(int graph_id, int graph_width) {
-  if (graphs.find(graph_id) == graphs.end()) {
-    return static_cast<double *>(calloc(1, graph_width * sizeof(double)));
-  } else {
-    return copy_graph(graphs[graph_id], graph_width);
-  }
-}
-
-void store_graph(int graph_id, struct special_node *s) {
-  if (s->graph == nullptr) {
-    graphs[graph_id] = nullptr;
-  } else {
-    if (graphs.find(graph_id) != graphs.end()) { free(graphs[graph_id]); }
-    graphs[graph_id] = s->graph;
-  }
 }
 
 /**
@@ -647,28 +618,18 @@ void new_graph(struct text_object *obj, char *buf, int buf_max_size,
   s->width = dpi_scale(g->width);
   if (s->width != 0) { s->graph_width = s->width; }
 
-  if (s->graph_width != s->graph_allocated) {
-    auto *graph = static_cast<double *>(
-        realloc(s->graph, s->graph_width * sizeof(double)));
-    LOG_TRACE("reallocating graph from {} to {}", s->graph_allocated, s->graph_width);
-    if (s->graph == nullptr) {
-      /* initialize */
-      std::fill_n(graph, s->graph_width, 0.0);
-      s->scale = 100;
-    } else if (graph != nullptr) {
-      if (s->graph_width > s->graph_allocated) {
-        /* initialize the new region */
-        std::fill(graph + s->graph_allocated, graph + s->graph_width, 0.0);
-      }
-    } else {
-      LOG_ERROR("graph realloc failed for width {}", s->graph_width);
-      graph = s->graph;
-      s->graph_width = s->graph_allocated;
-    }
-    s->graph = graph;
-    s->graph_allocated = s->graph_width;
-    graphs[g->id] = graph;
+  size_t owner = reinterpret_cast<size_t>(obj);
+  if (s->graph_owner != owner) {
+    s->graph_data.clear();
+    s->graph_owner = owner;
   }
+
+  /* on first use, take the pre-allocated storage from the scan-time struct
+   * (O(1) pointer swap); otherwise resize to match the current width */
+  if (s->graph_data.empty() && !g->history.empty()) {
+    s->graph_data = std::move(g->history);
+  }
+  s->graph_data.resize(s->graph_width, 0.0);
   s->height = dpi_scale(g->height);
   s->colours_set = g->colours_set;
   s->first_colour = g->first_colour;
@@ -700,15 +661,7 @@ void new_graph(struct text_object *obj, char *buf, int buf_max_size,
     s->speedgraph = TRUE;
   }
 
-  if (store_graph_data_explicitly.get(*state)) {
-    if (s->graph) { s->graph = retrieve_graph(g->id, s->graph_width); }
-
-    graph_append(s, val, g->flags);
-
-    store_graph(g->id, s);
-  } else {
-    graph_append(s, val, g->flags);
-  }
+  graph_append(s, val, g->flags);
 
   if (out_to_stdout.get(*state)) { new_graph_in_shell(s, buf, buf_max_size); }
 }
@@ -913,7 +866,3 @@ void new_tab(struct text_object *obj, char *p, unsigned int p_max_size) {
   s->arg = dpi_scale(t->arg);
 }
 
-void clear_stored_graphs() {
-  graph_count = 0;
-  graphs.clear();
-}

--- a/src/content/specials.cc
+++ b/src/content/specials.cc
@@ -39,6 +39,7 @@
 #include <sys/param.h>
 #endif /* HAVE_SYS_PARAM_H */
 #include <algorithm>
+#include <functional>
 #include <sstream>
 #include "../common.h"
 #include "../conky.h"
@@ -107,6 +108,7 @@ struct graph {
   char speedgraph;  /* If the current graph is a speed graph */
   char invertflag;  /* If the axis needs to be inverted */
   int minheight;    /* Clamp values below this threshold to this threshold */
+  size_t data_hash;            /* identifies the data source for slot reuse */
   std::vector<double> history; /* pre-allocated at scan time when width known */
 };
 
@@ -260,7 +262,8 @@ static void free_graph(struct text_object *obj) {
  * @param[in]  speedGraph if graph is network speed graph or not
  * @return whether parsing was successful
  **/
-bool scan_graph(struct text_object *obj, const char *argstr, double defscale, char speedGraph) {
+bool scan_graph(struct text_object *obj, const char *argstr, double defscale,
+                char speedGraph, graph_data_key key) {
   char first_colour_name[1024] = {'\0'};
   char last_colour_name[1024] = {'\0'};
 
@@ -410,6 +413,13 @@ bool scan_graph(struct text_object *obj, const char *argstr, double defscale, ch
   sscanf(argstr, "%lf", &g->scale);
 
 done:
+  if (std::holds_alternative<std::string>(key)) {
+    g->data_hash = std::hash<std::string>{}(std::get<std::string>(key));
+  } else if (std::holds_alternative<size_t>(key)) {
+    g->data_hash = std::get<size_t>(key);
+  } else {
+    g->data_hash = reinterpret_cast<size_t>(obj);
+  }
   /* pre-allocate history at scan time when width is known to avoid
    * reallocation on first draw */
   if (g->width > 0) {
@@ -618,10 +628,9 @@ void new_graph(struct text_object *obj, char *buf, int buf_max_size,
   s->width = dpi_scale(g->width);
   if (s->width != 0) { s->graph_width = s->width; }
 
-  size_t owner = reinterpret_cast<size_t>(obj);
-  if (s->graph_owner != owner) {
+  if (s->data_hash != g->data_hash) {
     s->graph_data.clear();
-    s->graph_owner = owner;
+    s->data_hash = g->data_hash;
   }
 
   /* on first use, take the pre-allocated storage from the scan-time struct

--- a/src/content/specials.h
+++ b/src/content/specials.h
@@ -29,9 +29,14 @@
 #ifndef _SPECIALS_H
 #define _SPECIALS_H
 
+#include <string>
 #include <tuple>
+#include <variant>
 #include <vector>
 #include "colours.hh"
+
+using graph_data_key = std::variant<std::monostate, std::string, size_t>;
+inline const graph_data_key graph_parent_obj_key = std::monostate{};
 
 /* special stuff in text_buffer */
 
@@ -73,7 +78,7 @@ struct special_node {
   short width;
   double arg;
   std::vector<double> graph_data;
-  size_t graph_owner; /* address of owning text_object; detects slot reuse */
+  size_t data_hash; /* identifies the data source; detects slot reuse */
   double scale; /* maximum value */
   short show_scale;
   int graph_width;
@@ -105,7 +110,8 @@ const char *scan_gauge(struct text_object *, const char *, double);
 #ifdef BUILD_GUI
 void scan_font(struct text_object *, const char *);
 std::pair<char *, size_t> scan_command(const char *);
-bool scan_graph(struct text_object *, const char *, double, char);
+bool scan_graph(struct text_object *, const char *, double, char,
+                graph_data_key key = graph_parent_obj_key);
 void scan_tab(struct text_object *, const char *);
 void scan_stippled_hr(struct text_object *, const char *);
 

--- a/src/content/specials.h
+++ b/src/content/specials.h
@@ -30,6 +30,7 @@
 #define _SPECIALS_H
 
 #include <tuple>
+#include <vector>
 #include "colours.hh"
 
 /* special stuff in text_buffer */
@@ -71,11 +72,11 @@ struct special_node {
   short height;
   short width;
   double arg;
-  double *graph;
+  std::vector<double> graph_data;
+  size_t graph_owner; /* address of owning text_object; detects slot reuse */
   double scale; /* maximum value */
   short show_scale;
   int graph_width;
-  int graph_allocated;
   int scaled; /* auto adjust maximum */
   int scale_log;
   bool colours_set;
@@ -126,8 +127,6 @@ void new_alignr(struct text_object *, char *, unsigned int);
 void new_alignc(struct text_object *, char *, unsigned int);
 void new_goto(struct text_object *, char *, unsigned int);
 void new_tab(struct text_object *, char *, unsigned int);
-
-void clear_stored_graphs();
 
 struct special_node *new_special(char *buf, enum text_node_t t);
 

--- a/src/core.cc
+++ b/src/core.cc
@@ -376,6 +376,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
                                           void *free_at_crash) {
   // struct text_object *obj = new_text_object();
   struct text_object *obj = new_text_object_internal();
+  std::unique_ptr<text_object, decltype(&free)> obj_guard(obj, free);
 
   obj->line = line;
 
@@ -386,11 +387,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
 #define __OBJ_IF obj_be_ifblock_if(ifblock_opaque, obj)
 #define __OBJ_ARG(...)                              \
   if (!arg) {                                       \
-    auto _cmd_name = std::string(s);                \
-    free(s);                                        \
-    free(obj);                                      \
-    free(free_at_crash);                            \
-    COMMAND_ARG_ERR(_cmd_name.c_str(), __VA_ARGS__);\
+    COMMAND_ARG_ERR(s, __VA_ARGS__);                \
   }
 
 /* defines to be used below */
@@ -1059,7 +1056,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
     if (parse_top_args(s, arg, obj) != 0) {
       obj->cb_handle = create_cb_handle(update_top);
     } else {
-      free(obj);
+      obj_guard.reset();
       return nullptr;
     }
   }
@@ -1077,13 +1074,11 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END
 #endif /* __linux__ */
       OBJ_ARG(tail, nullptr, "tail needs arguments")
-          init_tailhead("tail", arg, obj, free_at_crash);
+          init_tailhead("tail", arg, obj);
   obj->callbacks.print = &print_tail;
-  obj->callbacks.free = &free_tailhead;
   END OBJ_ARG(head, nullptr, "head needs arguments")
-      init_tailhead("head", arg, obj, free_at_crash);
+      init_tailhead("head", arg, obj);
   obj->callbacks.print = &print_head;
-  obj->callbacks.free = &free_tailhead;
   END OBJ_ARG(lines, nullptr, "lines needs an argument") obj->data.s =
       STRNDUP_ARG;
   obj->callbacks.print = &print_lines;
@@ -1509,8 +1504,6 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ_IF(if_updatenr, nullptr) obj->data.i =
       arg != nullptr ? strtol(arg, nullptr, 10) : 0;
   if (obj->data.i == 0) {
-    free(obj);
-    free(free_at_crash);
     COMMAND_ARG_ERR("if_updatenr", "if_updatenr needs a number above 0 as argument");
   }
   set_updatereset(obj->data.i > get_updatereset() ? obj->data.i
@@ -1760,8 +1753,6 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   if (obj->data.i > 0) {
     ++obj->data.i;
   } else {
-    free(obj);
-    free(free_at_crash);
     COMMAND_ARG_ERR("audacious_title", "audacious_title: invalid length argument");
   }
   obj->callbacks.print = &print_audacious_title;
@@ -1819,8 +1810,6 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   if (arg != nullptr) {
     obj->data.s = STRNDUP_ARG;
   } else {
-    free(obj);
-    free(free_at_crash);
     COMMAND_ARG_ERR("lua_bar", "lua_bar needs arguments: <height>,<width> <function name> "
              "[function parameters]");
   }
@@ -1836,8 +1825,6 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   if (buf != nullptr) {
     obj->data.s = buf;
   } else {
-    free(obj);
-    free(free_at_crash);
     COMMAND_ARG_ERR("lua_graph", "lua_graph needs arguments: <function name> [height],[width] "
              "[gradient colour 1] [gradient colour 2] [scale] [-t] [-l]");
   }
@@ -1849,8 +1836,6 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   if (arg != nullptr) {
     obj->data.s = STRNDUP_ARG;
   } else {
-    free(obj);
-    free(free_at_crash);
     COMMAND_ARG_ERR("lua_gauge", "lua_gauge needs arguments: <height>,<width> <function name> "
              "[function parameters]");
   }
@@ -1905,8 +1890,6 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
                                                              obj, arg,
                                                              text_node_t::
                                                                  NONSPECIAL)) {
-    free(obj);
-    free(free_at_crash);
     COMMAND_ARG_ERR("nvidia", "nvidia: invalid argument"
              " specified: '{}'",
              arg);
@@ -1917,8 +1900,6 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
       nvidiabar, 0,
       "nvidiabar needs an argument") if (set_nvidia_query(obj, arg,
                                                           text_node_t::BAR)) {
-    free(obj);
-    free(free_at_crash);
     COMMAND_ARG_ERR("nvidiabar", "nvidiabar: invalid argument"
              " specified: '{}'",
              arg);
@@ -1930,8 +1911,6 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
       "nvidiagraph needs an argument") if (set_nvidia_query(obj, arg,
                                                             text_node_t::
                                                                 GRAPH)) {
-    free(obj);
-    free(free_at_crash);
     COMMAND_ARG_ERR("nvidiagraph", "nvidiagraph: invalid argument"
              " specified: '{}'",
              arg);
@@ -1943,8 +1922,6 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
       "nvidiagauge needs an argument") if (set_nvidia_query(obj, arg,
                                                             text_node_t::
                                                                 GAUGE)) {
-    free(obj);
-    free(free_at_crash);
     COMMAND_ARG_ERR("nvidiagauge", "nvidiagauge: invalid argument"
              " specified: '{}'",
              arg);
@@ -1957,8 +1934,6 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
       apcupsd, &update_apcupsd,
       "apcupsd needs arguments: <host> <port>") if (apcupsd_scan_arg(arg) !=
                                                     0) {
-    free(obj);
-    free(free_at_crash);
     COMMAND_ARG_ERR("apcupsd", "apcupsd needs arguments: <host> <port>");
   }
   obj->callbacks.print = &gen_print_nothing;
@@ -1995,9 +1970,8 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
 #endif /* BUILD_APCUPSD */
 #ifdef BUILD_JOURNAL
   END OBJ_ARG(journal, 0, "journal needs arguments")
-      init_journal("journal", arg, obj, free_at_crash);
+      init_journal("journal", arg, obj);
   obj->callbacks.print = &print_journal;
-  obj->callbacks.free = &free_journal;
 #endif /* BUILD_JOURNAL */
 #ifdef BUILD_PULSEAUDIO
   END OBJ_IF(if_pa_sink_muted, 0) obj->callbacks.iftest = &puau_muted;
@@ -2059,6 +2033,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
 #undef __OBJ_ARG
 #undef END
 
+  obj_guard.release();
   return obj;
 }
 
@@ -2202,9 +2177,11 @@ int extract_variable_text_internal(struct text_object *retval,
         try {
           obj = construct_text_object(buf, arg, line, &ifblock_opaque, orig_p);
         } catch (std::exception &e) {
-          const char *cmd = buf;
+          const char *cmd = nullptr;
           if (auto *ce = dynamic_cast<conky::bad_command_arguments_error *>(&e)) {
             cmd = ce->command.c_str();
+          } else {
+            cmd = buf;
           }
           LOG_ERROR("${{{}}}: {}", cmd, e.what());
           obj = new_text_object_internal();
@@ -2213,7 +2190,6 @@ int extract_variable_text_internal(struct text_object *retval,
           snprintf(fallback, text_buffer_size.get(*state), "${%s}", cmd);
           obj_be_plain_text(obj, fallback);
           free(fallback);
-          free(orig_p);
         }
         if (obj != nullptr) { append_object(retval, obj); }
         free(buf);

--- a/src/core.cc
+++ b/src/core.cc
@@ -724,7 +724,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
 #ifdef BUILD_GUI
   END OBJ(cpugraph, &update_cpu_usage) get_cpu_count();
   SCAN_CPU(arg, obj->data.i);
-  scan_graph(obj, arg, 1, FALSE);
+  scan_graph(obj, arg, 1, FALSE, fmt::format("cpu:{}", obj->data.i));
   LOG_TRACE("adding $cpugraph for CPU {}", obj->data.i);
   obj->callbacks.graphval = &cpu_barval;
   obj->callbacks.free = &free_cpu;
@@ -1234,9 +1234,9 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ(memwithbuffersbar, &update_meminfo) scan_bar(obj, arg, 1);
   obj->callbacks.barval = &mem_with_buffers_barval;
 #ifdef BUILD_GUI
-  END OBJ(memgraph, &update_meminfo) scan_graph(obj, arg, 1, FALSE);
+  END OBJ(memgraph, &update_meminfo) scan_graph(obj, arg, 1, FALSE, "mem");
   obj->callbacks.graphval = &mem_barval;
-  END OBJ(memwithbuffersgraph, &update_meminfo) scan_graph(obj, arg, 1, FALSE);
+  END OBJ(memwithbuffersgraph, &update_meminfo) scan_graph(obj, arg, 1, FALSE, "memwithbuffers");
   obj->callbacks.graphval = &mem_with_buffers_barval;
 #endif /* BUILD_GUI*/
 #ifdef HAVE_SOUNDCARD_H
@@ -1821,7 +1821,9 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
       "lua_graph needs arguments: <function name> [height],[width] [gradient "
       "colour 1] [gradient colour 2] [scale] [-t] [-l]") auto [buf, skip] =
       scan_command(arg);
-  scan_graph(obj, arg + skip, 100, FALSE);
+  scan_graph(obj, arg + skip, 100, FALSE,
+             buf != nullptr ? graph_data_key{fmt::format("lua:{}", buf)}
+                            : graph_parent_obj_key);
   if (buf != nullptr) {
     obj->data.s = buf;
   } else {
@@ -1954,7 +1956,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ(apcupsd_loadbar, &update_apcupsd) scan_bar(obj, arg, 100);
   obj->callbacks.barval = &apcupsd_loadbarval;
 #ifdef BUILD_GUI
-  END OBJ(apcupsd_loadgraph, &update_apcupsd) scan_graph(obj, arg, 100, FALSE);
+  END OBJ(apcupsd_loadgraph, &update_apcupsd) scan_graph(obj, arg, 100, FALSE, "apcupsd_load");
   obj->callbacks.graphval = &apcupsd_loadbarval;
   END OBJ(apcupsd_loadgauge, &update_apcupsd) scan_gauge(obj, arg, 100);
   obj->callbacks.gaugeval = &apcupsd_loadbarval;

--- a/src/data/exec.cc
+++ b/src/data/exec.cc
@@ -294,7 +294,9 @@ void scan_exec_arg(struct text_object *obj, const char *arg, exec_flag flags) {
     cmd = scan_gauge(obj, cmd, 100);
   } else if (flags & exec_flag::graph) {
     auto [buf, skip] = scan_command(cmd);
-    scan_graph(obj, cmd + skip, 100, FALSE);
+    scan_graph(obj, cmd + skip, 100, FALSE,
+               buf != nullptr ? graph_data_key{fmt::format("exec:{}", buf)}
+                              : graph_parent_obj_key);
     cmd = buf;
     if (cmd == nullptr) {
       LOG_ERROR("error parsing execgraph arguments: '{}'", arg ? arg : "(null)");

--- a/src/data/hardware/diskio.cc
+++ b/src/data/hardware/diskio.cc
@@ -173,9 +173,12 @@ void print_diskio_write(struct text_object *obj, char *p,
 #ifdef BUILD_GUI
 void parse_diskiograph_arg(struct text_object *obj, const char *arg) {
   auto [buf, skip] = scan_command(arg);
-  scan_graph(obj, arg + skip, 0, FALSE);
+  const char *dev = dev_name(buf);
+  scan_graph(obj, arg + skip, 0, FALSE,
+             dev != nullptr ? graph_data_key{fmt::format("diskio:{}", dev)}
+                            : graph_parent_obj_key);
 
-  obj->data.opaque = prepare_diskio_stat(dev_name(buf));
+  obj->data.opaque = prepare_diskio_stat(dev);
   free_and_zero(buf);
 }
 

--- a/src/data/hardware/nvidia.cc
+++ b/src/data/hardware/nvidia.cc
@@ -458,7 +458,10 @@ int set_nvidia_query(struct text_object *obj, const char *arg,
       break;
     case text_node_t::GRAPH: {
       auto [buf, skip] = scan_command(arg);
-      scan_graph(obj, arg + skip, 100, FALSE);
+      scan_graph(obj, arg + skip, 100, FALSE,
+                 buf != nullptr
+                     ? graph_data_key{fmt::format("nvidia:{}:{}", nvs->target_id, buf)}
+                     : graph_parent_obj_key);
       arg = buf;
     } break;
     case text_node_t::GAUGE:

--- a/src/data/ical.cc
+++ b/src/data/ical.cc
@@ -110,16 +110,10 @@ void parse_ical_args(struct text_object *obj, const char *arg,
 
   if (sscanf(arg, "%d %s", &num, filename) != 2) {
     free(filename);
-    free(obj);
-    free(free_at_crash);
-    free(free_at_crash2);
     COMMAND_ARG_ERR("ical", "wrong number of arguments for $ical");
   }
   file = fopen(filename, "r");
   if (!file) {
-    free(obj);
-    free(free_at_crash);
-    free(free_at_crash2);
     SYSTEM_ERR("can't read file '{}'", filename);
     free(filename);
     return;

--- a/src/data/iconv_tools.cc
+++ b/src/data/iconv_tools.cc
@@ -110,14 +110,10 @@ void init_iconv_start(struct text_object *obj, void *free_at_crash,
   char iconv_to[ICONV_CODEPAGE_LENGTH];
 
   if (iconv_converting) {
-    free(obj);
-    free(free_at_crash);
     COMMAND_ARG_ERR("iconv_start", "you must stop your last iconv conversion before "
              "starting another");
   }
   if (sscanf(arg, "%s %s", iconv_from, iconv_to) != 2) {
-    free(obj);
-    free(free_at_crash);
     COMMAND_ARG_ERR("iconv_start", "invalid arguments for iconv_start, expected: <from_codepage> <to_codepage>");
   } else {
     iconv_t new_iconv;

--- a/src/data/network/net_stat.cc
+++ b/src/data/network/net_stat.cc
@@ -334,7 +334,15 @@ void parse_net_stat_graph_arg(struct text_object *obj, const char *arg,
                               void *free_at_crash) {
   /* scan arguments and get interface name back */
   auto [buf, skip] = scan_command(arg);
-  scan_graph(obj, arg + skip, 0, TRUE);
+
+  graph_data_key key = graph_parent_obj_key;
+  if (buf == nullptr) {
+    key = fmt::format("net:{}", DEFAULTNETDEV);
+  } else if (strcmp("$gw_iface", buf) != 0 && strcmp("${gw_iface}", buf) != 0) {
+    key = fmt::format("net:{}", buf);
+  } /* gw_iface resolves dynamically; fall back to obj-address keying */
+
+  scan_graph(obj, arg + skip, 0, TRUE, key);
 
   // default to DEFAULTNETDEV
   if (buf != nullptr) {

--- a/src/data/network/read_tcpip.cc
+++ b/src/data/network/read_tcpip.cc
@@ -65,8 +65,6 @@ void parse_read_tcpip_arg(struct text_object *obj, const char *arg,
     strncpy(rtd->host, "localhost", 10);
   }
   if (rtd->port < 1 || rtd->port > 65535) {
-    free(obj);
-    free(free_at_crash);
     COMMAND_ARG_ERR("read_tcp/read_udp",
         "read_tcp and read_udp need a port from 1 to 65535 as argument");
   }
@@ -93,8 +91,6 @@ void parse_tcp_ping_arg(struct text_object *obj, const char *arg,
       break;
     default:  // this point should never be reached
       free(hostname);
-      free(obj);
-      free(free_at_crash);
       COMMAND_ARG_ERR("tcp_ping", "tcp_ping: failed to read arguments");
   }
   if ((he = gethostbyname(hostname)) == nullptr) {
@@ -102,8 +98,6 @@ void parse_tcp_ping_arg(struct text_object *obj, const char *arg,
              hostname);
     if ((he = gethostbyname("localhost")) == nullptr) {
       free(hostname);
-      free(obj);
-      free(free_at_crash);
       SYSTEM_ERR("tcp_ping: resolving 'localhost' also failed");
     }
   }

--- a/src/data/os/journal.cc
+++ b/src/data/os/journal.cc
@@ -44,24 +44,18 @@ struct journal {
   journal() : wanted_lines(1), flags(SD_JOURNAL_LOCAL_ONLY) {}
 };
 
-void free_journal(struct text_object *obj) {
-  journal *conf = static_cast<journal *>(obj->data.opaque);
-  obj->data.opaque = nullptr;
-  delete conf;
+static void free_journal(struct text_object *obj) {
+  delete static_cast<journal *>(obj->data.opaque);
 }
 
-void init_journal(const char *type, const char *arg, struct text_object *obj,
-                  void *free_at_crash) {
+void init_journal(const char *type, const char *arg, struct text_object *obj) {
   unsigned int argc;
-  journal *options = new journal();
+  auto options = std::make_unique<journal>();
 
   char type_arg[8] = {};
   char ignored[2] = {};
   argc = sscanf(arg, "%d %7s %1s", &options->wanted_lines, type_arg, ignored);
   if (argc > 2) {
-    free_journal(obj);
-    free(obj);
-    free(free_at_crash);
     COMMAND_ARG_ERR(type,
         "too many arguments provided; expected: [line_count=1] [type='local']");
   }
@@ -81,14 +75,12 @@ void init_journal(const char *type, const char *arg, struct text_object *obj,
     } else if (strcmp(type_arg, "user") == 0) {
       options->flags |= SD_JOURNAL_CURRENT_USER;
     } else {
-      free_journal(obj);
-      free(obj);
-      free(free_at_crash);
       COMMAND_ARG_ERR(type, "type must be one of: 'local', 'runtime', 'system', 'user'");
     }
   }
 
-  obj->data.opaque = options;
+  obj->data.opaque = options.release();
+  obj->callbacks.free = &free_journal;
 }
 
 static bool print_field(sd_journal *handle, const char *field, char spacer,

--- a/src/data/os/journal.h
+++ b/src/data/os/journal.h
@@ -30,8 +30,7 @@
 #ifndef _JOURNAL_H
 #define _JOURNAL_H
 
-void free_journal(struct text_object *);
-void init_journal(const char *, const char *, struct text_object *, void *);
+void init_journal(const char *, const char *, struct text_object *);
 void print_journal(struct text_object *, char *, unsigned int);
 
 #endif /* _JOURNAL_H */

--- a/src/data/proc.cc
+++ b/src/data/proc.cc
@@ -523,8 +523,6 @@ void scan_cmdline_to_pid_arg(struct text_object *obj, const char *arg,
     }
     if (obj->data.s[i - 1] == ' ') { obj->data.s[i - 1] = 0; }
   } else {
-    free(obj);
-    free(free_at_crash);
     COMMAND_ARG_ERR("cmdline_to_pid", "cmdline_to_pid needs an argument: ${{cmdline_to_pid commandline}}");
   }
 }

--- a/src/data/tailhead.cc
+++ b/src/data/tailhead.cc
@@ -71,16 +71,13 @@ static void tailstring(char *string, int endofstring, int wantedlines) {
   }
 }
 
-void free_tailhead(struct text_object *obj) {
-  auto *ht = static_cast<struct headtail *>(obj->data.opaque);
-  obj->data.opaque = nullptr;
-  delete ht;
+static void free_tailhead(struct text_object *obj) {
+  delete static_cast<struct headtail *>(obj->data.opaque);
 }
 
-void init_tailhead(const char *type, const char *arg, struct text_object *obj,
-                   void *free_at_crash) {
+void init_tailhead(const char *type, const char *arg, struct text_object *obj) {
   unsigned int args;
-  auto *ht = new headtail;
+  auto ht = std::make_unique<headtail>();
 
   std::unique_ptr<char[]> tmp(new char[DEFAULT_TEXT_BUFFER_SIZE]);
   memset(tmp.get(), 0, DEFAULT_TEXT_BUFFER_SIZE);
@@ -90,16 +87,10 @@ void init_tailhead(const char *type, const char *arg, struct text_object *obj,
   // XXX: Buffer overflow ?
   args = sscanf(arg, "%s %d %d", tmp.get(), &ht->wantedlines, &ht->max_uses);
   if (args < 2 || args > 3) {
-    free_tailhead(obj);
-    free(obj);
-    free(free_at_crash);
     COMMAND_ARG_ERR(type,
         "{} needs a file as 1st and a number of lines as 2nd argument", type);
   }
   if (ht->max_uses < 1) {
-    free_tailhead(obj);
-    free(obj);
-    free(free_at_crash);
     COMMAND_ARG_ERR(type, "invalid arg for {}, next_check must be larger than 0", type);
   }
   if (ht->wantedlines > 0 && ht->wantedlines <= MAX_HEADTAIL_LINES) {
@@ -107,14 +98,12 @@ void init_tailhead(const char *type, const char *arg, struct text_object *obj,
     ht->buffer = nullptr;
     ht->current_use = 0;
   } else {
-    free_tailhead(obj);
-    free(obj);
-    free(free_at_crash);
     COMMAND_ARG_ERR(type,
         "invalid arg for {}, number of lines must be between 1 and {}", type,
         MAX_HEADTAIL_LINES);
   }
-  obj->data.opaque = ht;
+  obj->data.opaque = ht.release();
+  obj->callbacks.free = &free_tailhead;
 }
 
 static void print_tailhead(const char *type, struct text_object *obj, char *p,

--- a/src/data/tailhead.h
+++ b/src/data/tailhead.h
@@ -30,8 +30,7 @@
 #ifndef _TAILHEAD_H
 #define _TAILHEAD_H
 
-void free_tailhead(struct text_object *);
-void init_tailhead(const char *, const char *, struct text_object *, void *);
+void init_tailhead(const char *, const char *, struct text_object *);
 void print_head(struct text_object *, char *, unsigned int);
 void print_tail(struct text_object *, char *, unsigned int);
 

--- a/src/lua/setting.cc
+++ b/src/lua/setting.cc
@@ -48,6 +48,7 @@ settings_map *settings;
 /// Settings that have been removed. Maps old name to an explanation message.
 const std::unordered_map<std::string, std::string> removed_settings = {
     {"own_window_argb_visual", "ARGB is now always enabled when available. Control opacity with `own_window_colour` (e.g. '#8000')."},
+    {"store_graph_data_explicitly", "Graph data is now always stored directly in the node; this setting has no effect."},
 };
 
 /*

--- a/tests/test-graph.cc
+++ b/tests/test-graph.cc
@@ -44,7 +44,6 @@ constexpr double default_width = 0;
 constexpr double default_height = 25;
 
 struct graph {
-  int id;
   char flags;
   int width, height;
   bool colours_set;
@@ -58,8 +57,16 @@ static std::pair<struct graph, bool> test_parse(const char *s) {
   bool result = scan_graph(&obj, s, default_scale,FALSE);
   auto g = static_cast<struct graph *>(obj.special_data);
   struct graph graph = *g;
-  free(g);
+  obj.callbacks.free(&obj);
   return {graph, result};
+}
+
+static void free_specials_list() {
+  while (specials != nullptr) {
+    auto *next = specials->next;
+    delete specials;
+    specials = next;
+  }
 }
 
 std::string unquote(const std::string &s) {
@@ -187,6 +194,51 @@ TEST_CASE("scan_graph correctly parses input strings") {
       auto [g, success] = test_parse("21,340 -t red blue 0.5");
       REQUIRE(g.tempgrad == true);
     }
+  }
+}
+
+TEST_CASE("graph slot reuse across draw cycles") {
+  state = std::make_unique<lua::state>();
+  conky::export_symbols(*state);
+
+  SECTION("graph data persists when same text_object reuses a slot") {
+    struct text_object obj = {};
+    scan_graph(&obj, "2,10", 0.0, FALSE);
+
+    char buf[64];
+
+    special_count = 0;
+    new_graph(&obj, buf, sizeof(buf), 1.0);
+
+    special_count = 0;
+    new_graph(&obj, buf, sizeof(buf), 2.0);
+
+    REQUIRE(specials->graph_data[0] == 2.0);
+    REQUIRE(specials->graph_data[1] == 1.0);
+
+    obj.callbacks.free(&obj);
+    free_specials_list();
+  }
+
+  SECTION("graph data is cleared when a different text_object reuses the slot") {
+    struct text_object obj1 = {}, obj2 = {};
+    scan_graph(&obj1, "2,10", 0.0, FALSE);
+    scan_graph(&obj2, "2,10", 0.0, FALSE);
+
+    char buf[64];
+
+    special_count = 0;
+    new_graph(&obj1, buf, sizeof(buf), 1.0);
+
+    special_count = 0;
+    new_graph(&obj2, buf, sizeof(buf), 2.0);
+
+    REQUIRE(specials->graph_data[0] == 2.0);
+    REQUIRE(specials->graph_data[1] == 0.0);  // cleared, not 1.0
+
+    obj1.callbacks.free(&obj1);
+    obj2.callbacks.free(&obj2);
+    free_specials_list();
   }
 }
 


### PR DESCRIPTION
This PR fixes a double-free I introduced in 28f2dcd, and fixes some other memory related quirks by switching graph data from manually (mis)managed C array to `std::vector`.

Other compilation units now don't need to manage `free_at_crash` anymore which is constructed in `core.cc`. `text_object` uses a smart pointer that's freed automatically when dropped on error paths.

Pointers are still passed around because #2347 assumes they are and it will be much easier to clean them up properly once that's done.

I did these changes under #2347 to reduce number of commits affected by introduced double free in case of a rollback. Unlikely, a bit more work now, but keeps the history easier to reason about.

I also fixed a leak in `specials.cc` that was reported in #2264. I'm not 100% it's the correct leak: it _was_ a leak and none of the other variables seemed to have been the cause so that should be _it_.

Third commit adds `graph_data_key` which allows calls to `scan_graph` to provide "construction parameters" that are used to "reattach" old graph data. `store_graph_data_explicitly` was really aiming for something like this, but the old code caused the #2264 leak which was very common (any graph leaks). New code handles the same intent correctly (in more cases) and memory is managed by standard C++ mechanisms. It still detaches old data when `text_object` index shifts, but that's more in line with [parsing cleanup goal](https://github.com/brndnmtthws/conky/issues?q=is%3Aissue%20state%3Aopen%20milestone%3A%22Parsing%20cleanup%22) and will be much easier to do once #2347 is complete.

- [x] Tested locally with address sanitizer.
- [x] Verified both edge cases described in `store_graph_data_explicitly` setting are now handled properly by default.
  - Added 2 tests for them.
- [x] Closes #2313. (initial goal)
  - Handled by stdlib now.
- [x] Closes #2264.
  - Only leak I could find. "Can't reproduce" otherwise.
- [x] Closes #2250.
  - I'm the owner of the issue.
- [x] Closes #1494 (store_graph_data_explicitly removed)