### PR TITLE
Fix crash when XDG_SESSION_TYPE is empty

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1861,10 +1861,12 @@ void get_system_details() {
   }
 #endif
 
-  if (info.system.wm_name != nullptr) {
-    LOG_INFO("'{}' {} session running", info.system.wm_name, session_ty);
-  } else {
-    LOG_INFO("unknown {} session running", session_ty);
+  if (session_ty != nullptr) {
+    if (info.system.wm_name != nullptr) {
+      LOG_INFO("'{}' {} session running", info.system.wm_name, session_ty);
+    } else {
+      LOG_INFO("unknown {} session running", session_ty);
+    }
   }
 }
 


### PR DESCRIPTION
In that case `session_ty` is empty and there is an assert violation when trying to print the values a bit later.
