### PR TITLE
fix(core): align update schedule to wall-clock seconds

### DIFF
--- a/src/common.cc
+++ b/src/common.cc
@@ -141,6 +141,17 @@ double get_time() {
   return tv.tv_sec + (tv.tv_nsec * 1e-9);
 }
 
+/* Wall-clock (CLOCK_REALTIME) time in seconds. get_time() uses a monotonic
+ * clock for robust interval timing, but its second boundaries are offset from
+ * wall-clock seconds by an arbitrary, slowly drifting amount. Use this to
+ * align the update schedule to real-second boundaries so that displayed clocks
+ * (e.g. ${time}) tick on the wall second instead of lagging by that offset. */
+double get_realtime() {
+  struct timespec tv {};
+  clock_gettime(CLOCK_REALTIME, &tv);
+  return tv.tv_sec + (tv.tv_nsec * 1e-9);
+}
+
 #if defined(_POSIX_C_SOURCE) && !defined(__OpenBSD__) && !defined(__HAIKU__)
 std::filesystem::path to_real_path(const std::string &source) {
   wordexp_t p;

--- a/src/common.h
+++ b/src/common.h
@@ -60,6 +60,7 @@ void free_all_processes(void);
 struct process *get_first_process(void);
 void get_cpu_count(void);
 double get_time(void);
+double get_realtime(void);
 
 /// @brief Handles environment variable expansion in paths and canonicalization.
 ///

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -751,7 +751,11 @@ static void generate_text() {
   double time = get_time();
   next_update_time += ui;
   if (next_update_time < time || next_update_time > time + ui) {
-    next_update_time = time - fmod(time, ui) + ui;
+    /* Re-anchor to the next wall-clock boundary (expressed in monotonic time)
+     * so displayed clocks tick on the real second. fmod(get_realtime(), ui) is
+     * how far we are past the last wall boundary; subtract it from monotonic
+     * `time` to get that boundary, then add one interval. */
+    next_update_time = time - fmod(get_realtime(), ui) + ui;
   }
   last_update_time = current_update_time;
   total_updates++;
@@ -1853,7 +1857,10 @@ void main_loop() {
   get_system_details();
 
   last_update_time = 0.0;
-  next_update_time = get_time() - fmod(get_time(), active_update_interval());
+  /* Align the update grid to wall-clock (not monotonic) second boundaries so
+   * displayed clocks don't lag by the monotonic/realtime phase offset. This is
+   * <= now, so the first update still fires immediately. */
+  next_update_time = get_time() - fmod(get_realtime(), active_update_interval());
   info.looped = 0;
   while (terminate == 0 && (total_run_times.get(*state) == 0 ||
                             info.looped < total_run_times.get(*state))) {


### PR DESCRIPTION
## Problem

A `${time}` display can run up to ~1 second behind the real clock, and occasionally skips/repeats a second. On some machines it's barely noticeable; on others the displayed second changes almost a full second late.

## Root cause

`get_time()` uses `CLOCK_MONOTONIC` (good: robust interval timing, immune to wall-clock jumps), and the update schedule is anchored to **monotonic**-second boundaries:

```c
next_update_time = get_time() - fmod(get_time(), ui);   // monotonic grid
```

Monotonic-second boundaries are offset from **wall-clock** seconds by an arbitrary amount -- the realtime/monotonic phase difference, fixed per boot and slowly drifting as NTP slews `CLOCK_REALTIME`. So conky redraws the clock at e.g. 0.85s past each wall second, displaying the value ~0.85s late (≈ "1 second behind"), and as the offset drifts past a boundary a second is skipped.

Measured on one machine: the update consistently fired ~0.96s into each wall second (phase stable to a few ms), i.e. the displayed clock lagged real time by almost a full second.

## Fix

Add `get_realtime()` (CLOCK_REALTIME) and anchor the schedule's *phase* to wall-clock seconds while still sleeping on the monotonic clock:

```c
next_update_time = get_time() - fmod(get_realtime(), ui);   // wall-aligned phase
```

Interval timing stays monotonic (jump-robust); only the boundary phase is aligned to the real second. Displayed clocks now tick on time. Verified by sampling the rendered clock region: the visible second-change moved from ~0.96s into the wall second to on-time.

## Blast radius
- Affects only *when* periodic updates fire; no change to content or interval length.
- On platforms where `get_time()` already uses `CLOCK_REALTIME` (no `_POSIX_MONOTONIC_CLOCK`), `get_realtime() == get_time()`, so behavior is unchanged.
