### PR TITLE
style: run clang-format and fix graph minheight parsing

### DIFF
--- a/lua/libcairo_imlib2_helper.h
+++ b/lua/libcairo_imlib2_helper.h
@@ -30,8 +30,8 @@
 
 #include "logging.h"
 
-void cairo_place_image(const char *file, cairo_t *cr, int x, int y,
-                       int width, int height, double alpha) {
+void cairo_place_image(const char *file, cairo_t *cr, int x, int y, int width,
+                       int height, double alpha) {
   int w, h, stride;
   Imlib_Image alpha_image, image, premul;
   cairo_surface_t *result;
@@ -82,12 +82,12 @@ void cairo_place_image(const char *file, cairo_t *cr, int x, int y,
   /* and use the alpha channel of the source image */
   imlib_image_copy_alpha_to_image(alpha_image, 0, 0);
 
-  stride = cairo_format_stride_for_width (CAIRO_FORMAT_ARGB32, width);
+  stride = cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, width);
 
   /* now pass the result to cairo */
   result = cairo_image_surface_create_for_data(
-      (unsigned char  *)imlib_image_get_data_for_reading_only(), CAIRO_FORMAT_ARGB32,
-      width, height, stride);
+      (unsigned char *)imlib_image_get_data_for_reading_only(),
+      CAIRO_FORMAT_ARGB32, width, height, stride);
 
   cairo_set_source_surface(cr, result, x, y);
   cairo_paint_with_alpha(cr, alpha);
@@ -100,7 +100,6 @@ void cairo_place_image(const char *file, cairo_t *cr, int x, int y,
   imlib_free_image();
 
   cairo_surface_destroy(result);
-
 }
 
 void cairo_draw_image(const char *file, cairo_surface_t *cs, int x, int y,

--- a/lua/libcairo_xlib.cc
+++ b/lua/libcairo_xlib.cc
@@ -6,9 +6,9 @@
  * authors to the unified conky_surface() API.
  */
 
-#include <cairo.h>
-#include <cairo-xlib.h>
 #include <X11/Xlib.h>
+#include <cairo-xlib.h>
+#include <cairo.h>
 
 #include <cstdio>
 
@@ -16,17 +16,18 @@
 
 /* ---- deprecation helper ------------------------------------------------- */
 
-#define DEPRECATION_WARNING(func)                                          \
-  do {                                                                     \
-    static bool once = false;                                              \
-    if (!once) {                                                           \
-      once = true;                                                         \
-      fprintf(stderr,                                                      \
-        "conky: WARNING: " #func " is deprecated and will be "             \
-        "removed in a future release. Use conky_surface() instead."        \
-        "See: https://github.com/brndnmtthws/conky/wiki/Lua:-Evaluation"   \
-        "\n");                                                             \
-    }                                                                      \
+#define DEPRECATION_WARNING(func)                                              \
+  do {                                                                         \
+    static bool once = false;                                                  \
+    if (!once) {                                                               \
+      once = true;                                                             \
+      fprintf(stderr,                                                          \
+              "conky: WARNING: " #func                                         \
+              " is deprecated and will be "                                    \
+              "removed in a future release. Use conky_surface() instead."      \
+              "See: https://github.com/brndnmtthws/conky/wiki/Lua:-Evaluation" \
+              "\n");                                                           \
+    }                                                                          \
   } while (0)
 
 /* ---- argument checking helpers ------------------------------------------ */
@@ -66,31 +67,30 @@ static bool check_end(lua_State *L, int idx, const char *func) {
 }
 
 /* Validate single-arg surface getters. */
-#define CHECK_SURFACE_ONLY(func)                                     \
-  if (!check_arg(L, 1, "cairo_surface_t", #func) ||                 \
-      !check_end(L, 2, #func))                                      \
-    return 0
+#define CHECK_SURFACE_ONLY(func)                                             \
+  if (!check_arg(L, 1, "cairo_surface_t", #func) || !check_end(L, 2, #func)) \
+  return 0
 
 /* ---- helpers for repetitive getter patterns ----------------------------- */
 
 /* surface -> pointer getter (Display*, Screen*, Visual*) */
-#define DEFINE_SURFACE_PTR_GETTER(cfunc, tolua_type)                \
-  static int l_##cfunc(lua_State *L) {                              \
-    DEPRECATION_WARNING(cfunc);                                     \
-    CHECK_SURFACE_ONLY(cfunc);                                      \
-    auto *s = (cairo_surface_t *)tolua_tousertype(L, 1, 0);        \
-    tolua_pushusertype(L, (void *)cfunc(s), tolua_type);            \
-    return 1;                                                       \
+#define DEFINE_SURFACE_PTR_GETTER(cfunc, tolua_type)        \
+  static int l_##cfunc(lua_State *L) {                      \
+    DEPRECATION_WARNING(cfunc);                             \
+    CHECK_SURFACE_ONLY(cfunc);                              \
+    auto *s = (cairo_surface_t *)tolua_tousertype(L, 1, 0); \
+    tolua_pushusertype(L, (void *)cfunc(s), tolua_type);    \
+    return 1;                                               \
   }
 
 /* surface -> int getter (depth, width, height) */
-#define DEFINE_SURFACE_INT_GETTER(cfunc)                            \
-  static int l_##cfunc(lua_State *L) {                              \
-    DEPRECATION_WARNING(cfunc);                                     \
-    CHECK_SURFACE_ONLY(cfunc);                                      \
-    auto *s = (cairo_surface_t *)tolua_tousertype(L, 1, 0);        \
-    tolua_pushnumber(L, (lua_Number)cfunc(s));                      \
-    return 1;                                                       \
+#define DEFINE_SURFACE_INT_GETTER(cfunc)                    \
+  static int l_##cfunc(lua_State *L) {                      \
+    DEPRECATION_WARNING(cfunc);                             \
+    CHECK_SURFACE_ONLY(cfunc);                              \
+    auto *s = (cairo_surface_t *)tolua_tousertype(L, 1, 0); \
+    tolua_pushnumber(L, (lua_Number)cfunc(s));              \
+    return 1;                                               \
   }
 
 /* ---- binding functions -------------------------------------------------- */
@@ -98,12 +98,9 @@ static bool check_end(lua_State *L, int idx, const char *func) {
 static int l_cairo_xlib_surface_create(lua_State *L) {
   const char *fn = "cairo_xlib_surface_create";
   DEPRECATION_WARNING(cairo_xlib_surface_create);
-  if (!check_arg(L, 1, "Display", fn) ||
-      !check_arg(L, 2, "Drawable", fn) ||
-      !check_arg(L, 3, "Visual", fn) ||
-      !check_num(L, 4, fn) ||
-      !check_num(L, 5, fn) ||
-      !check_end(L, 6, fn))
+  if (!check_arg(L, 1, "Display", fn) || !check_arg(L, 2, "Drawable", fn) ||
+      !check_arg(L, 3, "Visual", fn) || !check_num(L, 4, fn) ||
+      !check_num(L, 5, fn) || !check_end(L, 6, fn))
     return 0;
 
   auto *dpy = (Display *)tolua_tousertype(L, 1, 0);
@@ -111,21 +108,17 @@ static int l_cairo_xlib_surface_create(lua_State *L) {
   auto *visual = (Visual *)tolua_tousertype(L, 3, 0);
   int w = (int)tolua_tonumber(L, 4, 0);
   int h = (int)tolua_tonumber(L, 5, 0);
-  tolua_pushusertype(
-      L, cairo_xlib_surface_create(dpy, drawable, visual, w, h),
-      "cairo_surface_t");
+  tolua_pushusertype(L, cairo_xlib_surface_create(dpy, drawable, visual, w, h),
+                     "cairo_surface_t");
   return 1;
 }
 
 static int l_cairo_xlib_surface_create_for_bitmap(lua_State *L) {
   const char *fn = "cairo_xlib_surface_create_for_bitmap";
   DEPRECATION_WARNING(cairo_xlib_surface_create_for_bitmap);
-  if (!check_arg(L, 1, "Display", fn) ||
-      !check_arg(L, 2, "Pixmap", fn) ||
-      !check_arg(L, 3, "Screen", fn) ||
-      !check_num(L, 4, fn) ||
-      !check_num(L, 5, fn) ||
-      !check_end(L, 6, fn))
+  if (!check_arg(L, 1, "Display", fn) || !check_arg(L, 2, "Pixmap", fn) ||
+      !check_arg(L, 3, "Screen", fn) || !check_num(L, 4, fn) ||
+      !check_num(L, 5, fn) || !check_end(L, 6, fn))
     return 0;
 
   auto *dpy = (Display *)tolua_tousertype(L, 1, 0);
@@ -142,10 +135,8 @@ static int l_cairo_xlib_surface_create_for_bitmap(lua_State *L) {
 static int l_cairo_xlib_surface_set_size(lua_State *L) {
   const char *fn = "cairo_xlib_surface_set_size";
   DEPRECATION_WARNING(cairo_xlib_surface_set_size);
-  if (!check_arg(L, 1, "cairo_surface_t", fn) ||
-      !check_num(L, 2, fn) ||
-      !check_num(L, 3, fn) ||
-      !check_end(L, 4, fn))
+  if (!check_arg(L, 1, "cairo_surface_t", fn) || !check_num(L, 2, fn) ||
+      !check_num(L, 3, fn) || !check_end(L, 4, fn))
     return 0;
 
   auto *s = (cairo_surface_t *)tolua_tousertype(L, 1, 0);
@@ -158,10 +149,8 @@ static int l_cairo_xlib_surface_set_drawable(lua_State *L) {
   const char *fn = "cairo_xlib_surface_set_drawable";
   DEPRECATION_WARNING(cairo_xlib_surface_set_drawable);
   if (!check_arg(L, 1, "cairo_surface_t", fn) ||
-      !check_arg(L, 2, "Drawable", fn) ||
-      !check_num(L, 3, fn) ||
-      !check_num(L, 4, fn) ||
-      !check_end(L, 5, fn))
+      !check_arg(L, 2, "Drawable", fn) || !check_num(L, 3, fn) ||
+      !check_num(L, 4, fn) || !check_end(L, 5, fn))
     return 0;
 
   auto *s = (cairo_surface_t *)tolua_tousertype(L, 1, 0);

--- a/src/buffer.hh
+++ b/src/buffer.hh
@@ -1,11 +1,11 @@
 #ifndef CONKY_BUFFER_HH
 #define CONKY_BUFFER_HH
 
+#include <spdlog/fmt/fmt.h>
 #include <cstring>
 #include <memory>
 #include <string_view>
 #include <utility>
-#include <spdlog/fmt/fmt.h>
 #include "logging.h"
 
 namespace conky {
@@ -13,7 +13,8 @@ namespace conky {
 /// Bounds-checked sequential writer into a fixed-capacity char buffer.
 ///
 /// Two modes:
-///   buffer_writer w(cap);           — allocates its own buffer; use release() to
+///   buffer_writer w(cap);           — allocates its own buffer; use release()
+///   to
 ///                                  transfer ownership as a unique_ptr
 ///   buffer_writer w(cap, buf);      — writes into caller-owned buf; use
 ///                                  terminate() to null-terminate in place
@@ -90,8 +91,9 @@ class buffer_writer {
   // buffer and taking it would allow use-after-free.
   std::unique_ptr<char[]> take() {
     if (!m_owned)
-      CRIT_ERR("take() called on a non-owning buffer_writer; "
-               "the buffer belongs to the caller and cannot be transferred");
+      CRIT_ERR(
+          "take() called on a non-owning buffer_writer; "
+          "the buffer belongs to the caller and cannot be transferred");
     terminate();
     m_owned = false;
     return std::unique_ptr<char[]>(std::exchange(m_buf, nullptr));

--- a/src/common.cc
+++ b/src/common.cc
@@ -132,7 +132,7 @@ int update_uname() {
 }
 
 double get_time() {
-  struct timespec tv {};
+  struct timespec tv{};
 #ifdef _POSIX_MONOTONIC_CLOCK
   clock_gettime(CLOCK_MONOTONIC, &tv);
 #else
@@ -147,7 +147,7 @@ double get_time() {
  * align the update schedule to real-second boundaries so that displayed clocks
  * (e.g. ${time}) tick on the wall second instead of lagging by that offset. */
 double get_realtime() {
-  struct timespec tv {};
+  struct timespec tv{};
   clock_gettime(CLOCK_REALTIME, &tv);
   return tv.tv_sec + (tv.tv_nsec * 1e-9);
 }
@@ -257,7 +257,8 @@ std::string current_username() {
   const char *user = std::getenv("USER");
 
   if (!user) {
-    LOG_ERROR("can't determine current user (USER environment variable not set)");
+    LOG_ERROR(
+        "can't determine current user (USER environment variable not set)");
     return std::string();
   }
 
@@ -272,7 +273,10 @@ std::optional<std::filesystem::path> user_home(const std::string &username) {
 
   struct passwd *pw = getpwnam(username.c_str());
   if (!pw) {
-    LOG_DEBUG("can't determine HOME directory for user '{}' (neither w/ HOME nor getpwnam)", username);
+    LOG_DEBUG(
+        "can't determine HOME directory for user '{}' (neither w/ HOME nor "
+        "getpwnam)",
+        username);
     return std::nullopt;
   }
   return std::filesystem::path(pw->pw_dir);
@@ -286,7 +290,9 @@ std::string tilde_expand(const std::string &unexpanded) {
   if (unexpanded.length() == 1) {
     auto home = user_home();
     if (home->empty()) {
-      LOG_WARNING("can't expand '~' path because user_home couldn't locate home directory");
+      LOG_WARNING(
+          "can't expand '~' path because user_home couldn't locate home "
+          "directory");
       return unexpanded;
     }
     return home.value();
@@ -295,7 +301,9 @@ std::string tilde_expand(const std::string &unexpanded) {
   if (next == '/') {
     auto home = user_home();
     if (home->empty()) {
-      LOG_WARNING("can't expand '~' path because user_home couldn't locate home directory");
+      LOG_WARNING(
+          "can't expand '~' path because user_home couldn't locate home "
+          "directory");
       return unexpanded;
     }
     return home.value().string() + unexpanded.substr(1);
@@ -518,7 +526,10 @@ double loadgraphval(struct text_object *obj) {
 
 uint8_t cpu_percentage(struct text_object *obj) {
   if (static_cast<unsigned int>(obj->data.i) > info.cpu_count) {
-    USER_ERR("attempting to use more CPUs than you have (requested CPU {}, but only {} available)", obj->data.i, info.cpu_count);
+    USER_ERR(
+        "attempting to use more CPUs than you have (requested CPU {}, but only "
+        "{} available)",
+        obj->data.i, info.cpu_count);
   }
   if (info.cpu_usage != nullptr) {
     return round_to_positive_int(info.cpu_usage[obj->data.i] * 100.0);
@@ -528,7 +539,10 @@ uint8_t cpu_percentage(struct text_object *obj) {
 
 double cpu_barval(struct text_object *obj) {
   if (static_cast<unsigned int>(obj->data.i) > info.cpu_count) {
-    USER_ERR("attempting to use more CPUs than you have (requested CPU {}, but only {} available)", obj->data.i, info.cpu_count);
+    USER_ERR(
+        "attempting to use more CPUs than you have (requested CPU {}, but only "
+        "{} available)",
+        obj->data.i, info.cpu_count);
   }
   if (info.cpu_usage != nullptr) { return info.cpu_usage[obj->data.i]; }
   return 0.;
@@ -890,7 +904,8 @@ static size_t read_github_data_cb(char *data, size_t size, size_t nmemb,
           's' == *(ptr + 3) && z + 13 < sz) { /* "message": */
         if ('B' == *(ptr + 10) && 'a' == *(ptr + 11) &&
             'd' == *(ptr + 12)) { /* "Bad credentials" */
-          LOG_ERROR("github: bad credentials, generate a new token at {}", NEW_TOKEN);
+          LOG_ERROR("github: bad credentials, generate a new token at {}",
+                    NEW_TOKEN);
           snprintf(p, 80, "%s",
                    "GitHub: Bad credentials, generate a new token.");
           skip = 1U;
@@ -898,7 +913,10 @@ static size_t read_github_data_cb(char *data, size_t size, size_t nmemb,
         }
         if ('M' == *(ptr + 10) && 'i' == *(ptr + 11) &&
             's' == *(ptr + 12)) { /* Missing the 'notifications' scope. */
-          LOG_ERROR("github: missing 'notifications' scope, generate a new token at {}", NEW_TOKEN);
+          LOG_ERROR(
+              "github: missing 'notifications' scope, generate a new token at "
+              "{}",
+              NEW_TOKEN);
           snprintf(
               p, 80, "%s",
               "GitHub: Missing the notifications scope. Generate a new token.");
@@ -922,7 +940,10 @@ void print_github(struct text_object *obj, char *p, unsigned int p_max_size) {
   std::string token = github_token.get(*state);
 
   if (token.empty()) {
-    LOG_ERROR("${{github_notifications}} requires a token, generate one at {} and add github_token='TOKEN' to conky.config", NEW_TOKEN);
+    LOG_ERROR(
+        "${{github_notifications}} requires a token, generate one at {} and "
+        "add github_token='TOKEN' to conky.config",
+        NEW_TOKEN);
     snprintf(p, p_max_size, "%s",
              "GitHub notifications requires token, generate a new one.");
     return;

--- a/src/conky-imlib2.cc
+++ b/src/conky-imlib2.cc
@@ -24,9 +24,9 @@
 #include "conky-imlib2.h"
 
 #include "common.h"
-#include "output/display-output.hh"
-#include "logging.h"
 #include "content/text_object.h"
+#include "logging.h"
+#include "output/display-output.hh"
 
 #include <Imlib2.h>
 #include <climits>
@@ -127,7 +127,10 @@ void cimlib_add_image(const char *args) {
   memset(cur, 0, sizeof(struct image_list_s));
 
   if (sscanf(args, "%1023s", cur->name) == 0) {
-    LOG_ERROR("invalid args for $image, format is '<path to image> (-p x,y) (-s WxH) (-n) (-f interval)' (got '{}')", args);
+    LOG_ERROR(
+        "invalid args for $image, format is '<path to image> (-p x,y) (-s WxH) "
+        "(-n) (-f interval)' (got '{}')",
+        args);
     delete[] cur;
     return;
   }
@@ -199,7 +202,9 @@ static void cimlib_draw_image(struct image_list_s *cur, int *clip_x,
   }
   rep = 0; /* reset so disappearing images are reported */
 
-  LOG_DEBUG("drawing image '{}' at ({},{}) scaled to {}x{}, cache interval {} (no_cache {})",
+  LOG_DEBUG(
+      "drawing image '{}' at ({},{}) scaled to {}x{}, cache interval {} "
+      "(no_cache {})",
       cur->name, cur->x, cur->y, cur->w, cur->h, cur->flush_interval,
       cur->no_cache);
 

--- a/src/conky-imlib2.h
+++ b/src/conky-imlib2.h
@@ -24,8 +24,8 @@
 #ifndef _CONKY_IMBLI2_H_
 #define _CONKY_IMBLI2_H_
 
-#include "lua/setting.hh"
 #include "content/text_object.h"
+#include "lua/setting.hh"
 
 #include <array>
 

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1899,7 +1899,8 @@ void main_loop() {
   /* Align the update grid to wall-clock (not monotonic) second boundaries so
    * displayed clocks don't lag by the monotonic/realtime phase offset. This is
    * <= now, so the first update still fires immediately. */
-  next_update_time = get_time() - fmod(get_realtime(), active_update_interval());
+  next_update_time =
+      get_time() - fmod(get_realtime(), active_update_interval());
   info.looped = 0;
   while (terminate == 0 && (total_run_times.get(*state) == 0 ||
                             info.looped < total_run_times.get(*state))) {

--- a/src/conky.h
+++ b/src/conky.h
@@ -42,8 +42,8 @@
 #include <filesystem>
 #include <memory>
 
-#include "content/colours.hh"
 #include "common.h" /* at least for struct dns_data */
+#include "content/colours.hh"
 #include "lua/luamm.hh"
 
 #if defined(HAS_MCHECK_H)

--- a/src/content/algebra.cc
+++ b/src/content/algebra.cc
@@ -32,9 +32,9 @@
 #include <cstdlib>
 #include <cstring>
 #include <memory>
-#include "config.h"
 #include "../conky.h"
 #include "../logging.h"
+#include "config.h"
 
 /* find the operand in the given expression
  * returns the index of the first op character or -1 on error
@@ -44,7 +44,7 @@ int find_match_op(const char *expr) {
 
   /* if first operand is a string, skip it */
   if (expr[idx] == '"') {
-    for (idx=1; expr[idx] && expr[idx] != '"'; idx++);
+    for (idx = 1; expr[idx] && expr[idx] != '"'; idx++);
     idx++;
   }
 
@@ -199,15 +199,16 @@ int compare(const char *expr) {
   type1 = get_arg_type(expr_dup);
   type2 = get_arg_type(expr_dup + idx + 1);
   if (type1 == ARG_BAD || type2 == ARG_BAD) {
-    LOG_ERROR("bad compare arguments: '{}' and '{}'", expr_dup, (expr_dup + idx + 1));
+    LOG_ERROR("bad compare arguments: '{}' and '{}'", expr_dup,
+              (expr_dup + idx + 1));
     free(expr_dup);
     return -2;
   }
   if (type1 == ARG_LONG && type2 == ARG_DOUBLE) { type1 = ARG_DOUBLE; }
   if (type1 == ARG_DOUBLE && type2 == ARG_LONG) { type2 = ARG_DOUBLE; }
   if (type1 != type2) {
-    LOG_ERROR("cannot compare arguments '{}' and '{}' of different types", expr_dup,
-             (expr_dup + idx + 1));
+    LOG_ERROR("cannot compare arguments '{}' and '{}' of different types",
+              expr_dup, (expr_dup + idx + 1));
     free(expr_dup);
     return -2;
   }

--- a/src/content/colours.cc
+++ b/src/content/colours.cc
@@ -65,7 +65,7 @@ std::optional<Colour> parse_error(const std::string &color_str,
   snprintf(reason, len + 1, format, args...);
 
   LOG_ERROR("can't parse color '{}' (len: {}): {}", color_str,
-           color_str.length(), reason);
+            color_str.length(), reason);
   delete[] reason;
 
   return ERROR_COLOUR;
@@ -73,7 +73,7 @@ std::optional<Colour> parse_error(const std::string &color_str,
 std::optional<Colour> parse_error(const std::string &color_str,
                                   const char *reason) {
   LOG_ERROR("can't parse color '{}' (len: {}): {}", color_str,
-           color_str.length(), reason);
+            color_str.length(), reason);
   return ERROR_COLOUR;
 }
 

--- a/src/content/combine.cc
+++ b/src/content/combine.cc
@@ -68,8 +68,7 @@ void parse_combine_arg(struct text_object *obj, const char *arg) {
     COMMAND_ARG_ERR("combine", "needs arguments: <text1> <text2>");
   }
 
-  cd =
-      static_cast<struct combine_data *>(malloc(sizeof(struct combine_data)));
+  cd = static_cast<struct combine_data *>(malloc(sizeof(struct combine_data)));
   memset(cd, 0, sizeof(struct combine_data));
 
   cd->left = static_cast<char *>(malloc(endvar[0] - startvar[0] + 1));

--- a/src/content/specials.cc
+++ b/src/content/specials.cc
@@ -108,7 +108,7 @@ struct graph {
   char speedgraph;  /* If the current graph is a speed graph */
   char invertflag;  /* If the axis needs to be inverted */
   int minheight;    /* Clamp values below this threshold to this threshold */
-  size_t data_hash;            /* identifies the data source for slot reuse */
+  size_t data_hash; /* identifies the data source for slot reuse */
   std::vector<double> history; /* pre-allocated at scan time when width known */
 };
 
@@ -236,8 +236,7 @@ std::pair<char *, size_t> scan_command(const char *s) {
     return {quoted_cmd, _size + 2};
   } else {
     size_t len;
-    for (len = 0; s[len] != '\0' && !isspace(s[len]); len++)
-      ;
+    for (len = 0; s[len] != '\0' && !isspace(s[len]); len++);
     return {strndup(s, len), len};
   }
 }
@@ -254,7 +253,8 @@ static void free_graph(struct text_object *obj) {
  * -t will set the tempgrad member to true, enabling temperature gradient colors
  * -x will set the invertx flag to true, inverting the x axis
  * -y will set the invertx flag to true, inverting the y axis
- * -m will set the minheight to value, this will clamp values below the threshold to the threshold
+ * -m will set the minheight to value, this will clamp values below the
+ * threshold to the threshold
  *
  * @param[out] obj  struct in which to save width, height and other options
  * @param[in]  args argument string to parse
@@ -280,9 +280,7 @@ bool scan_graph(struct text_object *obj, const char *argstr, double defscale,
   g->tempgrad = FALSE;
   g->invertflag = FALSE;
   g->minheight = 0;
-  if (speedGraph) {
-    g->speedgraph = TRUE;
-  }
+  if (speedGraph) { g->speedgraph = TRUE; }
   if (argstr == nullptr) return false;
 
   /* set tempgrad to true if '-t' specified.
@@ -311,31 +309,32 @@ bool scan_graph(struct text_object *obj, const char *argstr, double defscale,
   }
 
   /* set MINHEIGHT to specified value if '-m' specified.
-   * It doesn't matter where the argument is exactly. 
+   * It doesn't matter where the argument is exactly.
    * Accepted values are from [0-5] */
   const char *position = strstr(argstr, " " MINHEIGHT);
-  if ((position != nullptr) ||
-      strncmp(argstr, MINHEIGHT, strlen(MINHEIGHT)) == 0) {
-      int minheight = 0;
-      position += strlen(MINHEIGHT) + 1;
-      int size = strlen(argstr);
-      // Avoid whitespaces
-      while(*position == ' ' && position < argstr + size) {
-        position++;
-      }
-      // Get the numeric value start and end position
-      const char* numStart = position;
-      while (isdigit(*position)) {
-          position++;
-      }
-      // Convert the numeric value to an integer
-      std::string numStr(numStart, position);
-      if (!numStr.empty()) {
-          minheight = atoi(numStr.c_str());
-      }
-      // If specified value is greater than the max threshold
-      minheight = minheight > 5 ? 5 : minheight;
-      g->minheight = minheight;
+  if (position != nullptr) {
+    position += 1;
+  } else if (strncmp(argstr, MINHEIGHT, strlen(MINHEIGHT)) == 0) {
+    position = argstr;
+  }
+  if (position != nullptr) {
+    int minheight = 0;
+    int size = strlen(argstr);
+    position += strlen(MINHEIGHT);
+    // Avoid whitespaces
+    while (position < argstr + size && *position == ' ') { position++; }
+    // Get the numeric value start and end position
+    const char *numStart = position;
+    while (position < argstr + size &&
+           isdigit(static_cast<unsigned char>(*position))) {
+      position++;
+    }
+    // Convert the numeric value to an integer
+    std::string numStr(numStart, position);
+    if (!numStr.empty()) { minheight = atoi(numStr.c_str()); }
+    // If specified value is greater than the max threshold
+    minheight = minheight > 5 ? 5 : minheight;
+    g->minheight = minheight;
   }
 
   /* all the following functions try to interpret the beginning of a
@@ -356,12 +355,12 @@ bool scan_graph(struct text_object *obj, const char *argstr, double defscale,
   last_colour_name[0] = '\0';
   g->scale = defscale;
 
-  /* [height],[width] [color1] [color2] 
-   * This could match as [height],[width] [scale] [-l | -t], 
+  /* [height],[width] [color1] [color2]
+   * This could match as [height],[width] [scale] [-l | -t],
    * therfore we ensure last_colour_name is not TEMPGRAD or LOGGRAPH */
   if (sscanf(argstr, "%d,%d %s %s", &g->height, &g->width, first_colour_name,
-             last_colour_name) == 4 && 
-             strchr(last_colour_name,'-') == NULL) {
+             last_colour_name) == 4 &&
+      strchr(last_colour_name, '-') == NULL) {
     apply_graph_colours(g, first_colour_name, last_colour_name);
     goto done;
   }
@@ -398,11 +397,11 @@ bool scan_graph(struct text_object *obj, const char *argstr, double defscale,
   last_colour_name[0] = '\0';
   g->scale = defscale;
 
-  /* [color1] [color2] 
-   * This could match as [scale] [-l | -t], 
+  /* [color1] [color2]
+   * This could match as [scale] [-l | -t],
    * therfore we ensure last_colour_name is not TEMPGRAD or LOGGRAPH */
   if (sscanf(argstr, "%s %s", first_colour_name, last_colour_name) == 2 &&
-             strchr(last_colour_name,'-') == NULL) { 
+      strchr(last_colour_name, '-') == NULL) {
     apply_graph_colours(g, first_colour_name, last_colour_name);
     goto done;
   }
@@ -422,9 +421,7 @@ done:
   }
   /* pre-allocate history at scan time when width is known to avoid
    * reallocation on first draw */
-  if (g->width > 0) {
-    g->history.resize(dpi_scale(g->width), 0.0);
-  }
+  if (g->width > 0) { g->history.resize(dpi_scale(g->width), 0.0); }
   return true;
 }
 #endif /* BUILD_GUI */
@@ -433,9 +430,7 @@ done:
  * Printing various special text objects
  */
 
-struct special_node *new_special_t_node() {
-  return new special_node{};
-}
+struct special_node *new_special_t_node() { return new special_node{}; }
 
 /**
  * expands the current global linked list specials to special_count elements
@@ -558,20 +553,21 @@ static void graph_append(struct special_node *graph, double f, char showaslog) {
   graph->graph_data[0] = f; /* add new data */
 
   if (graph->scaled != 0) {
-    double* currentmax = std::max_element(
-        graph->graph_data.data(), graph->graph_data.data() + graph->graph_data.size());
+    double *currentmax =
+        std::max_element(graph->graph_data.data(),
+                         graph->graph_data.data() + graph->graph_data.size());
     graph->scale = *currentmax;
     if (graph->speedgraph) {
-        if(maxspeedval < graph->scale){
-          maxspeedval = graph->scale;
-        }
-        graph->scale = maxspeedval;
-        /* If the currentmax is the maxspeedval and 
-         * currentmax location is at the last position
-         * Then we reset our maxspeedval */
-        if(*currentmax == maxspeedval && currentmax == (graph->graph_data.data() + graph->graph_data.size() - 1)) {
-          maxspeedval = 1e-47;
-        }
+      if (maxspeedval < graph->scale) { maxspeedval = graph->scale; }
+      graph->scale = maxspeedval;
+      /* If the currentmax is the maxspeedval and
+       * currentmax location is at the last position
+       * Then we reset our maxspeedval */
+      if (*currentmax == maxspeedval &&
+          currentmax ==
+              (graph->graph_data.data() + graph->graph_data.size() - 1)) {
+        maxspeedval = 1e-47;
+      }
     }
     if (graph->scale < 1e-47) {
       /* avoid NaN's when the graph is all-zero (e.g. before the first update)
@@ -660,15 +656,9 @@ void new_graph(struct text_object *obj, char *buf, int buf_max_size,
     s->scale = log10(s->scale + 1);
   }
 #endif
-  if ((g->invertflag & SF_INVERTX) != 0){
-    s->invertx = 1;
-  }
-  if ((g->invertflag & SF_INVERTY) != 0){
-    s->inverty = 1;
-  }
-  if (g->speedgraph) {
-    s->speedgraph = TRUE;
-  }
+  if ((g->invertflag & SF_INVERTX) != 0) { s->invertx = 1; }
+  if ((g->invertflag & SF_INVERTY) != 0) { s->inverty = 1; }
+  if (g->speedgraph) { s->speedgraph = TRUE; }
 
   graph_append(s, val, g->flags);
 
@@ -874,4 +864,3 @@ void new_tab(struct text_object *obj, char *p, unsigned int p_max_size) {
   s->width = dpi_scale(t->width);
   s->arg = dpi_scale(t->arg);
 }
-

--- a/src/content/specials.h
+++ b/src/content/specials.h
@@ -79,7 +79,7 @@ struct special_node {
   double arg;
   std::vector<double> graph_data;
   size_t data_hash; /* identifies the data source; detects slot reuse */
-  double scale; /* maximum value */
+  double scale;     /* maximum value */
   short show_scale;
   int graph_width;
   int scaled; /* auto adjust maximum */

--- a/src/content/temphelper.cc
+++ b/src/content/temphelper.cc
@@ -26,8 +26,8 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include "config.h"
 #include "../conky.h"
+#include "config.h"
 
 template <>
 conky::lua_traits<TEMP_UNIT>::Map conky::lua_traits<TEMP_UNIT>::map = {

--- a/src/content/template.cc
+++ b/src/content/template.cc
@@ -231,7 +231,8 @@ char *find_and_replace_templates(const char *inbuf) {
       free(tmpl_out);
       o = outbuf + strlen(outbuf);
     } else {
-      LOG_ERROR("failed to handle template '{}' with args '{}'", templ, args ? args : "(none)");
+      LOG_ERROR("failed to handle template '{}' with args '{}'", templ,
+                args ? args : "(none)");
     }
   }
   *o = '\0';

--- a/src/content/text_object.cc
+++ b/src/content/text_object.cc
@@ -29,9 +29,9 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include "config.h"
 #include "../conky.h"
 #include "../logging.h"
+#include "config.h"
 
 void gen_free_opaque(struct text_object *obj) {
   free_and_zero(obj->data.opaque);
@@ -72,7 +72,9 @@ int append_object(struct text_object *root, struct text_object *obj) {
 
   /* update pointers of the list to append to */
   if (end != nullptr) {
-    if (end->next != nullptr) { CRIT_ERR("text_object list leak: non-null end->next reassigned"); }
+    if (end->next != nullptr) {
+      CRIT_ERR("text_object list leak: non-null end->next reassigned");
+    }
     end->next = obj;
   } else {
     root->next = obj;

--- a/src/core.cc
+++ b/src/core.cc
@@ -34,7 +34,6 @@
 #include "core.h"
 
 #include "build.h"
-#include "lua/colour-settings.hh"
 #include "content/colours.hh"
 #include "content/combine.h"
 #include "content/text_object.h"
@@ -45,6 +44,7 @@
 #include "data/hardware/i8k.h"
 #include "data/misc.h"
 #include "data/proc.h"
+#include "lua/colour-settings.hh"
 #ifdef BUILD_IMLIB2
 #include "conky-imlib2.h"
 #endif /* BUILD_IMLIB2 */
@@ -174,7 +174,8 @@ void stock_parse_arg(struct text_object *obj, const char *arg) {
 
   obj->data.s = nullptr;
   if (sscanf(arg, "%7s %15s", stock, data) != 2) {
-    LOG_ERROR("wrong number of arguments for $stock (got '{}')", arg ? arg : "(null)");
+    LOG_ERROR("wrong number of arguments for $stock (got '{}')",
+              arg ? arg : "(null)");
     return;
   }
   if (!strcasecmp("ask", data)) {
@@ -342,7 +343,8 @@ void stock_parse_arg(struct text_object *obj, const char *arg) {
   } else if (!strcasecmp("dy", data)) {
     strncpy(data, "y", 3);
   } else {
-    LOG_ERROR("\"{}\" is not supported by $stock. supported: 1ytp, 200ma, 50ma, "
+    LOG_ERROR(
+        "\"{}\" is not supported by $stock. supported: 1ytp, 200ma, 50ma, "
         "52weeklow, 52weekhigh, 52weekrange, adv, ag, ahcrt, ask, askrt, "
         "asksize, bid, bidrt, bidsize, bookvalue, c200ma, c50ma, c52whigh, "
         "c52wlow, change, changert, cip, commission, cprt, dayshigh, dayslow, "
@@ -385,10 +387,8 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   if (!strcmp(s, #a)) {  \
     obj->cb_handle = create_cb_handle(n);
 #define __OBJ_IF obj_be_ifblock_if(ifblock_opaque, obj)
-#define __OBJ_ARG(...)                              \
-  if (!arg) {                                       \
-    COMMAND_ARG_ERR(s, __VA_ARGS__);                \
-  }
+#define __OBJ_ARG(...) \
+  if (!arg) { COMMAND_ARG_ERR(s, __VA_ARGS__); }
 
 /* defines to be used below */
 #define OBJ(a, n) __OBJ_HEAD(a, n) {
@@ -433,13 +433,14 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   obj->callbacks.free = &gen_free_opaque;
   END
 #endif /* !__OpenBSD__ */
-  OBJ(freq, nullptr) get_cpu_count();
+      OBJ(freq, nullptr) get_cpu_count();
   if ((arg == nullptr) || strlen(arg) >= 3 ||
       strtol(&arg[0], nullptr, 10) == 0 ||
       static_cast<unsigned int>(strtol(&arg[0], nullptr, 10)) >
           info.cpu_count) {
     obj->data.i = 1;
-    LOG_WARNING("invalid CPU number '{}', falling back to CPU 1", arg ? arg : "(null)");
+    LOG_WARNING("invalid CPU number '{}', falling back to CPU 1",
+                arg ? arg : "(null)");
   } else {
     obj->data.i = strtol(&arg[0], nullptr, 10);
   }
@@ -450,7 +451,8 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
       static_cast<unsigned int>(strtol(&arg[0], nullptr, 10)) >
           info.cpu_count) {
     obj->data.i = 1;
-    LOG_WARNING("invalid CPU number '{}', falling back to CPU 1", arg ? arg : "(null)");
+    LOG_WARNING("invalid CPU number '{}', falling back to CPU 1",
+                arg ? arg : "(null)");
   } else {
     obj->data.i = strtol(&arg[0], nullptr, 10);
   }
@@ -462,7 +464,8 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
       static_cast<unsigned int>(strtol(&arg[0], nullptr, 10)) >
           info.cpu_count) {
     obj->data.i = 1;
-    LOG_WARNING("invalid CPU number '{}', falling back to CPU 1", arg ? arg : "(null)");
+    LOG_WARNING("invalid CPU number '{}', falling back to CPU 1",
+                arg ? arg : "(null)");
   } else {
     obj->data.i = strtol(&arg[0], nullptr, 10);
   }
@@ -488,7 +491,8 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   if (!arg || strlen(arg) >= 3 || strtol(&arg[0], nullptr, 10) == 0 ||
       (unsigned int)strtol(&arg[0], nullptr, 10) > info.cpu_count) {
     obj->data.i = 1;
-    LOG_WARNING("invalid CPU number '{}', falling back to CPU 1", arg ? arg : "(null)");
+    LOG_WARNING("invalid CPU number '{}', falling back to CPU 1",
+                arg ? arg : "(null)");
   } else {
     obj->data.i = strtol(&arg[0], nullptr, 10);
   }
@@ -497,7 +501,8 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   if (!arg || strlen(arg) >= 3 || strtol(&arg[0], nullptr, 10) == 0 ||
       (unsigned int)strtol(&arg[0], nullptr, 10) > info.cpu_count) {
     obj->data.i = 1;
-    LOG_WARNING("invalid CPU number '{}', falling back to CPU 1", arg ? arg : "(null)");
+    LOG_WARNING("invalid CPU number '{}', falling back to CPU 1",
+                arg ? arg : "(null)");
   } else {
     obj->data.i = strtol(&arg[0], nullptr, 10);
   }
@@ -1236,7 +1241,8 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
 #ifdef BUILD_GUI
   END OBJ(memgraph, &update_meminfo) scan_graph(obj, arg, 1, FALSE, "mem");
   obj->callbacks.graphval = &mem_barval;
-  END OBJ(memwithbuffersgraph, &update_meminfo) scan_graph(obj, arg, 1, FALSE, "memwithbuffers");
+  END OBJ(memwithbuffersgraph, &update_meminfo)
+      scan_graph(obj, arg, 1, FALSE, "memwithbuffers");
   obj->callbacks.graphval = &mem_with_buffers_barval;
 #endif /* BUILD_GUI*/
 #ifdef HAVE_SOUNDCARD_H
@@ -1504,7 +1510,8 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ_IF(if_updatenr, nullptr) obj->data.i =
       arg != nullptr ? strtol(arg, nullptr, 10) : 0;
   if (obj->data.i == 0) {
-    COMMAND_ARG_ERR("if_updatenr", "if_updatenr needs a number above 0 as argument");
+    COMMAND_ARG_ERR("if_updatenr",
+                    "if_updatenr needs a number above 0 as argument");
   }
   set_updatereset(obj->data.i > get_updatereset() ? obj->data.i
                                                   : get_updatereset());
@@ -1595,20 +1602,21 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   obj->callbacks.free = &gen_free_opaque;
   END OBJ_ARG(smapi_bat_bar, 0, "smapi_bat_bar needs an argument") int cnt;
   if (sscanf(arg, "%i %n", &obj->data.i, &cnt) <= 0) {
-    LOG_ERROR("first argument to smapi_bat_bar must be an integer (got '{}')", arg ? arg : "(null)");
+    LOG_ERROR("first argument to smapi_bat_bar must be an integer (got '{}')",
+              arg ? arg : "(null)");
     obj->data.i = -1;
   } else
     arg = scan_bar(obj, arg + cnt, 100);
   obj->callbacks.barval = &smapi_bat_barval;
 #endif /* BUILD_IBM */
 #ifdef BUILD_MPD
-#define mpd_set_maxlen(name)                       \
-  if (arg) {                                       \
-    int i;                                         \
-    sscanf(arg, "%d", &i);                         \
-    if (i > 0)                                     \
-      obj->data.i = i + 1;                         \
-    else                                           \
+#define mpd_set_maxlen(name)                        \
+  if (arg) {                                        \
+    int i;                                          \
+    sscanf(arg, "%d", &i);                          \
+    if (i > 0)                                      \
+      obj->data.i = i + 1;                          \
+    else                                            \
       LOG_ERROR(#name ": invalid length argument"); \
   }
   END OBJ(mpd_artist, nullptr) mpd_set_maxlen(mpd_artist);
@@ -1753,7 +1761,8 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   if (obj->data.i > 0) {
     ++obj->data.i;
   } else {
-    COMMAND_ARG_ERR("audacious_title", "audacious_title: invalid length argument");
+    COMMAND_ARG_ERR("audacious_title",
+                    "audacious_title: invalid length argument");
   }
   obj->callbacks.print = &print_audacious_title;
   END OBJ(audacious_length, 0) obj->callbacks.print = &print_audacious_length;
@@ -1810,8 +1819,9 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   if (arg != nullptr) {
     obj->data.s = STRNDUP_ARG;
   } else {
-    COMMAND_ARG_ERR("lua_bar", "lua_bar needs arguments: <height>,<width> <function name> "
-             "[function parameters]");
+    COMMAND_ARG_ERR("lua_bar",
+                    "lua_bar needs arguments: <height>,<width> <function name> "
+                    "[function parameters]");
   }
   obj->callbacks.barval = &lua_barval;
   obj->callbacks.free = &gen_free_opaque;
@@ -1827,8 +1837,10 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   if (buf != nullptr) {
     obj->data.s = buf;
   } else {
-    COMMAND_ARG_ERR("lua_graph", "lua_graph needs arguments: <function name> [height],[width] "
-             "[gradient colour 1] [gradient colour 2] [scale] [-t] [-l]");
+    COMMAND_ARG_ERR(
+        "lua_graph",
+        "lua_graph needs arguments: <function name> [height],[width] "
+        "[gradient colour 1] [gradient colour 2] [scale] [-t] [-l]");
   }
   obj->callbacks.graphval = &lua_barval;
   obj->callbacks.free = &gen_free_opaque;
@@ -1838,8 +1850,10 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   if (arg != nullptr) {
     obj->data.s = STRNDUP_ARG;
   } else {
-    COMMAND_ARG_ERR("lua_gauge", "lua_gauge needs arguments: <height>,<width> <function name> "
-             "[function parameters]");
+    COMMAND_ARG_ERR(
+        "lua_gauge",
+        "lua_gauge needs arguments: <height>,<width> <function name> "
+        "[function parameters]");
   }
   obj->callbacks.gaugeval = &lua_barval;
   obj->callbacks.free = &gen_free_opaque;
@@ -1883,8 +1897,7 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
       parse_scroll_arg(obj, arg, free_at_crash, s);
   obj->callbacks.print = &print_scroll;
   obj->callbacks.free = &free_scroll;
-  END OBJ(combine, nullptr)
-    parse_combine_arg(obj, arg);
+  END OBJ(combine, nullptr) parse_combine_arg(obj, arg);
   obj->callbacks.print = &print_combine;
   obj->callbacks.free = &free_combine;
 #ifdef BUILD_NVIDIA
@@ -1892,9 +1905,10 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
                                                              obj, arg,
                                                              text_node_t::
                                                                  NONSPECIAL)) {
-    COMMAND_ARG_ERR("nvidia", "nvidia: invalid argument"
-             " specified: '{}'",
-             arg);
+    COMMAND_ARG_ERR("nvidia",
+                    "nvidia: invalid argument"
+                    " specified: '{}'",
+                    arg);
   }
   obj->callbacks.print = &print_nvidia_value;
   obj->callbacks.free = &free_nvidia;
@@ -1902,9 +1916,10 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
       nvidiabar, 0,
       "nvidiabar needs an argument") if (set_nvidia_query(obj, arg,
                                                           text_node_t::BAR)) {
-    COMMAND_ARG_ERR("nvidiabar", "nvidiabar: invalid argument"
-             " specified: '{}'",
-             arg);
+    COMMAND_ARG_ERR("nvidiabar",
+                    "nvidiabar: invalid argument"
+                    " specified: '{}'",
+                    arg);
   }
   obj->callbacks.barval = &get_nvidia_barval;
   obj->callbacks.free = &free_nvidia;
@@ -1913,9 +1928,10 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
       "nvidiagraph needs an argument") if (set_nvidia_query(obj, arg,
                                                             text_node_t::
                                                                 GRAPH)) {
-    COMMAND_ARG_ERR("nvidiagraph", "nvidiagraph: invalid argument"
-             " specified: '{}'",
-             arg);
+    COMMAND_ARG_ERR("nvidiagraph",
+                    "nvidiagraph: invalid argument"
+                    " specified: '{}'",
+                    arg);
   }
   obj->callbacks.graphval = &get_nvidia_barval;
   obj->callbacks.free = &free_nvidia;
@@ -1924,9 +1940,10 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
       "nvidiagauge needs an argument") if (set_nvidia_query(obj, arg,
                                                             text_node_t::
                                                                 GAUGE)) {
-    COMMAND_ARG_ERR("nvidiagauge", "nvidiagauge: invalid argument"
-             " specified: '{}'",
-             arg);
+    COMMAND_ARG_ERR("nvidiagauge",
+                    "nvidiagauge: invalid argument"
+                    " specified: '{}'",
+                    arg);
   }
   obj->callbacks.gaugeval = &get_nvidia_barval;
   obj->callbacks.free = &free_nvidia;
@@ -1956,7 +1973,8 @@ struct text_object *construct_text_object(char *s, const char *arg, long line,
   END OBJ(apcupsd_loadbar, &update_apcupsd) scan_bar(obj, arg, 100);
   obj->callbacks.barval = &apcupsd_loadbarval;
 #ifdef BUILD_GUI
-  END OBJ(apcupsd_loadgraph, &update_apcupsd) scan_graph(obj, arg, 100, FALSE, "apcupsd_load");
+  END OBJ(apcupsd_loadgraph, &update_apcupsd)
+      scan_graph(obj, arg, 100, FALSE, "apcupsd_load");
   obj->callbacks.graphval = &apcupsd_loadbarval;
   END OBJ(apcupsd_loadgauge, &update_apcupsd) scan_gauge(obj, arg, 100);
   obj->callbacks.gaugeval = &apcupsd_loadbarval;
@@ -2092,7 +2110,7 @@ int extract_variable_text_internal(struct text_object *retval,
 
   if (static_cast<int>(strcmp(p, const_p) != 0) != 0) {
     LOG_TRACE("replaced all templates in text: input is\n'{}'\noutput is\n'{}'",
-          const_p, p);
+              const_p, p);
   } else {
     LOG_TRACE("no templates to replace");
   }
@@ -2180,15 +2198,16 @@ int extract_variable_text_internal(struct text_object *retval,
           obj = construct_text_object(buf, arg, line, &ifblock_opaque, orig_p);
         } catch (std::exception &e) {
           const char *cmd = nullptr;
-          if (auto *ce = dynamic_cast<conky::bad_command_arguments_error *>(&e)) {
+          if (auto *ce =
+                  dynamic_cast<conky::bad_command_arguments_error *>(&e)) {
             cmd = ce->command.c_str();
           } else {
             cmd = buf;
           }
           LOG_ERROR("${{{}}}: {}", cmd, e.what());
           obj = new_text_object_internal();
-          auto *fallback = static_cast<char *>(
-              malloc(text_buffer_size.get(*state)));
+          auto *fallback =
+              static_cast<char *>(malloc(text_buffer_size.get(*state)));
           snprintf(fallback, text_buffer_size.get(*state), "${%s}", cmd);
           obj_be_plain_text(obj, fallback);
           free(fallback);

--- a/src/data/audio/audacious.cc
+++ b/src/data/audio/audacious.cc
@@ -26,10 +26,10 @@
 #include <cmath>
 
 #include <mutex>
-#include "audacious.h"
 #include "../../conky.h"
 #include "../../logging.h"
 #include "../../update-cb.hh"
+#include "audacious.h"
 
 #include <glib.h>
 #ifdef NEW_AUDACIOUS_FOUND
@@ -101,9 +101,7 @@ class audacious_cb : public conky::callback<aud_result> {
   audacious_cb(uint32_t period) : Base(period, false, Tuple()) {
 #ifdef NEW_AUDACIOUS_FOUND
     DBusGConnection *connection = dbus_g_bus_get(DBUS_BUS_SESSION, nullptr);
-    if (!connection) {
-      SYSTEM_ERR("can't connect to D-Bus session bus");
-    }
+    if (!connection) { SYSTEM_ERR("can't connect to D-Bus session bus"); }
 
     session = dbus_g_proxy_new_for_name(connection, AUDACIOUS_DBUS_SERVICE,
                                         AUDACIOUS_DBUS_PATH,
@@ -214,8 +212,7 @@ void print_audacious_title(struct text_object *obj, char *p,
 
 void print_audacious_filename(struct text_object *obj, char *p,
                               unsigned int p_max_size) {
-  snprintf(p, p_max_size, "%s",
-           get_res().filename.c_str());
+  snprintf(p, p_max_size, "%s", get_res().filename.c_str());
 }
 
 double audacious_barval(struct text_object *) {

--- a/src/data/audio/cmus.cc
+++ b/src/data/audio/cmus.cc
@@ -21,8 +21,8 @@
  */
 
 #include "../../conky.h"
-#include "../../logging.h"
 #include "../../content/text_object.h"
+#include "../../logging.h"
 
 #include <math.h>
 #include <stdio.h>

--- a/src/data/audio/libmpdclient.cc
+++ b/src/data/audio/libmpdclient.cc
@@ -129,7 +129,7 @@ static int do_connect_fail(mpd_Connection *connection,
 
 static int uds_connect(mpd_Connection *connection, const char *host,
                        float timeout) {
-  struct sockaddr_un addr {};
+  struct sockaddr_un addr{};
 
   strncpy(addr.sun_path, host, sizeof(addr.sun_path) - 1);
   addr.sun_family = AF_UNIX;
@@ -164,7 +164,7 @@ static int mpd_connect(mpd_Connection *connection, const char *host, int port,
                        float timeout) {
   int error;
   char service[INTLEN + 1];
-  struct addrinfo hints {};
+  struct addrinfo hints{};
   struct addrinfo *res = nullptr;
   struct addrinfo *addrinfo = nullptr;
 
@@ -384,7 +384,7 @@ mpd_Connection *mpd_newConnection(const char *host, int port, float timeout) {
   char *output = nullptr;
   auto *connection =
       static_cast<mpd_Connection *>(malloc(sizeof(mpd_Connection)));
-  struct timeval tv {};
+  struct timeval tv{};
   fd_set fds;
 
   strncpy(connection->buffer, "", 1);
@@ -472,7 +472,7 @@ void mpd_closeConnection(mpd_Connection *connection) {
 static void mpd_executeCommand(mpd_Connection *connection,
                                const char *command) {
   int ret;
-  struct timeval tv {};
+  struct timeval tv{};
   fd_set fds;
   const char *commandPtr = command;
   int commandLen = strlen(command);
@@ -528,7 +528,7 @@ static void mpd_getNextReturnElement(mpd_Connection *connection) {
   char *name = nullptr;
   char *value = nullptr;
   fd_set fds;
-  struct timeval tv {};
+  struct timeval tv{};
   char *tok = nullptr;
   int readed;
   char *bufferCheck = nullptr;

--- a/src/data/audio/mixer.cc
+++ b/src/data/audio/mixer.cc
@@ -32,9 +32,9 @@
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include "../../conky.h"
-#include "../../logging.h"
 #include "../../content/specials.h"
 #include "../../content/text_object.h"
+#include "../../logging.h"
 
 #ifdef HAVE_SOUNDCARD_H
 #if defined(__linux__)

--- a/src/data/audio/moc.cc
+++ b/src/data/audio/moc.cc
@@ -21,8 +21,8 @@
  */
 
 #include "../../conky.h"
-#include "../../logging.h"
 #include "../../content/text_object.h"
+#include "../../logging.h"
 
 #include <cmath>
 #include <cstdio>
@@ -164,18 +164,17 @@ MOC_PRINT_GENERATOR(rate, "0kHz")
 
 #undef MOC_PRINT_GENERATOR
 
-double moc_barval(struct text_object * obj) {
+double moc_barval(struct text_object *obj) {
   (void)obj;
   uint32_t period = std::max(
-      lround(music_player_interval.get(*state) / active_update_interval()),
-      1l);
+      lround(music_player_interval.get(*state) / active_update_interval()), 1l);
   const moc_result &moc = conky::register_cb<moc_cb>(period)->get_result_copy();
   double progress;
 
   int totalsec = atoi(moc.totalsec.c_str());
   int cursec = atoi(moc.cursec.c_str());
 
-  if(totalsec == 0) {
+  if (totalsec == 0) {
     progress = 0.0;
   } else {
     progress = ((double)cursec) / ((double)totalsec);
@@ -184,6 +183,6 @@ double moc_barval(struct text_object * obj) {
   return progress;
 }
 
-uint8_t moc_percentage(struct text_object *obj){
+uint8_t moc_percentage(struct text_object *obj) {
   return round_to_positive_int(100.0f * moc_barval(obj));
 }

--- a/src/data/audio/mpd.cc
+++ b/src/data/audio/mpd.cc
@@ -30,10 +30,10 @@
 #include <cmath>
 #include <mutex>
 #include "../../conky.h"
-#include "libmpdclient.h"
 #include "../../logging.h"
-#include "../timeinfo.h"
 #include "../../update-cb.hh"
+#include "../timeinfo.h"
+#include "libmpdclient.h"
 
 namespace {
 

--- a/src/data/audio/pulseaudio.cc
+++ b/src/data/audio/pulseaudio.cc
@@ -31,12 +31,12 @@
 #include <math.h>
 #include <unistd.h>
 #include "../../common.h"
-#include "config.h"
 #include "../../conky.h"
-#include "../../core.h"
-#include "../../logging.h"
 #include "../../content/specials.h"
 #include "../../content/text_object.h"
+#include "../../core.h"
+#include "../../logging.h"
+#include "config.h"
 
 struct pulseaudio_default_results get_result_copy();
 

--- a/src/data/audio/pulseaudio.h
+++ b/src/data/audio/pulseaudio.h
@@ -96,7 +96,7 @@ class pulseaudio_c {
         ninits(0),
         result({std::string(), std::string(), std::string(), std::string(), 0,
                 0, 0, 0, std::string(), PA_SOURCE_SUSPENDED, 0, std::string(),
-                std::string(), 0}){};
+                std::string(), 0}) {};
 };
 
 #endif /* _PULSEAUDIO_H */

--- a/src/data/audio/xmms2.cc
+++ b/src/data/audio/xmms2.cc
@@ -309,7 +309,8 @@ int update_xmms2(void) {
     char *path = getenv("XMMS_PATH");
 
     if (!xmmsc_connect(xmms2_conn, path)) {
-      LOG_ERROR("xmms2 connection failed. {}", xmmsc_get_last_error(xmms2_conn));
+      LOG_ERROR("xmms2 connection failed. {}",
+                xmmsc_get_last_error(xmms2_conn));
       current_info->xmms2.conn_state = CONN_NO;
       return 0;
     }

--- a/src/data/data-source.cc
+++ b/src/data/data-source.cc
@@ -22,8 +22,8 @@
 
 #include <config.h>
 
-#include "data-source.hh"
 #include "../logging.h"
+#include "data-source.hh"
 
 #include <iostream>
 #include <sstream>
@@ -99,9 +99,7 @@ void do_register_data_source(const std::string &name,
   static data_source_constructor constructor;
 
   bool inserted = data_sources->insert({name, fn}).second;
-  if (!inserted) {
-    CRIT_ERR("data source '{}' already registered", name);
-  }
+  if (!inserted) { CRIT_ERR("data source '{}' already registered", name); }
 }
 
 disabled_data_source::disabled_data_source(lua::state *l,

--- a/src/data/entropy.cc
+++ b/src/data/entropy.cc
@@ -29,10 +29,10 @@
 
 #include <inttypes.h>
 #include <time.h>
-#include "config.h"
 #include "../conky.h"
-#include "../logging.h"
 #include "../content/text_object.h"
+#include "../logging.h"
+#include "config.h"
 
 /* check for OS and include appropriate headers */
 #if defined(__linux__)

--- a/src/data/exec.cc
+++ b/src/data/exec.cc
@@ -28,20 +28,20 @@
  */
 
 #include "exec.h"
-#include <cerrno>
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <cerrno>
 #include <cmath>
 #include <cstdio>
 #include <mutex>
 #include <string>
 #include "../conky.h"
-#include "../core.h"
-#include "../logging.h"
 #include "../content/specials.h"
 #include "../content/text_object.h"
+#include "../core.h"
+#include "../logging.h"
 #include "../update-cb.hh"
 
 struct exec_data {
@@ -122,7 +122,9 @@ static FILE *pid_popen(const char *command, const char *mode, pid_t *child) {
     close(parentend);
 
     // by dupping childend, the returned fd will have close-on-exec turned off
-    if (fcntl(childend, F_DUPFD, 0) == -1) { LOG_ERROR("failed to dup child fd: {}", strerror(errno)); }
+    if (fcntl(childend, F_DUPFD, 0) == -1) {
+      LOG_ERROR("failed to dup child fd: {}", strerror(errno));
+    }
     close(childend);
 
     execl("/bin/sh", "sh", "-c", remove_excess_quotes(command),
@@ -299,7 +301,8 @@ void scan_exec_arg(struct text_object *obj, const char *arg, exec_flag flags) {
                               : graph_parent_obj_key);
     cmd = buf;
     if (cmd == nullptr) {
-      LOG_ERROR("error parsing execgraph arguments: '{}'", arg ? arg : "(null)");
+      LOG_ERROR("error parsing execgraph arguments: '{}'",
+                arg ? arg : "(null)");
     }
 #endif /* BUILD_GUI */
   }

--- a/src/data/exec.h
+++ b/src/data/exec.h
@@ -75,7 +75,7 @@ enum class exec_flag : unsigned int {
 
 inline exec_flag operator|(exec_flag a, exec_flag b) {
   return static_cast<exec_flag>(static_cast<unsigned>(a) |
-                                    static_cast<unsigned>(b));
+                                static_cast<unsigned>(b));
 }
 
 inline bool operator&(exec_flag a, exec_flag b) {

--- a/src/data/fs.cc
+++ b/src/data/fs.cc
@@ -34,9 +34,9 @@
 #include <cctype>
 #include <cerrno>
 #include "../conky.h"
-#include "../logging.h"
 #include "../content/specials.h"
 #include "../content/text_object.h"
+#include "../logging.h"
 
 #ifdef HAVE_SYS_STATFS_H
 #include <sys/statfs.h>
@@ -63,7 +63,7 @@
 
 #if !defined(HAVE_STRUCT_STATFS_F_FSTYPENAME) && !defined(__OpenBSD__) &&  \
     !defined(__FreeBSD__) && !defined(__DragonFly__) && !defined(__sun) && \
-    !defined(__HAIKU__) && !(defined(__APPLE__) && defined(__MACH__)) && \
+    !defined(__HAIKU__) && !(defined(__APPLE__) && defined(__MACH__)) &&   \
     !defined(__NetBSD__)
 #include <mntent.h>
 #endif
@@ -124,14 +124,14 @@ struct fs_stat *prepare_fs_stat(const char *s) {
 }
 
 #if defined(__APPLE__)
-  #define statfs_func statfs
-  #define statfs_struct statfs
+#define statfs_func statfs
+#define statfs_struct statfs
 #elif defined(__NetBSD__)
-  #define statfs_func statvfs
-  #define statfs_struct statvfs
+#define statfs_func statvfs
+#define statfs_struct statvfs
 #else
-  #define statfs_func statfs64
-  #define statfs_struct statfs64
+#define statfs_func statfs64
+#define statfs_struct statfs64
 #endif /* defined(__APPLE__) */
 
 static void update_fs_stat(struct fs_stat *fs) {
@@ -144,7 +144,7 @@ static void update_fs_stat(struct fs_stat *fs) {
     fs->free = (long long)s.f_bfree * s.f_frsize;
     (void)strncpy(fs->type, s.f_basetype, sizeof(fs->type));
 #else
-  struct statfs_struct s {};
+  struct statfs_struct s{};
 
   if (statfs_func(fs->path, &s) == 0) {
     fs->size = static_cast<long long>(s.f_blocks) * s.f_bsize;
@@ -171,7 +171,7 @@ void get_fs_type(const char *path, char *result) {
     defined(__OpenBSD__) || defined(__DragonFly__) || defined(__HAIKU__) || \
     (defined(__APPLE__) && defined(__MACH__)) || defined(__NetBSD__)
 
-  struct statfs_struct s {};
+  struct statfs_struct s{};
   if (statfs_func(path, &s) == 0) {
     strncpy(result, s.f_fstypename, DEFAULT_TEXT_BUFFER_SIZE);
   } else {
@@ -189,7 +189,8 @@ void get_fs_type(const char *path, char *result) {
   char *slash;
 
   if (mtab == nullptr) {
-    LOG_ERROR("can't read /proc/mounts to determine fs type for '{}': {}", path, strerror(errno));
+    LOG_ERROR("can't read /proc/mounts to determine fs type for '{}': {}", path,
+              strerror(errno));
     strncpy(result, "unknown", DEFAULT_TEXT_BUFFER_SIZE);
     return;
   }
@@ -199,8 +200,7 @@ void get_fs_type(const char *path, char *result) {
   // find our path in the mtab
   search_path = strdup(path);
   do {
-    while ((match = strcmp(search_path, me->mnt_dir)) && getmntent(mtab))
-      ;
+    while ((match = strcmp(search_path, me->mnt_dir)) && getmntent(mtab));
     if (!match) break;
     fseek(mtab, 0, SEEK_SET);
     slash = strrchr(search_path, '/');

--- a/src/data/hardware/apcupsd.cc
+++ b/src/data/hardware/apcupsd.cc
@@ -23,8 +23,8 @@
 
 #include "apcupsd.h"
 #include "../../conky.h"
-#include "../../logging.h"
 #include "../../content/text_object.h"
+#include "../../logging.h"
 
 #include <netdb.h>
 #include <netinet/in.h>
@@ -186,7 +186,7 @@ int update_apcupsd() {
   }
 
   do {
-    struct addrinfo hints {};
+    struct addrinfo hints{};
     struct addrinfo *ai, *rp;
     int res;
     short sz = 0;

--- a/src/data/hardware/bsdapm.cc
+++ b/src/data/hardware/bsdapm.cc
@@ -30,10 +30,10 @@
 #include <sys/ioctl.h>
 #include <unistd.h>
 
-#include "config.h"
 #include "../../conky.h"
-#include "../../logging.h"
 #include "../../content/text_object.h"
+#include "../../logging.h"
+#include "config.h"
 
 #if defined(__OpenBSD__)
 #include <machine/apmvar.h>
@@ -146,7 +146,7 @@ void print_apm_battery_life(struct text_object *obj, char *p,
   } else {
     out = "ERR";
   }
-  
+
   snprintf(p, p_max_size, "%s", out);
 }
 

--- a/src/data/hardware/cpu.cc
+++ b/src/data/hardware/cpu.cc
@@ -33,10 +33,10 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
-#include "config.h"
 #include "../../conky.h"
-#include "../../logging.h"
 #include "../../content/text_object.h"
+#include "../../logging.h"
+#include "config.h"
 
 #ifdef __x86_64__
 #define CPU_FEATURE(x, z) __asm__ __volatile__("cpuid" : "=a"(z) : "a"(x))

--- a/src/data/hardware/diskio.cc
+++ b/src/data/hardware/diskio.cc
@@ -32,12 +32,12 @@
 #include <cstdlib>
 #include <vector>
 #include "../../common.h"
-#include "config.h"
 #include "../../conky.h" /* text_buffer_size */
-#include "../../core.h"
-#include "../../logging.h"
 #include "../../content/specials.h"
 #include "../../content/text_object.h"
+#include "../../core.h"
+#include "../../logging.h"
+#include "config.h"
 
 /* this is the root of all per disk stats,
  * also containing the totals. */
@@ -54,7 +54,7 @@ void clear_diskio_stats() {
 }
 
 struct diskio_stat *prepare_diskio_stat(const char *s) {
-  struct stat sb {};
+  struct stat sb{};
   std::vector<char> stat_name(text_buffer_size.get(*state)),
       device_name(text_buffer_size.get(*state)),
       device_s(text_buffer_size.get(*state));

--- a/src/data/hardware/hddtemp.cc
+++ b/src/data/hardware/hddtemp.cc
@@ -35,9 +35,9 @@
 #include <sys/socket.h>
 #include <unistd.h>
 #include "../../conky.h"
-#include "../../logging.h"
 #include "../../content/temphelper.h"
 #include "../../content/text_object.h"
+#include "../../logging.h"
 
 #define BUFLEN 512
 
@@ -103,7 +103,9 @@ static char *fetch_hddtemp_output(void) {
 
   if ((i = getaddrinfo(hddtemp_host.get(*state).c_str(),
                        hddtemp_port.get(*state).c_str(), &hints, &result))) {
-    LOG_ERROR("hddtemp DNS lookup failed for {}:{}: {}", hddtemp_host.get(*state).c_str(), hddtemp_port.get(*state).c_str(), gai_strerror(i));
+    LOG_ERROR("hddtemp DNS lookup failed for {}:{}: {}",
+              hddtemp_host.get(*state).c_str(),
+              hddtemp_port.get(*state).c_str(), gai_strerror(i));
     return nullptr;
   }
 
@@ -114,7 +116,8 @@ static char *fetch_hddtemp_output(void) {
     close(sockfd);
   }
   if (!rp) {
-    LOG_ERROR("could not connect to hddtemp at {}:{}", hddtemp_host.get(*state), hddtemp_port.get(*state));
+    LOG_ERROR("could not connect to hddtemp at {}:{}", hddtemp_host.get(*state),
+              hddtemp_port.get(*state));
     goto GET_OUT;
   }
 

--- a/src/data/hardware/i8k.cc
+++ b/src/data/hardware/i8k.cc
@@ -32,9 +32,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include "../../conky.h"
-#include "../../logging.h"
 #include "../../content/temphelper.h"
 #include "../../content/text_object.h"
+#include "../../logging.h"
 
 struct _i8k {
   char *version;

--- a/src/data/hardware/ibm.cc
+++ b/src/data/hardware/ibm.cc
@@ -34,10 +34,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "config.h"
 #include "../../conky.h"
-#include "../../logging.h"
 #include "../../content/temphelper.h"
+#include "../../logging.h"
+#include "config.h"
 
 static int ibm_acpi_temps[8];
 
@@ -290,7 +290,8 @@ void parse_ibm_temps_arg(struct text_object *obj, const char *arg) {
     obj->data.l = 0;
     LOG_WARNING(
         "invalid ibm_temps sensor '{}': must be 0-7, "
-        "falling back to 0 (CPU)", arg);
+        "falling back to 0 (CPU)",
+        arg);
   } else
     obj->data.l = atoi(arg);
 }

--- a/src/data/hardware/nvidia.cc
+++ b/src/data/hardware/nvidia.cc
@@ -94,11 +94,11 @@
 
 #include "nvidia.h"
 #include <X11/Xlib.h>
+#include "../../conky.h"
+#include "../../content/temphelper.h"
+#include "../../logging.h"
 #include "NVCtrl/NVCtrl.h"
 #include "NVCtrl/NVCtrlLib.h"
-#include "../../conky.h"
-#include "../../logging.h"
-#include "../../content/temphelper.h"
 
 // Current implementation uses X11 specific system utils
 #include "../../output/x11.h"
@@ -406,7 +406,7 @@ unique_display_t nvidia_display_setting::get_nvdisplay() {
     unique_display_t nvd(XOpenDisplay(nvdisplay.c_str()), &close_nvdisplay);
     if (!nvd) {
       LOG_ERROR("can't open nvidia display: {}",
-               XDisplayName(nvdisplay.c_str()));
+                XDisplayName(nvdisplay.c_str()));
     }
     return nvd;
   }
@@ -459,9 +459,9 @@ int set_nvidia_query(struct text_object *obj, const char *arg,
     case text_node_t::GRAPH: {
       auto [buf, skip] = scan_command(arg);
       scan_graph(obj, arg + skip, 100, FALSE,
-                 buf != nullptr
-                     ? graph_data_key{fmt::format("nvidia:{}:{}", nvs->target_id, buf)}
-                     : graph_parent_obj_key);
+                 buf != nullptr ? graph_data_key{fmt::format(
+                                      "nvidia:{}:{}", nvs->target_id, buf)}
+                                : graph_parent_obj_key);
       arg = buf;
     } break;
     case text_node_t::GAUGE:
@@ -707,9 +707,11 @@ static inline int get_nvidia_target_count(Display *dpy, TARGET_ID tid) {
 
   if (num_tgts < 1 && tid == TARGET_GPU) {
     // Print error and exit if there's no NVIDIA's GPU
-    LOG_ERROR("trying to query nvidia target failed (using the proprietary drivers), "
-             "are you sure they are installed correctly and a nvidia GPU is in use? "
-             "(target_count: {})", num_tgts);
+    LOG_ERROR(
+        "trying to query nvidia target failed (using the proprietary drivers), "
+        "are you sure they are installed correctly and a nvidia GPU is in use? "
+        "(target_count: {})",
+        num_tgts);
   }
 
   return num_tgts;
@@ -724,9 +726,8 @@ static int cache_nvidia_value(TARGET_ID tid, ATTR_ID aid, Display *dpy,
       if (!dpy || !XNVCTRLQueryTargetAttribute(
                       dpy, translate_nvidia_target[tid], gid, 0,
                       translate_nvidia_attribute[aid], value)) {
-        LOG_ERROR(
-            "nvidia query failed (arg: {}, tid: {}, aid: {})",
-            arg, static_cast<int>(tid), static_cast<int>(aid));
+        LOG_ERROR("nvidia query failed (arg: {}, tid: {}, aid: {})", arg,
+                  static_cast<int>(tid), static_cast<int>(aid));
         return -1;
       }
       ac_value[gid].memtotal = *value;
@@ -738,9 +739,8 @@ static int cache_nvidia_value(TARGET_ID tid, ATTR_ID aid, Display *dpy,
       if (!dpy || !XNVCTRLQueryTargetAttribute(
                       dpy, translate_nvidia_target[tid], gid, 0,
                       translate_nvidia_attribute[aid], value)) {
-        LOG_ERROR(
-            "nvidia query failed (arg: {}, tid: {}, aid: {})",
-            arg, static_cast<int>(tid), static_cast<int>(aid));
+        LOG_ERROR("nvidia query failed (arg: {}, tid: {}, aid: {})", arg,
+                  static_cast<int>(tid), static_cast<int>(aid));
         return -1;
       }
       ac_value[gid].gputempthreshold = *value;
@@ -767,9 +767,8 @@ static int get_nvidia_value(TARGET_ID tid, ATTR_ID aid, int gid,
     if (!dpy ||
         !XNVCTRLQueryTargetAttribute(dpy, translate_nvidia_target[tid], gid, 0,
                                      translate_nvidia_attribute[aid], &value)) {
-      LOG_ERROR(
-          "nvidia query failed (arg: {}, tid: {}, aid: {})",
-          arg, static_cast<int>(tid), static_cast<int>(aid));
+      LOG_ERROR("nvidia query failed (arg: {}, tid: {}, aid: {})", arg,
+                static_cast<int>(tid), static_cast<int>(aid));
       return -1;
     }
   }
@@ -793,9 +792,8 @@ static char *get_nvidia_string(TARGET_ID tid, ATTR_ID aid, int gid,
   if (!dpy || !XNVCTRLQueryTargetStringAttribute(
                   dpy, translate_nvidia_target[tid], gid, 0,
                   translate_nvidia_attribute[aid], &str)) {
-    LOG_ERROR(
-        "nvidia string query failed (tid: {}, aid: {}, GPU {})",
-        static_cast<int>(tid), static_cast<int>(aid), gid);
+    LOG_ERROR("nvidia string query failed (tid: {}, aid: {}, GPU {})",
+              static_cast<int>(tid), static_cast<int>(aid), gid);
     return nullptr;
   }
   return str;
@@ -823,11 +821,9 @@ void cache_nvidia_string_value_update(nvidia_c_string *ac_string, char *token,
     ac_string[gid].memTransferRatemax = *value;
 
   } else if (strcmp(token, (char *)"perf") == 0) {
-    if (search == SEARCH_MIN &&
-        ac_string[gid].perfmin < 0) {
+    if (search == SEARCH_MIN && ac_string[gid].perfmin < 0) {
       ac_string[gid].perfmin = *value;
-    } else if (search == SEARCH_MAX &&
-               ac_string[gid].perfmax < 0) {
+    } else if (search == SEARCH_MAX && ac_string[gid].perfmax < 0) {
       ac_string[gid].perfmax = *value;
     }
   }
@@ -1167,8 +1163,8 @@ double get_nvidia_barval(struct text_object *obj) {
         break;
 
       default:  // Throw error if unsupported args are used
-        COMMAND_ARG_ERR(nvs->command, "{}: invalid argument specified: '{}'", nvs->command,
-                 nvs->arg);
+        COMMAND_ARG_ERR(nvs->command, "{}: invalid argument specified: '{}'",
+                        nvs->command, nvs->arg);
     }
   }
 

--- a/src/data/hardware/smapi.cc
+++ b/src/data/hardware/smapi.cc
@@ -27,8 +27,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include "../../conky.h" /* text_buffer_size, PACKAGE_NAME, maybe more */
-#include "../../logging.h"
 #include "../../content/temphelper.h"
+#include "../../logging.h"
 
 #define SYS_SMAPI_PATH "/sys/devices/platform/smapi"
 
@@ -59,7 +59,8 @@ static char *smapi_read_str(const char *path) {
   FILE *fp;
   char str[256] = "failed";
   if ((fp = fopen(path, "r")) != nullptr) {
-    if (fscanf(fp, "%255s\n", str) < 0) LOG_ERROR("fscanf: {}", strerror(errno));
+    if (fscanf(fp, "%255s\n", str) < 0)
+      LOG_ERROR("fscanf: {}", strerror(errno));
     fclose(fp);
   }
   return strndup(str, text_buffer_size.get(*state));
@@ -127,7 +128,8 @@ uint8_t smapi_bat_percentage(struct text_object *obj) {
               ? smapi_get_bat_int(idx, "remaining_percent")
               : 0;
   } else
-    LOG_ERROR("argument to smapi_bat_perc must be an integer, got '{}'", obj->data.s ? obj->data.s : "(null)");
+    LOG_ERROR("argument to smapi_bat_perc must be an integer, got '{}'",
+              obj->data.s ? obj->data.s : "(null)");
 
   return val;
 }
@@ -142,7 +144,8 @@ void print_smapi_bat_temp(struct text_object *obj, char *p,
     /* temperature is in milli degree celsius */
     temp_print(p, p_max_size, val / 1000, TEMP_CELSIUS, 1);
   } else
-    LOG_ERROR("argument to smapi_bat_temp must be an integer, got '{}'", obj->data.s ? obj->data.s : "(null)");
+    LOG_ERROR("argument to smapi_bat_temp must be an integer, got '{}'",
+              obj->data.s ? obj->data.s : "(null)");
 }
 
 void print_smapi_bat_power(struct text_object *obj, char *p,
@@ -155,7 +158,8 @@ void print_smapi_bat_power(struct text_object *obj, char *p,
     /* power_now is in mW, set to W with one digit precision */
     snprintf(p, p_max_size, "%.1f", ((double)val / 1000));
   } else
-    LOG_ERROR("argument to smapi_bat_power must be an integer, got '{}'", obj->data.s ? obj->data.s : "(null)");
+    LOG_ERROR("argument to smapi_bat_power must be an integer, got '{}'",
+              obj->data.s ? obj->data.s : "(null)");
 }
 
 double smapi_bat_barval(struct text_object *obj) {
@@ -169,6 +173,7 @@ int smapi_bat_installed(struct text_object *obj) {
   if (obj->data.s && sscanf(obj->data.s, "%i", &idx) == 1) {
     if (!smapi_bat_installed_internal(idx)) { return 0; }
   } else
-    LOG_ERROR("argument to if_smapi_bat_installed must be an integer, got '{}'", obj->data.s ? obj->data.s : "(null)");
+    LOG_ERROR("argument to if_smapi_bat_installed must be an integer, got '{}'",
+              obj->data.s ? obj->data.s : "(null)");
   return 1;
 }

--- a/src/data/hardware/sony.cc
+++ b/src/data/hardware/sony.cc
@@ -33,10 +33,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "config.h"
 #include "../../conky.h"
-#include "../../logging.h"
 #include "../../content/text_object.h"
+#include "../../logging.h"
+#include "config.h"
 
 #define SONY_LAPTOP_DIR "/sys/devices/platform/sony-laptop"
 

--- a/src/data/iconv_tools.cc
+++ b/src/data/iconv_tools.cc
@@ -31,9 +31,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "config.h"
-#include "../logging.h"
 #include "../content/text_object.h"
+#include "../logging.h"
+#include "config.h"
 
 #define ICONV_CODEPAGE_LENGTH 20
 
@@ -46,7 +46,9 @@ int register_iconv(iconv_t *new_iconv) {
   iconv_cd = (void ***)realloc(iconv_cd, sizeof(iconv_t *) * (iconv_count + 1));
   if (!iconv_cd) { SYSTEM_ERR("failed to allocate iconv descriptor array"); }
   iconv_cd[iconv_count] = (void **)malloc(sizeof(iconv_t));
-  if (!iconv_cd[iconv_count]) { SYSTEM_ERR("failed to allocate iconv descriptor"); }
+  if (!iconv_cd[iconv_count]) {
+    SYSTEM_ERR("failed to allocate iconv descriptor");
+  }
   memcpy(iconv_cd[iconv_count], new_iconv, sizeof(iconv_t));
   iconv_count++;
   return iconv_count;
@@ -110,11 +112,14 @@ void init_iconv_start(struct text_object *obj, void *free_at_crash,
   char iconv_to[ICONV_CODEPAGE_LENGTH];
 
   if (iconv_converting) {
-    COMMAND_ARG_ERR("iconv_start", "you must stop your last iconv conversion before "
-             "starting another");
+    COMMAND_ARG_ERR("iconv_start",
+                    "you must stop your last iconv conversion before "
+                    "starting another");
   }
   if (sscanf(arg, "%s %s", iconv_from, iconv_to) != 2) {
-    COMMAND_ARG_ERR("iconv_start", "invalid arguments for iconv_start, expected: <from_codepage> <to_codepage>");
+    COMMAND_ARG_ERR("iconv_start",
+                    "invalid arguments for iconv_start, expected: "
+                    "<from_codepage> <to_codepage>");
   } else {
     iconv_t new_iconv;
 

--- a/src/data/misc.cc
+++ b/src/data/misc.cc
@@ -35,10 +35,10 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include "../conky.h"
-#include "../core.h"
-#include "../logging.h"
 #include "../content/specials.h"
 #include "../content/text_object.h"
+#include "../core.h"
+#include "../logging.h"
 
 static inline void read_file(const char *data, char *buf, const int size) {
   FILE *fp;

--- a/src/data/network/ccurl_thread.cc
+++ b/src/data/network/ccurl_thread.cc
@@ -145,7 +145,7 @@ void curl_internal::do_work() {
           break;
         default:
           LOG_ERROR("curl: no data from server, got HTTP status {}",
-                   http_status_code);
+                    http_status_code);
           break;
       }
     } else {
@@ -197,7 +197,9 @@ void curl_parse_arg(struct text_object *obj, const char *arg) {
   char *space;
 
   if (strlen(arg) < 1) {
-    LOG_ERROR("wrong number of arguments for $curl, expected: url [interval_minutes]");
+    LOG_ERROR(
+        "wrong number of arguments for $curl, expected: url "
+        "[interval_minutes]");
     return;
   }
 

--- a/src/data/network/irc.cc
+++ b/src/data/network/irc.cc
@@ -27,8 +27,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include "../../conky.h"
-#include "../../logging.h"
 #include "../../content/text_object.h"
+#include "../../logging.h"
 
 struct ll_text {
   char *text;

--- a/src/data/network/libtcp-portmon.cc
+++ b/src/data/network/libtcp-portmon.cc
@@ -27,11 +27,11 @@
 
 #include "libtcp-portmon.h"
 
-#include "../../logging.h"
 #include <cstdio>
 #include <cstring>
 #include <unordered_map>
 #include <vector>
+#include "../../logging.h"
 
 /* -------------------------------------------------------------------
  * IMPLEMENTATION INTERFACE

--- a/src/data/network/mail.cc
+++ b/src/data/network/mail.cc
@@ -33,8 +33,8 @@
 
 #include "../../common.h"
 #include "../../conky.h"
-#include "../../logging.h"
 #include "../../content/text_object.h"
+#include "../../logging.h"
 
 #include <netdb.h>
 #include <netinet/in.h>
@@ -120,7 +120,7 @@ class mail_cb
   uint16_t retries;
 
   void resolve_host() {
-    struct addrinfo hints {};
+    struct addrinfo hints{};
     char portbuf[8];
 
     memset(&hints, 0, sizeof(struct addrinfo));
@@ -203,7 +203,7 @@ struct mail_param_ex *global_mail;
 }  // namespace
 
 static void update_mail_count(struct local_mail_s *mail) {
-  struct stat st {};
+  struct stat st{};
 
   if (mail == nullptr) { return; }
 
@@ -487,7 +487,7 @@ std::unique_ptr<mail_param_ex> parse_mail_args(mail_type type,
   // see if password needs prompting
   if (pass[0] == '*' && pass[1] == '\0') {
     int fp = fileno(stdin);
-    struct termios term {};
+    struct termios term{};
 
     tcgetattr(fp, &term);
     term.c_lflag &= ~ECHO;
@@ -652,7 +652,7 @@ void free_mail_obj(struct text_object *obj) {
 
 static void command(int sockfd, const std::string &cmd, char *response,
                     const char *verify) {
-  struct timeval fetchtimeout {};
+  struct timeval fetchtimeout{};
   fd_set fdset;
   ssize_t total = 0;
   int numbytes = 0;
@@ -722,7 +722,7 @@ void imap_cb::work() {
   bool has_idle = false;
 
   while (fail < retries) {
-    struct timeval fetchtimeout {};
+    struct timeval fetchtimeout{};
     int res;
     fd_set fdset;
 
@@ -787,8 +787,7 @@ void imap_cb::work() {
             command(sockfd, "DONE\r\n", recvbuf, "a5 OK");
             command(sockfd, "a3 LOGOUT\r\n", recvbuf, "a3 OK");
           } catch (mail_fail &e) {
-            LOG_ERROR("error communicating with IMAP server: {}",
-                     e.what());
+            LOG_ERROR("error communicating with IMAP server: {}", e.what());
           }
           close(sockfd);
           return;
@@ -880,8 +879,8 @@ void imap_cb::work() {
         LOG_ERROR("error communicating with IMAP server: {}", e.what());
       }
       LOG_WARNING("trying IMAP connection again for {}@{} (try {}/{})",
-               get<MP_USER>().c_str(), get<MP_HOST>().c_str(), fail + 1,
-               retries);
+                  get<MP_USER>().c_str(), get<MP_HOST>().c_str(), fail + 1,
+                  retries);
       sleep(fail); /* sleep more for the more failures we have */
     }
 
@@ -953,8 +952,8 @@ void pop3_cb::work() {
         LOG_ERROR("error communicating with POP3 server: {}", e.what());
       }
       LOG_WARNING("trying POP3 connection again for {}@{} (try {}/{})",
-               get<MP_USER>().c_str(), get<MP_HOST>().c_str(), fail + 1,
-               retries);
+                  get<MP_USER>().c_str(), get<MP_HOST>().c_str(), fail + 1,
+                  retries);
       sleep(fail); /* sleep more for the more failures we have */
     }
 

--- a/src/data/network/mboxscan.cc
+++ b/src/data/network/mboxscan.cc
@@ -32,9 +32,9 @@
 #include <cerrno>
 #include <memory>
 #include "../../conky.h"
+#include "../../content/text_object.h"
 #include "../../logging.h"
 #include "mail.h"
-#include "../../content/text_object.h"
 
 #define FROM_WIDTH 10
 #define SUBJECT_WIDTH 22
@@ -65,7 +65,7 @@ static void mbox_scan(char *args, char *output, size_t max_len) {
   int force_rescan = 0;
   std::unique_ptr<char[]> buf_(new char[text_buffer_size.get(*state)]);
   char *buf = buf_.get();
-  struct stat statbuf {};
+  struct stat statbuf{};
   struct ring_list *curr = nullptr, *prev = nullptr, *startlist = nullptr;
   FILE *fp;
 
@@ -138,9 +138,9 @@ static void mbox_scan(char *args, char *output, size_t max_len) {
     }
     if (strlen(mbox_mail_spool) < 1) {
       COMMAND_ARG_ERR("mboxscan",
-          "Usage: ${{mboxscan [-n <number of messages to print>] "
-          "[-fw <from width>] [-sw <subject width>] "
-          "[-t <delay in sec> mbox]}}");
+                      "Usage: ${{mboxscan [-n <number of messages to print>] "
+                      "[-fw <from width>] [-sw <subject width>] "
+                      "[-t <delay in sec> mbox]}}");
     }
 
     /* allowing $MAIL in the config */

--- a/src/data/network/net_stat.cc
+++ b/src/data/network/net_stat.cc
@@ -35,10 +35,10 @@
 #include <cerrno>
 #include <cstring>
 #include "../../conky.h"
-#include "../../logging.h"
-#include "net/if.h"
 #include "../../content/specials.h"
 #include "../../content/text_object.h"
+#include "../../logging.h"
+#include "net/if.h"
 #if defined(__sun)
 #include <sys/sockio.h>
 #endif
@@ -528,7 +528,7 @@ void free_if_up(struct text_object *obj) { free_and_zero(obj->data.opaque); }
 /* We should check if this is ok with OpenBSD and NetBSD as well. */
 int interface_up(struct text_object *obj) {
   int fd;
-  struct ifreq ifr {};
+  struct ifreq ifr{};
   auto *dev = static_cast<char *>(obj->data.opaque);
 
   if (dev == nullptr) { return 0; }
@@ -544,7 +544,9 @@ int interface_up(struct text_object *obj) {
   strncpy(ifr.ifr_name, dev, IFNAMSIZ);
   if (ioctl(fd, SIOCGIFFLAGS, &ifr) != 0) {
     /* if device does not exist, treat like not up */
-    if (errno != ENODEV && errno != ENXIO) { LOG_ERROR("SIOCGIFFLAGS: {}", strerror(errno)); }
+    if (errno != ENODEV && errno != ENXIO) {
+      LOG_ERROR("SIOCGIFFLAGS: {}", strerror(errno));
+    }
     goto END_FALSE;
   }
 

--- a/src/data/network/read_tcpip.cc
+++ b/src/data/network/read_tcpip.cc
@@ -37,8 +37,8 @@
 #include <cstdlib>
 #include <string>
 #include "../../conky.h"
-#include "../../logging.h"
 #include "../../content/text_object.h"
+#include "../../logging.h"
 
 #ifndef SOCK_CLOEXEC
 #define SOCK_CLOEXEC O_CLOEXEC
@@ -65,7 +65,8 @@ void parse_read_tcpip_arg(struct text_object *obj, const char *arg,
     strncpy(rtd->host, "localhost", 10);
   }
   if (rtd->port < 1 || rtd->port > 65535) {
-    COMMAND_ARG_ERR("read_tcp/read_udp",
+    COMMAND_ARG_ERR(
+        "read_tcp/read_udp",
         "read_tcp and read_udp need a port from 1 to 65535 as argument");
   }
 
@@ -95,7 +96,7 @@ void parse_tcp_ping_arg(struct text_object *obj, const char *arg,
   }
   if ((he = gethostbyname(hostname)) == nullptr) {
     LOG_WARNING("tcp_ping: problem resolving '{}', using 'localhost' instead",
-             hostname);
+                hostname);
     if ((he = gethostbyname("localhost")) == nullptr) {
       free(hostname);
       SYSTEM_ERR("tcp_ping: resolving 'localhost' also failed");
@@ -110,8 +111,7 @@ void parse_tcp_ping_arg(struct text_object *obj, const char *arg,
 }
 
 void print_tcp_ping(struct text_object *obj, char *p, unsigned int p_max_size) {
-  struct timeval tv1 {
-  }, tv2{}, timeout{};
+  struct timeval tv1{}, tv2{}, timeout{};
   auto *addr = static_cast<struct sockaddr_in *>(obj->data.opaque);
   int addrlen = sizeof(struct sockaddr);
   int sock = socket(addr->sin_family, SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP);
@@ -136,7 +136,8 @@ void print_tcp_ping(struct text_object *obj, char *p, unsigned int p_max_size) {
         gettimeofday(&tv2, nullptr);
         usecdiff =
             ((tv2.tv_sec - tv1.tv_sec) * 1000000) + tv2.tv_usec - tv1.tv_usec;
-        if (getsockopt(sock, SOL_SOCKET, SO_ERROR, &ret, &len) == 0 && ret == 0) {
+        if (getsockopt(sock, SOL_SOCKET, SO_ERROR, &ret, &len) == 0 &&
+            ret == 0) {
           snprintf(p, p_max_size, "%llu", (usecdiff / 1000U));
         } else {
 #define TCP_PING_FAILED "down"
@@ -158,9 +159,9 @@ void print_read_tcpip(struct text_object *obj, char *p, int p_max_size,
                       int protocol) {
   int sock, received;
   fd_set readfds;
-  struct timeval tv {};
+  struct timeval tv{};
   auto *rtd = static_cast<struct read_tcpip_data *>(obj->data.opaque);
-  struct addrinfo hints {};
+  struct addrinfo hints{};
   struct addrinfo *airesult, *rp;
   char portbuf[8];
 
@@ -174,7 +175,7 @@ void print_read_tcpip(struct text_object *obj, char *p, int p_max_size,
   snprintf(portbuf, 8, "%u", rtd->port);
   if (getaddrinfo(rtd->host, portbuf, &hints, &airesult) != 0) {
     LOG_ERROR("{}: problem resolving the hostname",
-             protocol == IPPROTO_TCP ? "read_tcp" : "read_udp");
+              protocol == IPPROTO_TCP ? "read_tcp" : "read_udp");
     return;
   }
   for (rp = airesult; rp != nullptr; rp = rp->ai_next) {
@@ -190,7 +191,7 @@ void print_read_tcpip(struct text_object *obj, char *p, int p_max_size,
       LOG_ERROR("read_tcp: couldn't create a connection");
     } else {
       LOG_ERROR("read_udp: couldn't listen");  // other error because udp is
-                                              // connectionless
+                                               // connectionless
     }
     return;
   }

--- a/src/data/network/rss.cc
+++ b/src/data/network/rss.cc
@@ -52,7 +52,9 @@ class rss_cb : public curl_callback<std::shared_ptr<PRSS>> {
 
       std::unique_lock<std::mutex> lock(Base::result_mutex);
       Base::result = tmp;
-    } catch (std::runtime_error &e) { LOG_ERROR("rss parse failed: {}", e.what()); }
+    } catch (std::runtime_error &e) {
+      LOG_ERROR("rss parse failed: {}", e.what());
+    }
   }
 
  public:
@@ -168,7 +170,9 @@ void rss_scan_arg(struct text_object *obj, const char *arg) {
   argc = sscanf(arg, "%127s %f %63s %d %u", rd->uri, &rd->interval, rd->action,
                 &rd->act_par, &rd->nrspaces);
   if (argc < 3) {
-    LOG_ERROR("wrong number of arguments for $rss, expected: url interval action [param] [spaces]");
+    LOG_ERROR(
+        "wrong number of arguments for $rss, expected: url interval action "
+        "[param] [spaces]");
     free(rd);
     return;
   }

--- a/src/data/network/tcp-portmon.cc
+++ b/src/data/network/tcp-portmon.cc
@@ -19,9 +19,9 @@
  */
 #include "tcp-portmon.h"
 #include "../../conky.h"
-#include "libtcp-portmon.h"
-#include "../../logging.h"
 #include "../../content/text_object.h"
+#include "../../logging.h"
+#include "libtcp-portmon.h"
 
 static tcp_port_monitor_collection_t *pmc = nullptr;
 
@@ -48,10 +48,12 @@ int tcp_portmon_init(struct text_object *obj, const char *arg) {
   }
   if ((port_begin < 1) || (port_begin > 65535) || (port_end < 1) ||
       (port_end > 65535)) {
-    COMMAND_ARG_ERR("tcp_portmon", "tcp_portmon: port values must be from 1 to 65535");
+    COMMAND_ARG_ERR("tcp_portmon",
+                    "tcp_portmon: port values must be from 1 to 65535");
   }
   if (port_begin > port_end) {
-    COMMAND_ARG_ERR("tcp_portmon", "tcp_portmon: starting port must be <= ending port");
+    COMMAND_ARG_ERR("tcp_portmon",
+                    "tcp_portmon: starting port must be <= ending port");
   }
   if (strncmp(itembuf, "count", 31) == EQUAL) {
     item = COUNT;
@@ -72,15 +74,17 @@ int tcp_portmon_init(struct text_object *obj, const char *arg) {
   } else if (strncmp(itembuf, "lservice", 31) == EQUAL) {
     item = LOCALSERVICE;
   } else {
-    COMMAND_ARG_ERR("tcp_portmon", "tcp_portmon: invalid item specified: '{}'", itembuf);
+    COMMAND_ARG_ERR("tcp_portmon", "tcp_portmon: invalid item specified: '{}'",
+                    itembuf);
   }
   if ((argc == 3) && (item != COUNT)) {
     COMMAND_ARG_ERR("tcp_portmon",
-        "tcp_portmon: 3 argument form valid only for \"count\" "
-        "item");
+                    "tcp_portmon: 3 argument form valid only for \"count\" "
+                    "item");
   }
   if ((argc == 4) && (connection_index < 0)) {
-    COMMAND_ARG_ERR("tcp_portmon", "tcp_portmon: connection index must be non-negative");
+    COMMAND_ARG_ERR("tcp_portmon",
+                    "tcp_portmon: connection index must be non-negative");
   }
   /* ok, args looks good. save the text object data */
   pmd = (tcp_port_monitor_data *)malloc(sizeof(struct tcp_port_monitor_data));

--- a/src/data/os/bsdcommon.cc
+++ b/src/data/os/bsdcommon.cc
@@ -33,15 +33,15 @@
 #include <string.h>
 
 #if defined(__NetBSD__)
-  #include <uvm/uvm_extern.h>
-  #include <uvm/uvm_param.h>
+#include <uvm/uvm_extern.h>
+#include <uvm/uvm_param.h>
 #elif defined(__OpenBSD__)
-  #include <sys/proc.h>
-  #include <sys/sched.h>
-  #include <sys/swap.h>
-  #include <sys/vmmeter.h>
+#include <sys/proc.h>
+#include <sys/sched.h>
+#include <sys/swap.h>
+#include <sys/vmmeter.h>
 #else
-  #error Not supported BSD system
+#error Not supported BSD system
 #endif
 
 #include "../top.h"
@@ -54,9 +54,7 @@ static bool cpu_initialised = false;
 static struct bsdcommon::cpu_load *cpu_loads = nullptr;
 
 bool bsdcommon::init_kvm() {
-  if (kvm_initialised) {
-      return true;
-  }
+  if (kvm_initialised) { return true; }
 
   kd = kvm_open(nullptr, nullptr, nullptr, KVM_NO_FILES, kvm_errbuf);
   if (kd == nullptr) {
@@ -69,9 +67,7 @@ bool bsdcommon::init_kvm() {
 }
 
 void bsdcommon::deinit_kvm() {
-  if (!kvm_initialised || kd == nullptr) {
-    return;
-  }
+  if (!kvm_initialised || kd == nullptr) { return; }
 
   kvm_close(kd);
 }
@@ -103,14 +99,14 @@ void bsdcommon::get_cpu_count(float **cpu_usage, unsigned int *cpu_count) {
   if (*cpu_usage == nullptr) {
     // [0] - Total CPU
     // [1, 2, ... ] - CPU0, CPU1, ...
-    *cpu_usage = (float*)calloc(ncpu + 1, sizeof(float));
+    *cpu_usage = (float *)calloc(ncpu + 1, sizeof(float));
     if (*cpu_usage == nullptr) {
       SYSTEM_ERR("failed to allocate cpu_usage array");
     }
   }
 
   if (cpu_loads == nullptr) {
-    cpu_loads = (struct cpu_load*)calloc(ncpu + 1, sizeof(struct cpu_load));
+    cpu_loads = (struct cpu_load *)calloc(ncpu + 1, sizeof(struct cpu_load));
     if (cpu_loads == nullptr) {
       SYSTEM_ERR("failed to allocate cpu_loads array");
     }
@@ -127,7 +123,7 @@ void bsdcommon::update_cpu_usage(float **cpu_usage, unsigned int *cpu_count) {
   int mib_cpu0[2] = {CTL_KERN, KERN_CPTIME};
   int mib_cpun[3] = {CTL_KERN, KERN_CPTIME2, 0};
 #else
-  #error Not supported BSD system
+#error Not supported BSD system
 #endif
 
   size_t size = 0;
@@ -140,13 +136,11 @@ void bsdcommon::update_cpu_usage(float **cpu_usage, unsigned int *cpu_count) {
 
   size = sizeof(cp_time0);
   if (sysctl(mib_cpu0, 2, &cp_time0, &size, nullptr, 0) != 0) {
-      LOG_ERROR("unable to get cpu time for cpu0");
-      return;
+    LOG_ERROR("unable to get cpu time for cpu0");
+    return;
   }
 
-  for (int j = 0; j < CPUSTATES; ++j) {
-    total += cp_time0[j];
-  }
+  for (int j = 0; j < CPUSTATES; ++j) { total += cp_time0[j]; }
   used = total - cp_time0[CP_IDLE];
 
   if ((total - cpu_loads[0].old_total) != 0) {
@@ -169,12 +163,10 @@ void bsdcommon::update_cpu_usage(float **cpu_usage, unsigned int *cpu_count) {
 
     total = 0;
     used = 0;
-    for (int j = 0; j < CPUSTATES; ++j) {
-      total += cp_timen[j];
-    }
+    for (int j = 0; j < CPUSTATES; ++j) { total += cp_timen[j]; }
     used = total - cp_timen[CP_IDLE];
 
-    const int n = i + 1; // [0] is the total CPU, must shift by 1
+    const int n = i + 1;  // [0] is the total CPU, must shift by 1
     if ((total - cpu_loads[n].old_total) != 0) {
       const float diff_used = (float)(used - cpu_loads[n].old_used);
       const float diff_total = (float)(total - cpu_loads[n].old_total);
@@ -189,24 +181,20 @@ void bsdcommon::update_cpu_usage(float **cpu_usage, unsigned int *cpu_count) {
 }
 
 BSD_COMMON_PROC_STRUCT *bsdcommon::get_processes(short unsigned int *procs) {
-  if (!init_kvm()) {
-    return nullptr;
-  }
+  if (!init_kvm()) { return nullptr; }
 
   int n_processes = 0;
 #if defined(__NetBSD__)
-  BSD_COMMON_PROC_STRUCT *ps = kvm_getproc2(kd, KERN_PROC_ALL, 0,
-                                            sizeof(BSD_COMMON_PROC_STRUCT),
-                                            &n_processes);
- #elif defined(__OpenBSD__)
-  BSD_COMMON_PROC_STRUCT *ps = kvm_getprocs(kd, KERN_PROC_ALL, 0,
-                                            sizeof(BSD_COMMON_PROC_STRUCT),
-                                            &n_processes);
+  BSD_COMMON_PROC_STRUCT *ps = kvm_getproc2(
+      kd, KERN_PROC_ALL, 0, sizeof(BSD_COMMON_PROC_STRUCT), &n_processes);
+#elif defined(__OpenBSD__)
+  BSD_COMMON_PROC_STRUCT *ps = kvm_getprocs(
+      kd, KERN_PROC_ALL, 0, sizeof(BSD_COMMON_PROC_STRUCT), &n_processes);
 #else
-  #error Not supported BSD system
+#error Not supported BSD system
 #endif
 
- if (ps == nullptr) {
+  if (ps == nullptr) {
     LOG_ERROR("unable to get processes");
     return nullptr;
   }
@@ -221,26 +209,20 @@ static bool is_process_running(BSD_COMMON_PROC_STRUCT *p) {
 #elif defined(__OpenBSD__)
   return p->p_stat == SRUN;
 #else
-  #error Not supported BSD system
+#error Not supported BSD system
 #endif
 }
 
 void bsdcommon::get_number_of_running_processes(short unsigned int *run_procs) {
-  if (!init_kvm()) {
-    return;
-  }
+  if (!init_kvm()) { return; }
 
   short unsigned int nprocs = 0;
-  BSD_COMMON_PROC_STRUCT* ps = get_processes(&nprocs);
-  if (ps == nullptr) {
-    return;
-  }
+  BSD_COMMON_PROC_STRUCT *ps = get_processes(&nprocs);
+  if (ps == nullptr) { return; }
 
   short unsigned int ctr = 0;
   for (int i = 0; i < nprocs; ++i) {
-    if (is_process_running(&ps[i])) {
-      ++ctr;
-    }
+    if (is_process_running(&ps[i])) { ++ctr; }
   }
 
   *run_procs = ctr;
@@ -250,7 +232,7 @@ static bool is_top_process(BSD_COMMON_PROC_STRUCT *p) {
 #if defined(__NetBSD__) || defined(__OpenBSD__)
   return !((p->p_flag & P_SYSTEM)) && p->p_comm[0] != 0;
 #else
-  #error Not supported BSD system
+#error Not supported BSD system
 #endif
 }
 
@@ -258,7 +240,7 @@ static int32_t get_pid(BSD_COMMON_PROC_STRUCT *p) {
 #if defined(__NetBSD__) || defined(__OpenBSD__)
   return p->p_pid;
 #else
-  #error Not supported BSD system
+#error Not supported BSD system
 #endif
 }
 
@@ -300,7 +282,7 @@ static void proc_from_bsdproc(struct process *proc, BSD_COMMON_PROC_STRUCT *p) {
   proc->rss = (p->p_vm_rssize * getpagesize());
   proc->total_cpu_time = to_conky_time(p->p_rtime_sec, p->p_rtime_usec);
 #else
-  #error Not supported BSD system
+#error Not supported BSD system
 #endif
 
   if (proc->previous_user_time == ULONG_MAX) {
@@ -334,29 +316,21 @@ static void proc_from_bsdproc(struct process *proc, BSD_COMMON_PROC_STRUCT *p) {
 }
 
 void bsdcommon::update_top_info() {
-  if (!init_kvm()) {
-    return;
-  }
+  if (!init_kvm()) { return; }
 
   struct process *proc = nullptr;
   short unsigned int nprocs = 0;
 
   BSD_COMMON_PROC_STRUCT *ps = get_processes(&nprocs);
-  if (ps == nullptr) {
-    return;
-  }
+  if (ps == nullptr) { return; }
 
   for (int i = 0; i < nprocs; ++i) {
     BSD_COMMON_PROC_STRUCT *p = &ps[i];
 
-    if (!is_top_process(p)) {
-      continue;
-    }
+    if (!is_top_process(p)) { continue; }
 
     proc = get_process(get_pid(p));
-    if (!proc) {
-      continue;
-    }
+    if (!proc) { continue; }
 
     proc_from_bsdproc(proc, p);
   }
@@ -366,30 +340,24 @@ static bool is_process(BSD_COMMON_PROC_STRUCT *p, const char *name) {
 #if defined(__NetBSD__) || defined(__OpenBSD__)
   return p->p_comm[0] != 0 && strcmp(p->p_comm, name) == 0;
 #else
-  #error Not supported BSD system
+#error Not supported BSD system
 #endif
 }
 
 bool bsdcommon::is_conky_already_running() {
-  if (!init_kvm()) {
-    return false;
-  }
+  if (!init_kvm()) { return false; }
 
   struct process *proc = nullptr;
   short unsigned int nprocs = 0;
   int instances = 0;
 
   BSD_COMMON_PROC_STRUCT *ps = get_processes(&nprocs);
-  if (ps == nullptr) {
-    return false;
-  }
+  if (ps == nullptr) { return false; }
 
   for (int i = 0; i < nprocs && instances < 2; ++i) {
     BSD_COMMON_PROC_STRUCT *p = &ps[i];
 
-    if (is_process(p, "conky")) {
-      ++instances;
-    }
+    if (is_process(p, "conky")) { ++instances; }
   }
 
   return instances > 1;
@@ -445,11 +413,11 @@ void bsdcommon::update_meminfo(struct information &info) {
   int mib[2] = {CTL_VM, VM_METER};
   struct vmtotal meminfo;
 #else
-  #error Not supported BSD system.
+#error Not supported BSD system.
 #endif
 
   len = sizeof(meminfo);
-  if (sysctl(mib, 2, &meminfo, &len, NULL, 0) == -1 ) {
+  if (sysctl(mib, 2, &meminfo, &len, NULL, 0) == -1) {
     LOG_ERROR("unable to get meminfo");
     return;
   }
@@ -457,7 +425,8 @@ void bsdcommon::update_meminfo(struct information &info) {
 // TODO(gmb): Try to fill all memory related fields.
 #if defined(__NetBSD__)
   info.memmax = to_conky_size(meminfo.npages, meminfo.pagesize);
-  info.memfree = info.memeasyfree = to_conky_size(meminfo.free, meminfo.pagesize);
+  info.memfree = info.memeasyfree =
+      to_conky_size(meminfo.free, meminfo.pagesize);
   info.mem = info.memmax - info.memfree;
 
   info.swapmax = to_conky_size(meminfo.swpages, meminfo.pagesize);
@@ -481,6 +450,6 @@ void bsdcommon::update_meminfo(struct information &info) {
     info.swapfree = 0;
   }
 #else
-  #error Not supported BSD system.
+#error Not supported BSD system.
 #endif
 }

--- a/src/data/os/bsdcommon.h
+++ b/src/data/os/bsdcommon.h
@@ -32,14 +32,14 @@
 #define BSD_COMMON
 
 #if defined(__NetBSD__)
-  #include <sys/sysctl.h>
-  #define BSD_COMMON_PROC_STRUCT struct kinfo_proc2
+#include <sys/sysctl.h>
+#define BSD_COMMON_PROC_STRUCT struct kinfo_proc2
 #elif defined(__OpenBSD__)
-  #include <sys/types.h>
-  #include <sys/sysctl.h>
-  #define BSD_COMMON_PROC_STRUCT struct kinfo_proc
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#define BSD_COMMON_PROC_STRUCT struct kinfo_proc
 #else
-  #error Not supported BSD system
+#error Not supported BSD system
 #endif
 
 #include <stdint.h>
@@ -47,24 +47,24 @@
 #include "../../conky.h"
 
 namespace bsdcommon {
-  struct cpu_load {
-    uint64_t old_used;
-    uint64_t old_total;
-  };
+struct cpu_load {
+  uint64_t old_used;
+  uint64_t old_total;
+};
 
-  bool init_kvm();
-  void deinit_kvm();
+bool init_kvm();
+void deinit_kvm();
 
-  void get_cpu_count(float **cpu_usage, unsigned int *cpu_count);
-  void update_cpu_usage(float **cpu_usage, unsigned int *cpu_count);
+void get_cpu_count(float **cpu_usage, unsigned int *cpu_count);
+void update_cpu_usage(float **cpu_usage, unsigned int *cpu_count);
 
-  BSD_COMMON_PROC_STRUCT* get_processes(short unsigned int *procs);
+BSD_COMMON_PROC_STRUCT *get_processes(short unsigned int *procs);
 
-  void get_number_of_running_processes(short unsigned int *run_procs);
-  void update_top_info();
-  bool is_conky_already_running();
+void get_number_of_running_processes(short unsigned int *run_procs);
+void update_top_info();
+bool is_conky_already_running();
 
-  void update_meminfo(struct information &info);
-}
+void update_meminfo(struct information &info);
+}  // namespace bsdcommon
 
 #endif /*BSDCOMMON_H_*/

--- a/src/data/os/dragonfly.cc
+++ b/src/data/os/dragonfly.cc
@@ -52,11 +52,11 @@
 #include <dev/acpica/acpiio.h>
 
 #include "../../conky.h"
-#include "../hardware/diskio.h"
-#include "dragonfly.h"
 #include "../../logging.h"
+#include "../hardware/diskio.h"
 #include "../network/net_stat.h"
 #include "../top.h"
+#include "dragonfly.h"
 
 #define GETSYSCTL(name, var) getsysctl(name, &(var), sizeof(var))
 #define KELVTOC(x) ((x - 2732) / 10.0)
@@ -73,7 +73,8 @@ static int getsysctl(const char *name, void *ptr, size_t len) {
   }
 
   if (nlen != len && errno == ENOMEM) {
-    LOG_ERROR("sysctl '{}' size mismatch: got {}, expected {}", name, nlen, len);
+    LOG_ERROR("sysctl '{}' size mismatch: got {}, expected {}", name, nlen,
+              len);
     return -1;
   }
 
@@ -277,7 +278,9 @@ void get_cpu_count(void) {
   }
 
   info.cpu_usage = (float *)malloc((info.cpu_count + 1) * sizeof(float));
-  if (info.cpu_usage == nullptr) { SYSTEM_ERR("failed to allocate cpu_usage array"); }
+  if (info.cpu_usage == nullptr) {
+    SYSTEM_ERR("failed to allocate cpu_usage array");
+  }
 }
 
 struct cpu_info {
@@ -326,7 +329,8 @@ int update_cpu_usage(void) {
     if (percpu) {
       if (sysctlbyname("kern.cputime", percpu, &percpu_n, nullptr, 0) == -1 &&
           errno != ENOMEM) {
-        LOG_ERROR("kern.cputime with {} cpu(s): {}", info.cpu_count, strerror(errno));
+        LOG_ERROR("kern.cputime with {} cpu(s): {}", info.cpu_count,
+                  strerror(errno));
       } else {
         struct kinfo_cputime total;
         cputime_pcpu_statistics(&percpu[0], &total, info.cpu_count);
@@ -345,8 +349,7 @@ int update_cpu_usage(void) {
   return 0;
 }
 
-void free_cpu(struct text_object *) { /* no-op */
-}
+void free_cpu(struct text_object *) { /* no-op */ }
 
 int update_load_average(void) {
   double v[3];

--- a/src/data/os/freebsd.cc
+++ b/src/data/os/freebsd.cc
@@ -57,12 +57,12 @@
 #include <mutex>
 
 #include "../../conky.h"
-#include "../hardware/diskio.h"
-#include "freebsd.h"
-#include "../../logging.h"
-#include "../network/net_stat.h"
 #include "../../content/text_object.h"
+#include "../../logging.h"
+#include "../hardware/diskio.h"
+#include "../network/net_stat.h"
 #include "../top.h"
+#include "freebsd.h"
 
 #define GETSYSCTL(name, var) getsysctl(name, &(var), sizeof(var))
 #define KELVTOC(x) ((x - 2732) / 10.0)
@@ -310,7 +310,9 @@ void get_cpu_count(void) {
   }
 
   info.cpu_usage = (float *)malloc((info.cpu_count + 1) * sizeof(float));
-  if (info.cpu_usage == nullptr) { SYSTEM_ERR("failed to allocate cpu_usage array"); }
+  if (info.cpu_usage == nullptr) {
+    SYSTEM_ERR("failed to allocate cpu_usage array");
+  }
 }
 
 struct cpu_info {
@@ -397,8 +399,7 @@ int update_cpu_usage(void) {
   return 0;
 }
 
-void free_cpu(struct text_object *) { /* no-op */
-}
+void free_cpu(struct text_object *) { /* no-op */ }
 
 int update_load_average(void) {
   double v[3];
@@ -432,8 +433,7 @@ double get_acpi_temperature(int fd) {
 // not exist. On the contrary, if a non-leaf entry *does exist*, then EISDIR
 // errno is returned, meaning it exists, but it is an array/directory with
 // more elements hanging from it.
-static int sysctl_mib_exists(const char *mib)
-{
+static int sysctl_mib_exists(const char *mib) {
   size_t len;
   void *p = NULL;
   sysctlbyname(mib, p, &len, NULL, 0);
@@ -446,12 +446,12 @@ static void get_battery_stats(int *battime, int *batcapacity, int *batstate,
   int ac_present = sysctl_mib_exists("hw.acpi.acline");
 
   if (!battery_present && !ac_present) {
-	  // According to acpi(4), hw.acpi.acline is optional and only present
-	  // if supported by the hardware. If no battery and acline is detected,
-	  // for sure we are running on an AC line.
-	  *ac = 1;
-	  *batstate = 7;
-	  return;
+    // According to acpi(4), hw.acpi.acline is optional and only present
+    // if supported by the hardware. If no battery and acline is detected,
+    // for sure we are running on an AC line.
+    *ac = 1;
+    *batstate = 7;
+    return;
   }
 
   if (battery_present) {
@@ -805,9 +805,7 @@ bool is_conky_already_running(void) {
   }
 
   for (int i = 0; i < entries && instances < 2; ++i) {
-    if (!strcmp("conky", kp[i].ki_comm)) {
-        ++instances;
-    }
+    if (!strcmp("conky", kp[i].ki_comm)) { ++instances; }
   }
 
 cleanup:

--- a/src/data/os/haiku.cc
+++ b/src/data/os/haiku.cc
@@ -31,9 +31,9 @@
 
 #include "../../conky.h"
 #include "../../logging.h"
-#include "haiku.h"
 #include "../network/net_stat.h"
 #include "../top.h"
+#include "haiku.h"
 
 static short cpu_setup = 0;
 
@@ -98,7 +98,9 @@ void get_cpu_count(void) {
   info.cpu_count = si.cpu_count;
 
   info.cpu_usage = (float *)malloc((info.cpu_count + 1) * sizeof(float));
-  if (info.cpu_usage == nullptr) { SYSTEM_ERR("failed to allocate cpu_usage array"); }
+  if (info.cpu_usage == nullptr) {
+    SYSTEM_ERR("failed to allocate cpu_usage array");
+  }
 }
 
 int update_cpu_usage() {
@@ -118,7 +120,9 @@ int update_cpu_usage() {
 
   if (!prev_cpuinfo) {
     prev_cpuinfo = (cpu_info *)malloc(malloc_cpu_size);
-    if (prev_cpuinfo == nullptr) { SYSTEM_ERR("failed to allocate prev_cpuinfo array"); }
+    if (prev_cpuinfo == nullptr) {
+      SYSTEM_ERR("failed to allocate prev_cpuinfo array");
+    }
     memset(prev_cpuinfo, 0, malloc_cpu_size);
   }
 
@@ -146,8 +150,7 @@ int update_cpu_usage() {
   return 1;
 }
 
-void free_cpu(struct text_object *) { /* no-op */
-}
+void free_cpu(struct text_object *) { /* no-op */ }
 
 int update_load_average() {
   // TODO
@@ -262,10 +265,9 @@ bool is_conky_already_running(void) {
   int32 instances = 0;
 
   while (get_next_team_info(&team_cookie, &team_info) >= B_OK) {
-    while (get_next_thread_info(team_info.team, &thread_cookie, &thread_info) >= B_OK) {
-      if (!strcmp("conky", thread_info.name)) {
-        ++instances;
-      }
+    while (get_next_thread_info(team_info.team, &thread_cookie, &thread_info) >=
+           B_OK) {
+      if (!strcmp("conky", thread_info.name)) { ++instances; }
     }
   }
   return instances > 1;

--- a/src/data/os/journal.cc
+++ b/src/data/os/journal.cc
@@ -34,8 +34,8 @@
 #include <memory>
 #include "../../buffer.hh"
 #include "../../conky.h"
-#include "../../logging.h"
 #include "../../content/text_object.h"
+#include "../../logging.h"
 
 struct journal {
   int wanted_lines;
@@ -56,7 +56,8 @@ void init_journal(const char *type, const char *arg, struct text_object *obj) {
   char ignored[2] = {};
   argc = sscanf(arg, "%d %7s %1s", &options->wanted_lines, type_arg, ignored);
   if (argc > 2) {
-    COMMAND_ARG_ERR(type,
+    COMMAND_ARG_ERR(
+        type,
         "too many arguments provided; expected: [line_count=1] [type='local']");
   }
 
@@ -75,7 +76,8 @@ void init_journal(const char *type, const char *arg, struct text_object *obj) {
     } else if (strcmp(type_arg, "user") == 0) {
       options->flags |= SD_JOURNAL_CURRENT_USER;
     } else {
-      COMMAND_ARG_ERR(type, "type must be one of: 'local', 'runtime', 'system', 'user'");
+      COMMAND_ARG_ERR(
+          type, "type must be one of: 'local', 'runtime', 'system', 'user'");
     }
   }
 
@@ -104,13 +106,14 @@ bool read_log(sd_journal *handle, conky::buffer_writer &out) {
   uint64_t usec;
   if (sd_journal_get_realtime_usec(handle, &usec) < 0) return false;
 
-  auto tp = std::chrono::system_clock::time_point{
-      std::chrono::microseconds{usec}};
+  auto tp =
+      std::chrono::system_clock::time_point{std::chrono::microseconds{usec}};
   std::time_t epoch = std::chrono::system_clock::to_time_t(tp);
   std::tm local_tm{};
   localtime_r(&epoch, &local_tm);
 
-  size_t length = strftime(out.cursor(), out.remaining(), "%b %d %H:%M:%S", &local_tm);
+  size_t length =
+      strftime(out.cursor(), out.remaining(), "%b %d %H:%M:%S", &local_tm);
   if (length == 0) return false;
   out.advance(length);
 
@@ -134,16 +137,15 @@ void print_journal(struct text_object *obj, char *p, unsigned int p_max_size) {
     LOG_ERROR("unable to open journal");
     return;
   }
-  auto handle = std::unique_ptr<sd_journal, decltype(&sd_journal_close)>(raw, sd_journal_close);
+  auto handle = std::unique_ptr<sd_journal, decltype(&sd_journal_close)>(
+      raw, sd_journal_close);
 
   if (conf->wanted_lines == 0) {
     if (sd_journal_seek_head(handle.get()) < 0) {
       LOG_ERROR("unable to seek to start of journal");
       return;
     }
-    if (sd_journal_next(handle.get()) <= 0) {
-      return;
-    }
+    if (sd_journal_next(handle.get()) <= 0) { return; }
   } else {
     if (sd_journal_seek_tail(handle.get()) < 0) {
       LOG_ERROR("unable to seek to end of journal");
@@ -155,7 +157,6 @@ void print_journal(struct text_object *obj, char *p, unsigned int p_max_size) {
     }
   }
 
-  while (read_log(handle.get(), out) && sd_journal_next(handle.get()))
-    ;
+  while (read_log(handle.get(), out) && sd_journal_next(handle.get()));
   out.terminate();
 }

--- a/src/data/os/linux.cc
+++ b/src/data/os/linux.cc
@@ -35,11 +35,11 @@
 #include <clocale>
 #include "../../common.h"
 #include "../../conky.h"
-#include "../hardware/diskio.h"
+#include "../../content/temphelper.h"
 #include "../../logging.h"
+#include "../hardware/diskio.h"
 #include "../network/net_stat.h"
 #include "../proc.h"
-#include "../../content/temphelper.h"
 #ifndef HAVE_CLOCK_GETTIME
 #include <sys/time.h>
 #endif
@@ -1102,8 +1102,7 @@ int update_cpu_usage(void) {
   return 0;
 }
 
-void free_cpu(struct text_object *) { /* no-op */
-}
+void free_cpu(struct text_object *) { /* no-op */ }
 
 // fscanf() that reads floats with points even if you are using a locale where
 // floats are with commas
@@ -1455,7 +1454,7 @@ static void parse_sysfs_sensor(struct text_object *obj, const char *arg,
     return;
   }
   LOG_DEBUG("parsed {} args: '{}' '{}' {} {} {}", type, buf1, buf2, n, factor,
-       offset);
+            offset);
   sf = (struct sysfs *)malloc(sizeof(struct sysfs));
   memset(sf, 0, sizeof(struct sysfs));
   sf->fd = open_sysfs_sensor(path, (*buf1) ? buf1 : 0, buf2, n, &sf->arg,
@@ -1546,7 +1545,8 @@ char get_freq(char *p_client_buffer, size_t client_buffer_size,
   // open the CPU information file
   f = open_file("/proc/cpuinfo", &reported);
   if (!f) {
-    LOG_ERROR("failed to access '/proc/cpuinfo' at get_freq: {}", strerror(errno));
+    LOG_ERROR("failed to access '/proc/cpuinfo' at get_freq: {}",
+              strerror(errno));
     return 0;
   }
 
@@ -1654,7 +1654,8 @@ static char get_voltage(char *p_client_buffer, size_t client_buffer_size,
     }
     fclose(f);
   } else {
-    LOG_ERROR("failed to access '{}' at get_voltage: {}", current_freq_file, strerror(errno));
+    LOG_ERROR("failed to access '{}' at get_voltage: {}", current_freq_file,
+              strerror(errno));
     return 0;
   }
 
@@ -1674,7 +1675,8 @@ static char get_voltage(char *p_client_buffer, size_t client_buffer_size,
     }
     fclose(f);
   } else {
-    LOG_ERROR("failed to access '{}' at get_voltage: {}", current_freq_file, strerror(errno));
+    LOG_ERROR("failed to access '{}' at get_voltage: {}", current_freq_file,
+              strerror(errno));
     return 0;
   }
   snprintf(p_client_buffer, client_buffer_size, p_format,
@@ -1719,7 +1721,8 @@ void get_acpi_fan(char *p_client_buffer, size_t client_buffer_size) {
     return;
   }
   memset(buf, 0, sizeof(buf));
-  if (fscanf(fp, "%*s %99s", buf) <= 0) LOG_ERROR("fscanf: {}", strerror(errno));
+  if (fscanf(fp, "%*s %99s", buf) <= 0)
+    LOG_ERROR("fscanf: {}", strerror(errno));
   fclose(fp);
 
   snprintf(p_client_buffer, client_buffer_size, "%s", buf);
@@ -1797,7 +1800,8 @@ void get_acpi_ac_adapter(char *p_client_buffer, size_t client_buffer_size,
       return;
     }
     memset(buf, 0, sizeof(buf));
-    if (fscanf(fp, "%*s %99s", buf) <= 0) LOG_ERROR("fscanf: {}", strerror(errno));
+    if (fscanf(fp, "%*s %99s", buf) <= 0)
+      LOG_ERROR("fscanf: {}", strerror(errno));
     fclose(fp);
 
     snprintf(p_client_buffer, client_buffer_size, "%s", buf);
@@ -2380,24 +2384,20 @@ void get_battery_power_draw(char *buffer, unsigned int n, const char *bat) {
 
   snprintf(path, 255, SYSFS_BATTERY_BASE_PATH "/%s/current_now", bat);
   fp = open_file(path, &reported_other);
-  if (fp == nullptr)
-    return;
+  if (fp == nullptr) return;
   ret = fgets(value, 256, fp);
   fclose(fp);
 
-  if (ret == nullptr)
-    return;
+  if (ret == nullptr) return;
   double result = strtol(value, NULL, 10) * 1e-6;
 
   snprintf(path, 255, SYSFS_BATTERY_BASE_PATH "/%s/voltage_now", bat);
   fp = open_file(path, &reported_other);
-  if (fp == nullptr)
-    return;
+  if (fp == nullptr) return;
   ret = fgets(value, 256, fp);
   fclose(fp);
 
-  if (fp == nullptr)
-    return;
+  if (fp == nullptr) return;
   result *= strtol(value, NULL, 10) * 1e-6;
   snprintf(buffer, n, "%.1f", result);
 }
@@ -2828,11 +2828,10 @@ void print_distribution(struct text_object * /*obj*/, char *p,
   // Alternatives that are already handled by above file:
   // /etc/lsb-release - Debian/Ubuntu only, LSB spec
   // /etc/redhat-release - single string
-  // /etc/centos-release - single string e.g. "CentOS Linux release 7.9.2009 (Core)"
-  // /etc/fedora-release - single string
-  // /etc/debian_version - version only
-  // /etc/alpine-release - version only
-  // /etc/arch-release - single string: "Arch Linux"
+  // /etc/centos-release - single string e.g. "CentOS Linux release 7.9.2009
+  // (Core)" /etc/fedora-release - single string /etc/debian_version - version
+  // only /etc/alpine-release - version only /etc/arch-release - single string:
+  // "Arch Linux"
 
   // 2) Fallback: parse /proc/version
   // This file doesn't necessarily have distribution name in it (e.g. on Arch).
@@ -3225,21 +3224,15 @@ bool is_conky_already_running(void) {
   while ((ent = readdir(dir)) != NULL) {
     char *endptr = ent->d_name;
     long lpid = strtol(ent->d_name, &endptr, 10);
-    if (*endptr != '\0') {
-      continue;
-    }
+    if (*endptr != '\0') { continue; }
 
     snprintf(buf, sizeof(buf), "/proc/%ld/stat", lpid);
     FILE *fp = fopen(buf, "r");
-    if (!fp) {
-      continue;
-    }
+    if (!fp) { continue; }
 
     if (fgets(buf, sizeof(buf), fp) != NULL) {
       char *conky = strstr(buf, "(conky)");
-      if (conky) {
-        instances++;
-      }
+      if (conky) { instances++; }
     }
     fclose(fp);
   }

--- a/src/data/os/netbsd.cc
+++ b/src/data/os/netbsd.cc
@@ -48,8 +48,8 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 #include <sys/types.h>
-#include <uvm/uvm_param.h>
 #include <uvm/uvm_extern.h>
+#include <uvm/uvm_param.h>
 
 #include <net/if.h>
 #include <net/if_types.h>
@@ -185,12 +185,9 @@ int update_cpu_usage() {
   return 1;
 }
 
-void get_top_info(void) {
-  bsdcommon::update_top_info();
-}
+void get_top_info(void) { bsdcommon::update_top_info(); }
 
-void free_cpu(struct text_object *) { /* no-op */
-}
+void free_cpu(struct text_object *) { /* no-op */ }
 
 int update_load_average() {
   double v[3];
@@ -233,7 +230,7 @@ int get_entropy_poolsize(unsigned int *val) { return 1; }
 
 char get_freq(char *p_client_buffer, size_t client_buffer_size,
               const char *p_format, int divisor, unsigned int cpu) {
-  //TODO(gmb)
+  // TODO(gmb)
   return 1;
 }
 

--- a/src/data/os/netbsd.h
+++ b/src/data/os/netbsd.h
@@ -8,8 +8,8 @@
 #include <strings.h>
 #include <unistd.h>
 
-#include <sys/param.h>
 #include <sys/mount.h>
+#include <sys/param.h>
 #include <sys/statvfs.h>
 
 #include "../../common.h"

--- a/src/data/os/openbsd.cc
+++ b/src/data/os/openbsd.cc
@@ -31,10 +31,10 @@
 #include <sys/ioctl.h>
 #include <sys/malloc.h>
 #include <sys/param.h>
-#include <sys/resource.h>
 #include <sys/proc.h>
-#include <sys/sensors.h>
+#include <sys/resource.h>
 #include <sys/sched.h>
+#include <sys/sensors.h>
 #include <sys/socket.h>
 #include <sys/swap.h>
 #include <sys/sysctl.h>
@@ -59,12 +59,12 @@
 #include <net80211/ieee80211_ioctl.h>
 
 #include "../../conky.h"
-#include "../hardware/diskio.h"
-#include "../../logging.h"
-#include "../network/net_stat.h"
-#include "openbsd.h"
 #include "../../content/temphelper.h"
+#include "../../logging.h"
+#include "../hardware/diskio.h"
+#include "../network/net_stat.h"
 #include "../top.h"
+#include "openbsd.h"
 
 #define MAXSHOWDEVS 16
 
@@ -192,8 +192,7 @@ int update_cpu_usage() {
   return 1;
 }
 
-void free_cpu(struct text_object *) { /* no-op */
-}
+void free_cpu(struct text_object *) { /* no-op */ }
 
 int update_load_average() {
   double v[3];
@@ -242,7 +241,7 @@ int update_obsd_sensors() {
     // continue;
   }
   for (int t = 0; t < SENSOR_MAX_TYPES; t++) {
-    type = (enum sensor_type) t;
+    type = (enum sensor_type)t;
     mib[3] = type;
     for (numt = 0; numt < sensordev.maxnumt[type]; numt++) {
       mib[4] = numt;
@@ -428,9 +427,7 @@ cleanup:
 
 int update_diskio() { return 0; /* XXX: implement? hifi: not sure how */ }
 
-void get_top_info(void) {
-  bsdcommon::update_top_info();
-}
+void get_top_info(void) { bsdcommon::update_top_info(); }
 
 void get_battery_short_status(char *buffer, unsigned int n, const char *bat) {
   /* Not implemented */
@@ -448,4 +445,3 @@ int get_entropy_poolsize(unsigned int *val) { return 1; }
 bool is_conky_already_running() {
   return bsdcommon::is_conky_already_running();
 }
-

--- a/src/data/os/openbsd.h
+++ b/src/data/os/openbsd.h
@@ -4,11 +4,11 @@
 #define OPENBSD_H_
 
 #include <machine/apmvar.h>
+#include <sys/mount.h>
 #include <sys/param.h>
 #include <sys/sensors.h>
 #include <sys/sysctl.h>
 #include <sys/types.h>
-#include <sys/mount.h>
 
 #include "../../common.h"
 
@@ -21,7 +21,7 @@ void print_obsd_sensors_volt(struct text_object *, char *, unsigned int);
 void get_obsd_vendor(struct text_object *, char *buf,
                      unsigned int client_buffer_size);
 void get_obsd_product(struct text_object *, char *buf,
-                     unsigned int client_buffer_size);
+                      unsigned int client_buffer_size);
 
 #if defined(i386) || defined(__i386__)
 typedef struct apm_power_info *apm_info_t;

--- a/src/data/os/solaris.cc
+++ b/src/data/os/solaris.cc
@@ -107,7 +107,7 @@ static kstat_named_t *get_kstat(const char *module, int inst, const char *name,
   ksp = kstat_lookup(kstat, (char *)module, inst, (char *)name);
   if (ksp == nullptr) {
     LOG_ERROR("cannot lookup kstat {}:{}:{}:{} {}", module, inst, name, stat,
-             strerror(errno));
+              strerror(errno));
     pthread_mutex_unlock(&kstat_mtx);
     return nullptr;
   }
@@ -120,7 +120,7 @@ static kstat_named_t *get_kstat(const char *module, int inst, const char *name,
       return knp;
     } else {
       LOG_ERROR("kstat {}:{}:{}:{} has unexpected type {}", module, inst, name,
-               stat, ksp->ks_type);
+                stat, ksp->ks_type);
       pthread_mutex_unlock(&kstat_mtx);
       return nullptr;
     }
@@ -341,8 +341,7 @@ int update_cpu_usage(void) {
   return 0;
 }
 
-void free_cpu(struct text_object *) { /* no-op */
-}
+void free_cpu(struct text_object *) { /* no-op */ }
 
 void update_proc_entry(struct process *p) {
   psinfo_t proc;

--- a/src/data/proc.cc
+++ b/src/data/proc.cc
@@ -385,7 +385,8 @@ void print_pid_parent(struct text_object *obj, char *p,
       if (end != nullptr) { *(end) = 0; }
       snprintf(p, p_max_size, "%s", begin);
     } else {
-      LOG_ERROR("can't find the process parent in '{}'", pathstream.str().c_str());
+      LOG_ERROR("can't find the process parent in '{}'",
+                pathstream.str().c_str());
     }
     free(buf);
   }
@@ -442,7 +443,8 @@ void print_pid_state(struct text_object *obj, char *p,
       }
       snprintf(p, p_max_size, "%s", begin);
     } else {
-      LOG_ERROR("can't find the process state in '{}'", pathstream.str().c_str());
+      LOG_ERROR("can't find the process state in '{}'",
+                pathstream.str().c_str());
     }
     free(buf);
   }
@@ -466,7 +468,8 @@ void print_pid_state_short(struct text_object *obj, char *p,
       begin += strlen(STATE_ENTRY);
       if (*begin != 0) { snprintf(p, p_max_size, "%c", *begin); }
     } else {
-      LOG_ERROR("can't find the process state in '{}'", pathstream.str().c_str());
+      LOG_ERROR("can't find the process state in '{}'",
+                pathstream.str().c_str());
     }
     free(buf);
   }
@@ -523,7 +526,9 @@ void scan_cmdline_to_pid_arg(struct text_object *obj, const char *arg,
     }
     if (obj->data.s[i - 1] == ' ') { obj->data.s[i - 1] = 0; }
   } else {
-    COMMAND_ARG_ERR("cmdline_to_pid", "cmdline_to_pid needs an argument: ${{cmdline_to_pid commandline}}");
+    COMMAND_ARG_ERR(
+        "cmdline_to_pid",
+        "cmdline_to_pid needs an argument: ${{cmdline_to_pid commandline}}");
   }
 }
 
@@ -591,7 +596,8 @@ void print_pid_threads(struct text_object *obj, char *p,
       if (end != nullptr) { *(end) = 0; }
       snprintf(p, p_max_size, "%s", begin);
     } else {
-      LOG_ERROR("can't find the number of the threads of the process in '{}'", pathstream.str().c_str());
+      LOG_ERROR("can't find the number of the threads of the process in '{}'",
+                pathstream.str().c_str());
     }
     free(buf);
   }
@@ -975,7 +981,8 @@ void print_pid_read(struct text_object *obj, char *p, unsigned int p_max_size) {
       if (end != nullptr) { *(end) = 0; }
       snprintf(p, p_max_size, "%s", begin);
     } else {
-      LOG_ERROR("can't find the amount of bytes read in '{}'", pathstream.str().c_str());
+      LOG_ERROR("can't find the amount of bytes read in '{}'",
+                pathstream.str().c_str());
     }
     free(buf);
   }
@@ -1000,7 +1007,8 @@ void print_pid_write(struct text_object *obj, char *p,
       if (end != nullptr) { *(end) = 0; }
       snprintf(p, p_max_size, "%s", begin);
     } else {
-      LOG_ERROR("can't find the amount of bytes written in '{}'", pathstream.str().c_str());
+      LOG_ERROR("can't find the amount of bytes written in '{}'",
+                pathstream.str().c_str());
     }
     free(buf);
   }

--- a/src/data/tailhead.cc
+++ b/src/data/tailhead.cc
@@ -34,10 +34,10 @@
 #include <cstring>
 #include <memory>
 #include "../common.h"
-#include "config.h"
 #include "../conky.h"
-#include "../logging.h"
 #include "../content/text_object.h"
+#include "../logging.h"
+#include "config.h"
 
 #define MAX_HEADTAIL_LINES 30
 #define DEFAULT_MAX_HEADTAIL_USES 2
@@ -87,20 +87,22 @@ void init_tailhead(const char *type, const char *arg, struct text_object *obj) {
   // XXX: Buffer overflow ?
   args = sscanf(arg, "%s %d %d", tmp.get(), &ht->wantedlines, &ht->max_uses);
   if (args < 2 || args > 3) {
-    COMMAND_ARG_ERR(type,
-        "{} needs a file as 1st and a number of lines as 2nd argument", type);
+    COMMAND_ARG_ERR(
+        type, "{} needs a file as 1st and a number of lines as 2nd argument",
+        type);
   }
   if (ht->max_uses < 1) {
-    COMMAND_ARG_ERR(type, "invalid arg for {}, next_check must be larger than 0", type);
+    COMMAND_ARG_ERR(
+        type, "invalid arg for {}, next_check must be larger than 0", type);
   }
   if (ht->wantedlines > 0 && ht->wantedlines <= MAX_HEADTAIL_LINES) {
     ht->logfile = to_real_path(tmp.get());
     ht->buffer = nullptr;
     ht->current_use = 0;
   } else {
-    COMMAND_ARG_ERR(type,
-        "invalid arg for {}, number of lines must be between 1 and {}", type,
-        MAX_HEADTAIL_LINES);
+    COMMAND_ARG_ERR(
+        type, "invalid arg for {}, number of lines must be between 1 and {}",
+        type, MAX_HEADTAIL_LINES);
   }
   obj->data.opaque = ht.release();
   obj->callbacks.free = &free_tailhead;
@@ -110,7 +112,7 @@ static void print_tailhead(const char *type, struct text_object *obj, char *p,
                            unsigned int p_max_size) {
   int fd, i, endofstring = 0, linescounted = 0;
   FILE *fp;
-  struct stat st {};
+  struct stat st{};
   auto *ht = static_cast<struct headtail *>(obj->data.opaque);
 
   if (ht == nullptr) { return; }
@@ -172,7 +174,7 @@ static void print_tailhead(const char *type, struct text_object *obj, char *p,
       ht->buffer = strdup(p);
     } else {
       SYSTEM_ERR("${} can't find information about '{}'", type,
-               ht->logfile.c_str());
+                 ht->logfile.c_str());
     }
   }
 }

--- a/src/data/timeinfo.cc
+++ b/src/data/timeinfo.cc
@@ -37,8 +37,8 @@
 #include <cstring>
 #include <ctime>
 #include "../conky.h"
-#include "../logging.h"
 #include "../content/text_object.h"
+#include "../logging.h"
 
 #include <memory>
 
@@ -140,13 +140,13 @@ void free_tztime(struct text_object *obj) {
  * - exit conky on memory allocation failure
  * - XXX: no return value at all, otherwise this
  *        could be used globally */
-#define safe_asprintf(bufp, ...)                                   \
-  {                                                                \
-    int __v;                                                       \
-    if ((__v = asprintf(bufp, __VA_ARGS__)) == -1) {               \
-      LOG_ERROR("memory allocation failed");                       \
-      exit(__v);                                                   \
-    }                                                              \
+#define safe_asprintf(bufp, ...)                     \
+  {                                                  \
+    int __v;                                         \
+    if ((__v = asprintf(bufp, __VA_ARGS__)) == -1) { \
+      LOG_ERROR("memory allocation failed");         \
+      exit(__v);                                     \
+    }                                                \
   }
 
 // all chars after the ending " and between the seconds and the starting " are
@@ -255,7 +255,7 @@ static void do_format_time(struct text_object *obj, char *p,
                 break;
               default:
                 LOG_ERROR("$format_time doesn't have a special char '{}'",
-                         *currentchar);
+                          *currentchar);
             }
           } else if (*currentchar == '(') {
             for (temp = currentchar + 1; *temp != 0 && *temp != ')'; temp++) {
@@ -309,7 +309,8 @@ static void do_format_time(struct text_object *obj, char *p,
           "argument");
     }
   } else {
-    LOG_ERROR("$format_time did not receive a time in seconds as first argument");
+    LOG_ERROR(
+        "$format_time did not receive a time in seconds as first argument");
   }
 }
 

--- a/src/data/top.cc
+++ b/src/data/top.cc
@@ -644,7 +644,8 @@ int parse_top_args(const char *s, const char *arg, struct text_object *obj) {
           "must be one of: name, cpu, pid, mem, time, mem_res, mem_vsize, "
           "io_read, io_write, io_perc");
 #else  /* BUILD_IOSTATS */
-      LOG_ERROR("must be one of: name, cpu, pid, mem, time, mem_res, mem_vsize");
+      LOG_ERROR(
+          "must be one of: name, cpu, pid, mem, time, mem_res, mem_vsize");
 #endif /* BUILD_IOSTATS */
       free_and_zero(td->s);
       free_and_zero(obj->data.opaque);

--- a/src/data/top.h
+++ b/src/data/top.h
@@ -122,9 +122,9 @@ struct sorted_process {
 
 /**
  * @brief Returns process information for specified `name`.
- * 
+ *
  * @param name full command line or base name of the process.
- * @return struct process* containing usage details of a process. 
+ * @return struct process* containing usage details of a process.
  */
 struct process *get_process_by_name(std::string_view name);
 /**

--- a/src/data/users.cc
+++ b/src/data/users.cc
@@ -110,15 +110,21 @@ static void tty_user_time(char *ptr, char *tty) {
 static void users_alloc(struct information *ptr) {
   if (ptr->users.names == nullptr) {
     ptr->users.names = (char *)malloc(text_buffer_size.get(*state));
-    if (!ptr->users.names) { LOG_ERROR("failed to allocate user names buffer"); }
+    if (!ptr->users.names) {
+      LOG_ERROR("failed to allocate user names buffer");
+    }
   }
   if (ptr->users.terms == nullptr) {
     ptr->users.terms = (char *)malloc(text_buffer_size.get(*state));
-    if (!ptr->users.terms) { LOG_ERROR("failed to allocate user terms buffer"); }
+    if (!ptr->users.terms) {
+      LOG_ERROR("failed to allocate user terms buffer");
+    }
   }
   if (ptr->users.times == nullptr) {
     ptr->users.times = (char *)malloc(text_buffer_size.get(*state));
-    if (!ptr->users.times) { LOG_ERROR("failed to allocate user times buffer"); }
+    if (!ptr->users.times) {
+      LOG_ERROR("failed to allocate user times buffer");
+    }
   }
 }
 

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -432,15 +432,11 @@ struct rect {
 
   /// @brief Rectangle width.
   /// @return width of this rectangle.
-  inline T width() const {
-    return size().x();
-  }
+  inline T width() const { return size().x(); }
 
   /// @brief Rectangle height.
   /// @return height of this rectangle.
-  inline T height() const {
-    return size().y();
-  }
+  inline T height() const { return size().y(); }
 
   /// @brief Returns rectangle component at `index`.
   /// @param index component index.
@@ -663,8 +659,8 @@ struct fmt::formatter<conky::vec<T, Length>> : fmt::formatter<T> {
 template <typename T, conky::rect_kind Kind>
 struct fmt::formatter<conky::rect<T, Kind>> : fmt::formatter<T> {
   auto format(const conky::rect<T, Kind> &r, fmt::format_context &ctx) const {
-    return fmt::format_to(ctx.out(), "rect({}x{} @ {}, {})",
-                          r.width(), r.height(), r.x(), r.y());
+    return fmt::format_to(ctx.out(), "rect({}x{} @ {}, {})", r.width(),
+                          r.height(), r.x(), r.y());
   }
 };
 

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -15,7 +15,8 @@ namespace {
 static constexpr size_t project_root_len =
     sizeof(__FILE__) - 1 - sizeof("src/logging.cc") + 1;
 
-// Used to avoid the nasty 1-2-4-8 initial growth for relatively small data (spans/attributes)
+// Used to avoid the nasty 1-2-4-8 initial growth for relatively small data
+// (spans/attributes)
 template <typename T>
 std::vector<T> make_reserved(size_t capacity) {
   std::vector<T> v;
@@ -30,7 +31,8 @@ static thread_local auto tl_spans = make_reserved<conky::log::span>(8);
 // Thread-local per-message attributes (set before log call, cleared after)
 static thread_local auto tl_msg_attrs = make_reserved<conky::log::attribute>(4);
 
-static std::string format_attrs(std::initializer_list<conky::log::attribute> attrs) {
+static std::string format_attrs(
+    std::initializer_list<conky::log::attribute> attrs) {
   std::string result = "{";
   size_t i = 0;
   for (const auto &a : attrs) {
@@ -89,8 +91,8 @@ void conky::log::install_context(const std::vector<span> &ctx) {
 // info+: no spans; debug: spans without attrs; trace: spans with attrs
 class span_formatter_flag : public spdlog::custom_flag_formatter {
  public:
-  void format(const spdlog::details::log_msg &msg,
-              const std::tm &, spdlog::memory_buf_t &dest) override {
+  void format(const spdlog::details::log_msg &msg, const std::tm &,
+              spdlog::memory_buf_t &dest) override {
     if (msg.level > spdlog::level::debug) return;
     auto ctx = conky::log::current_span_context();
     if (!ctx.empty()) {
@@ -108,8 +110,8 @@ class span_formatter_flag : public spdlog::custom_flag_formatter {
 // Only visible at trace level
 class msg_attr_formatter_flag : public spdlog::custom_flag_formatter {
  public:
-  void format(const spdlog::details::log_msg &msg,
-              const std::tm &, spdlog::memory_buf_t &dest) override {
+  void format(const spdlog::details::log_msg &msg, const std::tm &,
+              spdlog::memory_buf_t &dest) override {
     if (msg.level > spdlog::level::trace) return;
     if (tl_msg_attrs.empty()) return;
     std::string result = " {";
@@ -131,19 +133,21 @@ class msg_attr_formatter_flag : public spdlog::custom_flag_formatter {
 // Custom source location formatter that omits [file:line] when empty
 class source_loc_formatter_flag : public spdlog::custom_flag_formatter {
  public:
-  void format(const spdlog::details::log_msg &msg,
-              const std::tm &, spdlog::memory_buf_t &dest) override {
+  void format(const spdlog::details::log_msg &msg, const std::tm &,
+              spdlog::memory_buf_t &dest) override {
     if (msg.source.empty()) return;
     const char *file = msg.source.filename;
     if (strlen(file) > project_root_len) { file += project_root_len; }
     bool hide_func = !stderr_sink->should_log(spdlog::level::debug) ||
-        (strcmp(msg.source.funcname, "operator()") == 0 &&
-         msg.payload.size() >= 2 && msg.payload[0] == '>' && msg.payload[1] == '>');
+                     (strcmp(msg.source.funcname, "operator()") == 0 &&
+                      msg.payload.size() >= 2 && msg.payload[0] == '>' &&
+                      msg.payload[1] == '>');
     std::string result;
     if (hide_func) {
       result = fmt::format(" [{}:{}]", file, msg.source.line);
     } else {
-      result = fmt::format(" [{}:{}:{}]", file, msg.source.line, msg.source.funcname);
+      result = fmt::format(" [{}:{}:{}]", file, msg.source.line,
+                           msg.source.funcname);
     }
     dest.append(result.data(), result.data() + result.size());
   }
@@ -157,9 +161,7 @@ void conky::log::push_msg_attrs(std::initializer_list<attribute> attrs) {
   tl_msg_attrs.insert(tl_msg_attrs.end(), attrs.begin(), attrs.end());
 }
 
-void conky::log::clear_msg_attrs() {
-  tl_msg_attrs.clear();
-}
+void conky::log::clear_msg_attrs() { tl_msg_attrs.clear(); }
 
 void conky::log::init_logger() {
   std::vector<spdlog::sink_ptr> sinks;
@@ -202,6 +204,4 @@ void conky::log::log_less() {
   stderr_sink->set_level(static_cast<spdlog::level::level_enum>(lvl + 1));
 }
 
-void conky::log::set_quiet() {
-  stderr_sink->set_level(spdlog::level::off);
-}
+void conky::log::set_quiet() { stderr_sink->set_level(spdlog::level::off); }

--- a/src/logging.h
+++ b/src/logging.h
@@ -35,8 +35,8 @@
 #include "i18n.h"
 
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
-#include <spdlog/spdlog.h>
 #include <spdlog/fmt/fmt.h>
+#include <spdlog/spdlog.h>
 #include <filesystem>
 
 template <>
@@ -125,14 +125,13 @@ void clear_msg_attrs();
 
 }  // namespace conky::log
 
-#define LOG_SCOPE(name, ...)                                            \
-  ([&]() -> conky::log::span_guard {                                    \
-    conky::log::span_guard _guard;                                      \
-    if (spdlog::default_logger()->should_log(spdlog::level::debug))     \
-      _guard.open(                                                      \
-          spdlog::source_loc{__FILE__, __LINE__, __func__},             \
-          name, ##__VA_ARGS__);                                         \
-    return _guard;                                                      \
+#define LOG_SCOPE(name, ...)                                              \
+  ([&]() -> conky::log::span_guard {                                      \
+    conky::log::span_guard _guard;                                        \
+    if (spdlog::default_logger()->should_log(spdlog::level::debug))       \
+      _guard.open(spdlog::source_loc{__FILE__, __LINE__, __func__}, name, \
+                  ##__VA_ARGS__);                                         \
+    return _guard;                                                        \
   }())
 
 // syslog.h defines LOG_DEBUG, LOG_INFO, LOG_WARNING etc. as integers
@@ -151,45 +150,57 @@ void clear_msg_attrs();
 #define LOG_CRITICAL(...) SPDLOG_CRITICAL(__VA_ARGS__)
 
 #define _LOG_STRIP_PARENS(...) __VA_ARGS__
-#define _LOG_MESSAGE_LEVEL_WITH_ATTRIBUTES_IMPLEMENTATION(spdlog_macro, attrs, ...) \
-  do {                                                  \
-    if (spdlog::default_logger()->should_log(           \
-            spdlog::level::trace)) {                    \
-      conky::log::push_msg_attrs({_LOG_STRIP_PARENS attrs}); \
-      spdlog_macro(__VA_ARGS__);                        \
-      conky::log::clear_msg_attrs();                    \
-    } else {                                            \
-      spdlog_macro(__VA_ARGS__);                        \
-    }                                                   \
+#define _LOG_MESSAGE_LEVEL_WITH_ATTRIBUTES_IMPLEMENTATION(spdlog_macro, attrs, \
+                                                          ...)                 \
+  do {                                                                         \
+    if (spdlog::default_logger()->should_log(spdlog::level::trace)) {          \
+      conky::log::push_msg_attrs({_LOG_STRIP_PARENS attrs});                   \
+      spdlog_macro(__VA_ARGS__);                                               \
+      conky::log::clear_msg_attrs();                                           \
+    } else {                                                                   \
+      spdlog_macro(__VA_ARGS__);                                               \
+    }                                                                          \
   } while (0)
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
-#define LOG_TRACE_WITH(attrs, ...) _LOG_MESSAGE_LEVEL_WITH_ATTRIBUTES_IMPLEMENTATION(SPDLOG_TRACE, attrs, __VA_ARGS__)
+#define LOG_TRACE_WITH(attrs, ...)                                       \
+  _LOG_MESSAGE_LEVEL_WITH_ATTRIBUTES_IMPLEMENTATION(SPDLOG_TRACE, attrs, \
+                                                    __VA_ARGS__)
 #else
 #define LOG_TRACE_WITH(attrs, ...) ((void)0)
 #endif
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_DEBUG
-#define LOG_DEBUG_WITH(attrs, ...) _LOG_MESSAGE_LEVEL_WITH_ATTRIBUTES_IMPLEMENTATION(SPDLOG_DEBUG, attrs, __VA_ARGS__)
+#define LOG_DEBUG_WITH(attrs, ...)                                       \
+  _LOG_MESSAGE_LEVEL_WITH_ATTRIBUTES_IMPLEMENTATION(SPDLOG_DEBUG, attrs, \
+                                                    __VA_ARGS__)
 #else
 #define LOG_DEBUG_WITH(attrs, ...) ((void)0)
 #endif
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_INFO
-#define LOG_INFO_WITH(attrs, ...) _LOG_MESSAGE_LEVEL_WITH_ATTRIBUTES_IMPLEMENTATION(SPDLOG_INFO, attrs, __VA_ARGS__)
+#define LOG_INFO_WITH(attrs, ...)                                       \
+  _LOG_MESSAGE_LEVEL_WITH_ATTRIBUTES_IMPLEMENTATION(SPDLOG_INFO, attrs, \
+                                                    __VA_ARGS__)
 #else
 #define LOG_INFO_WITH(attrs, ...) ((void)0)
 #endif
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_WARN
-#define LOG_WARNING_WITH(attrs, ...) _LOG_MESSAGE_LEVEL_WITH_ATTRIBUTES_IMPLEMENTATION(SPDLOG_WARN, attrs, __VA_ARGS__)
+#define LOG_WARNING_WITH(attrs, ...)                                    \
+  _LOG_MESSAGE_LEVEL_WITH_ATTRIBUTES_IMPLEMENTATION(SPDLOG_WARN, attrs, \
+                                                    __VA_ARGS__)
 #else
 #define LOG_WARNING_WITH(attrs, ...) ((void)0)
 #endif
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_ERROR
-#define LOG_ERROR_WITH(attrs, ...) _LOG_MESSAGE_LEVEL_WITH_ATTRIBUTES_IMPLEMENTATION(SPDLOG_ERROR, attrs, __VA_ARGS__)
+#define LOG_ERROR_WITH(attrs, ...)                                       \
+  _LOG_MESSAGE_LEVEL_WITH_ATTRIBUTES_IMPLEMENTATION(SPDLOG_ERROR, attrs, \
+                                                    __VA_ARGS__)
 #else
 #define LOG_ERROR_WITH(attrs, ...) ((void)0)
 #endif
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_CRITICAL
-#define LOG_CRITICAL_WITH(attrs, ...) _LOG_MESSAGE_LEVEL_WITH_ATTRIBUTES_IMPLEMENTATION(SPDLOG_CRITICAL, attrs, __VA_ARGS__)
+#define LOG_CRITICAL_WITH(attrs, ...)                                       \
+  _LOG_MESSAGE_LEVEL_WITH_ATTRIBUTES_IMPLEMENTATION(SPDLOG_CRITICAL, attrs, \
+                                                    __VA_ARGS__)
 #else
 #define LOG_CRITICAL_WITH(attrs, ...) ((void)0)
 #endif
@@ -202,25 +213,25 @@ void clear_msg_attrs();
   } while (0)
 
 /// User error (bad input/config) - logs and throws.
-#define USER_ERR(...)                                    \
-  do {                                                   \
-    LOG_ERROR(__VA_ARGS__);                              \
-    throw conky::error(fmt::format(__VA_ARGS__));        \
+#define USER_ERR(...)                             \
+  do {                                            \
+    LOG_ERROR(__VA_ARGS__);                       \
+    throw conky::error(fmt::format(__VA_ARGS__)); \
   } while (0)
 
 /// System error (missing feature/support) - logs and throws.
-#define SYSTEM_ERR(...)                                  \
-  do {                                                   \
-    LOG_ERROR(__VA_ARGS__);                              \
-    throw conky::error(fmt::format(__VA_ARGS__));        \
+#define SYSTEM_ERR(...)                           \
+  do {                                            \
+    LOG_ERROR(__VA_ARGS__);                       \
+    throw conky::error(fmt::format(__VA_ARGS__)); \
   } while (0)
 
 /// Invalid command arguments - logs and throws.
-#define COMMAND_ARG_ERR(Command, ...)                                    \
-  do {                                                                   \
-    LOG_ERROR(__VA_ARGS__);                                              \
-    throw conky::bad_command_arguments_error(Command,                    \
-                                             fmt::format(__VA_ARGS__));  \
+#define COMMAND_ARG_ERR(Command, ...)                                   \
+  do {                                                                  \
+    LOG_ERROR(__VA_ARGS__);                                             \
+    throw conky::bad_command_arguments_error(Command,                   \
+                                             fmt::format(__VA_ARGS__)); \
   } while (0)
 
 #endif /* _LOGGING_H */

--- a/src/lua/fonts.cc
+++ b/src/lua/fonts.cc
@@ -28,9 +28,9 @@
  */
 
 #include "fonts.h"
+#include "../logging.h"
 #include "../output/display-output.hh"
 #include "../output/gui.h"
-#include "../logging.h"
 
 unsigned int selected_font = 0;
 std::vector<font_list> fonts;

--- a/src/lua/llua.cc
+++ b/src/lua/llua.cc
@@ -32,9 +32,9 @@
 #include "../conky.h"
 #include "../geometry.h"
 #include "../logging.h"
+#include "../output/display-output.hh"
 #include "build.h"
 #include "llua.h"
-#include "../output/display-output.hh"
 
 #ifdef BUILD_GUI
 #include "../output/gui.h"
@@ -294,17 +294,16 @@ void llua_load(const char *script) {
   std::filesystem::path path;
   std::filesystem::path script_path(script);
 
-  path = to_real_path(script); // handles ~/some/path.lua
+  path = to_real_path(script);  // handles ~/some/path.lua
   if (!file_exists(path.c_str())) {
     if (!script_path.is_absolute()) {
       auto cfg_path = std::filesystem::path(to_real_path(XDG_CONFIG_FILE));
-      auto cfg_dir  = cfg_path.parent_path();
-  
+      auto cfg_dir = cfg_path.parent_path();
+
       // prepend the config directory to the script path
       auto full = cfg_dir / script_path;
       path = to_real_path(full.c_str());
-    }
-    else {
+    } else {
       // Already an absolute path
       path = to_real_path(script);
     }
@@ -430,7 +429,7 @@ static char *llua_do_call(const char *string, int retc) {
 
   if (lua_pcall(lua_L, argc, retc, 0) != 0) {
     LOG_ERROR("lua function '{}' execution failed: {}", func,
-             lua_tostring(lua_L, -1));
+              lua_tostring(lua_L, -1));
     lua_pop(lua_L, -1);
     return nullptr;
   }
@@ -471,9 +470,8 @@ static char *llua_getstring(const char *args) {
   func = llua_do_call(args, 1);
   if (func != nullptr) {
     if (lua_isstring(lua_L, -1) == 0) {
-      LOG_WARNING(
-          "lua function '{}' did not return a string, result discarded",
-          func);
+      LOG_WARNING("lua function '{}' did not return a string, result discarded",
+                  func);
     } else {
       ret = strdup(lua_tostring(lua_L, -1));
       lua_pop(lua_L, 1);
@@ -513,9 +511,8 @@ static int llua_getnumber(const char *args, double *ret) {
   func = llua_do_call(args, 1);
   if (func != nullptr) {
     if (lua_isnumber(lua_L, -1) == 0) {
-      LOG_WARNING(
-          "lua function '{}' did not return a number, result discarded",
-          func);
+      LOG_WARNING("lua function '{}' did not return a number, result discarded",
+                  func);
     } else {
       *ret = lua_tonumber(lua_L, -1);
       lua_pop(lua_L, 1);
@@ -643,9 +640,8 @@ bool llua_mouse_hook(const EventT &ev) {
       // TODO: (1.22.0) Force conky_ prefix on use_mouse_hook like llua_do_call
       // does
       // - keep only else case, remove ty_raw and make hook_name const.
-      LOG_WARNING(
-          "lua mouse hook '{}' is missing 'conky_' prefix",
-          raw_hook_name);
+      LOG_WARNING("lua mouse hook '{}' is missing 'conky_' prefix",
+                  raw_hook_name);
       hook_name = raw_hook_name;
       ty = ty_raw;
       lua_insert(lua_L, -2);
@@ -666,7 +662,7 @@ bool llua_mouse_hook(const EventT &ev) {
   bool result = false;
   if (lua_pcall(lua_L, 1, 1, 0) != LUA_OK) {
     LOG_ERROR("lua mouse hook '{}' execution failed: {}", hook_name,
-             lua_tostring(lua_L, -1));
+              lua_tostring(lua_L, -1));
     lua_pop(lua_L, 1);
   } else {
     result = lua_toboolean(lua_L, -1);
@@ -707,7 +703,7 @@ void llua_setup_window_table(conky::vec2i window_size,
   if (out_to_gui(*state)) {
     llua_set_number("width", window_size.x());
     llua_set_number("height", window_size.y());
-    
+
     llua_set_number("border_inner_margin", border_inner_margin.get(*state));
     llua_set_number("border_outer_margin", border_outer_margin.get(*state));
     llua_set_number("border_width", border_width.get(*state));

--- a/src/lua/setting.cc
+++ b/src/lua/setting.cc
@@ -47,8 +47,12 @@ settings_map *settings;
 
 /// Settings that have been removed. Maps old name to an explanation message.
 const std::unordered_map<std::string, std::string> removed_settings = {
-    {"own_window_argb_visual", "ARGB is now always enabled when available. Control opacity with `own_window_colour` (e.g. '#8000')."},
-    {"store_graph_data_explicitly", "Graph data is now always stored directly in the node; this setting has no effect."},
+    {"own_window_argb_visual",
+     "ARGB is now always enabled when available. Control opacity with "
+     "`own_window_colour` (e.g. '#8000')."},
+    {"store_graph_data_explicitly",
+     "Graph data is now always stored directly in the node; this setting has "
+     "no effect."},
 };
 
 /*
@@ -67,8 +71,7 @@ priv::config_setting_base *get_setting(lua::state &l, int index) {
   if (iter == settings->end()) {
     auto removed = removed_settings.find(name);
     if (removed != removed_settings.end()) {
-      LOG_WARNING("setting '{}' has been removed: {}", name,
-               removed->second);
+      LOG_WARNING("setting '{}' has been removed: {}", name, removed->second);
     } else {
       LOG_ERROR("unknown setting '{}'", name);
     }
@@ -173,9 +176,7 @@ namespace priv {
 config_setting_base::config_setting_base(std::string name_)
     : name(std::move(name_)), seq_no(get_next_seq_no()) {
   bool inserted = settings->insert({name, this}).second;
-  if (!inserted) {
-    CRIT_ERR("setting '{}' already registered", name);
-  }
+  if (!inserted) { CRIT_ERR("setting '{}' already registered", name); }
 }
 
 config_setting_base::config_setting_base(config_setting_base &&other) noexcept
@@ -211,8 +212,10 @@ void config_setting_base::process_setting(lua::state &l, bool init) {
   if (ptr == nullptr) { return; }
 
   if (init && ptr->deprecation_msg.has_value() && !l.isnil(-2)) {
-    LOG_WARNING("'{}' is deprecated and will be removed in a future "
-             "release: {}", ptr->name, *ptr->deprecation_msg);
+    LOG_WARNING(
+        "'{}' is deprecated and will be removed in a future "
+        "release: {}",
+        ptr->name, *ptr->deprecation_msg);
   }
 
   ptr->lua_setter(l, init);

--- a/src/lua/setting.hh
+++ b/src/lua/setting.hh
@@ -293,8 +293,7 @@ simple_config_setting<T, Traits>::do_convert(lua::state &l, int index) {
     LOG_ERROR(
         "invalid value of type '{}' for setting '{}', "
         "expected type '{}'",
-        l.type_name(l.type(index)), Base::name,
-        l.type_name(Traits::type));
+        l.type_name(l.type(index)), Base::name, l.type_name(Traits::type));
     return {default_value, false};
   }
 
@@ -361,7 +360,8 @@ class range_config_setting : public simple_config_setting<T, Traits> {
                                                             int index) {
     auto ret = Base::do_convert(l, index);
     if (ret.second && !between(ret.first, min, max)) {
-      LOG_ERROR("value {} is out of range for setting '{}' (expected {}-{})", ret.first, Base::name, min, max);
+      LOG_ERROR("value {} is out of range for setting '{}' (expected {}-{})",
+                ret.first, Base::name, min, max);
       // we ignore out-of-range values. an alternative would be to clamp them.
       // do we want to do that?
       ret.second = false;

--- a/src/lua/x11-settings.cc
+++ b/src/lua/x11-settings.cc
@@ -77,7 +77,7 @@ bool use_xpmdb_setting::set_up(lua::state &l) {
   if (!out_to_x.get(l)) return false;
 
   unsigned int depth = window.color_depth != 0 ? window.color_depth
-                                                : DefaultDepth(display, screen);
+                                               : DefaultDepth(display, screen);
   window.back_buffer =
       XCreatePixmap(display, window.window, window.geometry.width() + 1,
                     window.geometry.height() + 1, depth);

--- a/src/macros.h
+++ b/src/macros.h
@@ -62,10 +62,8 @@
 #define UNREACHABLE() (unreachable_impl())
 #endif /* compiler selection */
 #else  /* DEBUG */
-#define UNREACHABLE()              \
-  do {                             \
-    CRIT_ERR("reached unreachable"); \
-  } while (0)
+#define UNREACHABLE() \
+  do { CRIT_ERR("reached unreachable"); } while (0)
 #endif /* NDEBUG */
 
 #endif /* _CONKY_MACROS_H_ */

--- a/src/main.cc
+++ b/src/main.cc
@@ -34,8 +34,8 @@
 #include "config.h"
 #include "conky.h"
 #include "logging.h"
-#include "output/display-output.hh"
 #include "lua/lua-config.hh"
+#include "output/display-output.hh"
 
 #ifdef BUILD_X11
 #include "output/x11.h"
@@ -161,7 +161,8 @@ static void print_version() {
 #ifdef DEBUG
             << _("  * Debugging extensions\n")
 #endif
-#if defined BUILD_LUA_CAIRO || defined BUILD_LUA_IMLIB2 || BUILD_LUA_RSVG || BUILD_LUA_TEXT
+#if defined BUILD_LUA_CAIRO || defined BUILD_LUA_IMLIB2 || BUILD_LUA_RSVG || \
+    BUILD_LUA_TEXT
             << _("\n Lua bindings:\n")
 #endif
 #ifdef BUILD_LUA_CAIRO
@@ -193,8 +194,7 @@ static void print_version() {
 #ifdef BUILD_XFT
             << _("  * Xft\n")
 #endif /* BUILD_XFT */
-            << _("  * Xinput\n")
-            << _("  * ARGB visual\n")
+            << _("  * Xinput\n") << _("  * ARGB visual\n")
 #ifdef OWN_WINDOW
             << _("  * Own window\n")
 #endif
@@ -284,11 +284,13 @@ static void print_help(const char *prog_name) {
          " (and quit)\n"
          "   -p, --pause=SECS          pause for SECS seconds at startup "
          "before doing anything\n"
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || \
-    defined(__HAIKU__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#if defined(__linux__) || defined(__FreeBSD__) ||        \
+    defined(__FreeBSD_kernel__) || defined(__HAIKU__) || \
+    defined(__NetBSD__) || defined(__OpenBSD__)
          "   -U, --unique              only one conky process can be created\n"
 #endif /* Linux || FreeBSD || Haiku || NetBSD || OpenBSD */
-         , prog_name);
+         ,
+         prog_name);
 }
 
 inline void reset_optind() {
@@ -300,8 +302,8 @@ inline void reset_optind() {
 #endif
 }
 
-void clean_up(void);     // defined in conky.cc
-void handle_terminate(); // defined in conky.cc
+void clean_up(void);      // defined in conky.cc
+void handle_terminate();  // defined in conky.cc
 
 int main(int argc, char **argv) {
   conky::log::init_logger();
@@ -379,15 +381,17 @@ int main(int argc, char **argv) {
         window.window = strtol(optarg, nullptr, 0);
         break;
 #endif /* BUILD_X11 */
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || \
-    defined(__HAIKU__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#if defined(__linux__) || defined(__FreeBSD__) ||        \
+    defined(__FreeBSD_kernel__) || defined(__HAIKU__) || \
+    defined(__NetBSD__) || defined(__OpenBSD__)
       case 'U':
         unique_process = true;
         break;
 #endif /* Linux || FreeBSD || Haiku || NetBSD || OpenBSD */
       case '?':
         if (optopt != 0) {
-          LOG_ERROR("unknown option: '-{}'; try --help", static_cast<char>(optopt));
+          LOG_ERROR("unknown option: '-{}'; try --help",
+                    static_cast<char>(optopt));
         } else {
           LOG_ERROR("unknown option: '{}'; try --help", argv[optind - 1]);
         }
@@ -395,8 +399,9 @@ int main(int argc, char **argv) {
     }
   }
 
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || \
-    defined(__HAIKU__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#if defined(__linux__) || defined(__FreeBSD__) ||        \
+    defined(__FreeBSD_kernel__) || defined(__HAIKU__) || \
+    defined(__NetBSD__) || defined(__OpenBSD__)
   if (unique_process && is_conky_already_running()) {
     LOG_INFO("another conky instance is already running");
     return 0;
@@ -428,7 +433,7 @@ int main(int argc, char **argv) {
   bsdcommon::deinit_kvm();
 #endif
 
-//TODO(gmb): Move this to bsdcommon and remove external kd.
+// TODO(gmb): Move this to bsdcommon and remove external kd.
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
   kvm_close(kd);
 #endif

--- a/src/mouse-events.cc
+++ b/src/mouse-events.cc
@@ -179,7 +179,7 @@ void push_table_value(lua_State *L, std::string key, mouse_button_t button) {
 
 /* Class methods */
 mouse_event::mouse_event(mouse_event_t type)
-    : type(type), time(current_time_ms()){};
+    : type(type), time(current_time_ms()) {};
 
 void mouse_event::push_lua_table(lua_State *L) const {
   lua_newtable(L);
@@ -233,15 +233,13 @@ device_info *device_info::from_xi_id(xi_device_id device_id, Display *display) {
 
   int master;
 
-  if(device->use == XIMasterPointer){
+  if (device->use == XIMasterPointer) {
     master = device->deviceid;
-  }
-  else{
+  } else {
     master = device->attachment;
   }
 
-  device_info info =
-      device_info{device_id, master, std::string(device->name)};
+  device_info info = device_info{device_id, master, std::string(device->name)};
 
   size_t id = last_device_id++;
   info.init_xi_device(display, device);
@@ -296,7 +294,9 @@ size_t fixed_valuator_index(Display *display, XIDeviceInfo *device,
                       reinterpret_cast<unsigned char **>(&value)) == 0) {
       if (num_items == 0) break;
       if (type_return != XA_INTEGER) {
-        LOG_WARNING("invalid '{}' option value, expected a single integer; value will be ignored",
+        LOG_WARNING(
+            "invalid '{}' option value, expected a single integer; value will "
+            "be ignored",
             atom_names[*valuator]);
         XFree(value);
         break;
@@ -318,8 +318,7 @@ size_t fixed_valuator_index(Display *display, XIDeviceInfo *device,
 /// (section "XIScrollClass")
 bool fixed_valuator_relative(Display *display, XIDeviceInfo *device,
                              valuator_t valuator,
-                             XIValuatorClassInfo *class_info,
-                             bool is_scroll) {
+                             XIValuatorClassInfo *class_info, bool is_scroll) {
   const std::array<const char *, 2> atom_names = {
       "ConkyValuatorMoveMode",
       "ConkyValuatorScrollMode",
@@ -339,7 +338,9 @@ bool fixed_valuator_relative(Display *display, XIDeviceInfo *device,
                       reinterpret_cast<unsigned char **>(&value_return)) == 0) {
       if (num_items == 0) break;
       if (type_return != XA_ATOM) {
-        LOG_WARNING("invalid '{}' option value, expected an atom (string); value will be ignored",
+        LOG_WARNING(
+            "invalid '{}' option value, expected an atom (string); value will "
+            "be ignored",
             atom_names[*valuator >> 1]);
         XFree(value_return);
         break;
@@ -355,7 +356,9 @@ bool fixed_valuator_relative(Display *display, XIDeviceInfo *device,
       if (strcmp(reinterpret_cast<char *>(value), "relative") == 0) {
         relative = true;
       } else if (strcmp(reinterpret_cast<char *>(value), "absolute") != 0) {
-        LOG_WARNING("unknown '{}' option value: '{}', expected 'absolute' or 'relative'; value will be ignored",
+        LOG_WARNING(
+            "unknown '{}' option value: '{}', expected 'absolute' or "
+            "'relative'; value will be ignored",
             atom_names[*valuator >> 1], value);
         XFree(value);
         break;
@@ -413,10 +416,10 @@ void device_info::init_xi_device(
     else if (si->scroll_type == XIScrollTypeHorizontal)
       target = valuator_t::SCROLL_X;
 
-    LOG_DEBUG("xi scroll class: number={} type={} increment={}",
-              si->number,
-              si->scroll_type == XIScrollTypeVertical ? "vertical" : "horizontal",
-              si->increment);
+    LOG_DEBUG(
+        "xi scroll class: number={} type={} increment={}", si->number,
+        si->scroll_type == XIScrollTypeVertical ? "vertical" : "horizontal",
+        si->increment);
 
     // Only set if not already claimed and doesn't conflict with a move axis.
     // Some devices (e.g. Xephyr) alias scroll and move to the same valuator;
@@ -458,7 +461,7 @@ void device_info::init_xi_device(
         .max = class_info->max,
         .value = class_info->value,
         .relative = fixed_valuator_relative(display, device, valuator,
-                                             class_info, is_scroll),
+                                            class_info, is_scroll),
     };
 
     if (is_scroll) { info.increment = it->second; }
@@ -466,14 +469,14 @@ void device_info::init_xi_device(
     this->valuators[*valuator] = info;
   }
 
-  LOG_DEBUG("xi device '{}' valuators: move_x={} move_y={} scroll_x={} "
-            "scroll_y={} scroll_y_increment={}",
-            device->name,
-            this->valuators[*valuator_t::MOVE_X].index,
-            this->valuators[*valuator_t::MOVE_Y].index,
-            this->valuators[*valuator_t::SCROLL_X].index,
-            this->valuators[*valuator_t::SCROLL_Y].index,
-            this->valuators[*valuator_t::SCROLL_Y].increment);
+  LOG_DEBUG(
+      "xi device '{}' valuators: move_x={} move_y={} scroll_x={} "
+      "scroll_y={} scroll_y_increment={}",
+      device->name, this->valuators[*valuator_t::MOVE_X].index,
+      this->valuators[*valuator_t::MOVE_Y].index,
+      this->valuators[*valuator_t::SCROLL_X].index,
+      this->valuators[*valuator_t::SCROLL_Y].index,
+      this->valuators[*valuator_t::SCROLL_Y].increment);
 
   if (std::holds_alternative<xi_device_id>(source)) {
     XIFreeDeviceInfo(device);
@@ -542,12 +545,10 @@ xi_event_data *xi_event_data::read_cookie(Display *display, const void *data) {
       // possible but unrealistic with 32-bit values.
       result->valuators_relative[v] = current - valuator_info.value;
     }
-    LOG_TRACE_WITH(({"index", valuator_info.index},
-                    {"current", current},
-                    {"prev", valuator_info.value},
-                    {"relative", valuator_info.relative}),
-                   "xi valuator[{}] delta={}", v,
-                   result->valuators_relative[v]);
+    LOG_TRACE_WITH(
+        ({"index", valuator_info.index}, {"current", current},
+         {"prev", valuator_info.value}, {"relative", valuator_info.relative}),
+        "xi valuator[{}] delta={}", v, result->valuators_relative[v]);
     valuator_info.value = current;
   }
 

--- a/src/mouse-events.h
+++ b/src/mouse-events.h
@@ -45,7 +45,7 @@ extern "C" {
 #include <X11/extensions/XInput.h>
 #include <X11/extensions/XInput2.h>
 #undef COUNT  // define from X11/extensions/Xi.h
-#endif /* BUILD_X11 */
+#endif        /* BUILD_X11 */
 
 #include <lua.h>
 
@@ -141,7 +141,7 @@ struct mouse_positioned_event : public mouse_event {
 
   mouse_positioned_event(mouse_event_t type, vec2<size_t> pos,
                          vec2<size_t> pos_absolute)
-      : mouse_event(type), pos(pos), pos_absolute(pos_absolute){};
+      : mouse_event(type), pos(pos), pos_absolute(pos_absolute) {};
 
   void push_lua_data(lua_State *L) const;
 };
@@ -180,7 +180,7 @@ struct mouse_move_event : public mouse_positioned_event {
   mouse_move_event(vec2<size_t> pos, vec2<size_t> pos_absolute,
                    modifier_state_t mods = 0)
       : mouse_positioned_event{mouse_event_t::MOVE, pos, pos_absolute},
-        mods(mods){};
+        mods(mods) {};
 
   void push_lua_data(lua_State *L) const;
 };
@@ -225,7 +225,7 @@ struct mouse_scroll_event : public mouse_positioned_event {
                      scroll_direction_t direction, modifier_state_t mods = 0)
       : mouse_positioned_event{mouse_event_t::SCROLL, pos, pos_absolute},
         direction(direction),
-        mods(mods){};
+        mods(mods) {};
 
   void push_lua_data(lua_State *L) const;
 };
@@ -239,7 +239,7 @@ struct mouse_button_event : public mouse_positioned_event {
                      modifier_state_t mods = 0)
       : mouse_positioned_event{type, pos, pos_absolute},
         button(button),
-        mods(mods){};
+        mods(mods) {};
 
   void push_lua_data(lua_State *L) const;
 };
@@ -267,8 +267,8 @@ struct conky_valuator_info {
   double max = 0.0;
   double value = 0.0;
   bool relative = false;
-  /// Scroll increment from XIScrollClassInfo; sign defines direction convention.
-  /// Positive means increasing valuator value = down/right.
+  /// Scroll increment from XIScrollClassInfo; sign defines direction
+  /// convention. Positive means increasing valuator value = down/right.
   double increment = 1.0;
 };
 

--- a/src/output/display-console.hh
+++ b/src/output/display-console.hh
@@ -27,8 +27,8 @@
 #include <string>
 #include <type_traits>
 
-#include "display-output.hh"
 #include "../lua/luamm.hh"
+#include "display-output.hh"
 
 namespace conky {
 

--- a/src/output/display-file.cc
+++ b/src/output/display-file.cc
@@ -56,8 +56,7 @@ void register_output<output_t::FILE>(display_outputs_t &outputs) {
 }
 
 display_output_file::display_output_file(const std::string &name_)
-    : display_output_base(name_) {
-}
+    : display_output_base(name_) {}
 
 bool display_output_file::detect() {
   if (static_cast<unsigned int>(!overwrite_file.get(*state).empty()) != 0u ||
@@ -81,13 +80,15 @@ void display_output_file::begin_draw_stuff() {
   if (static_cast<unsigned int>(!overwrite_file.get(*state).empty()) != 0u) {
     overwrite_fpointer = fopen(overwrite_file.get(*state).c_str(), "we");
     if (overwrite_fpointer == nullptr) {
-      LOG_ERROR("cannot overwrite '{}': {}", overwrite_file.get(*state), strerror(errno));
+      LOG_ERROR("cannot overwrite '{}': {}", overwrite_file.get(*state),
+                strerror(errno));
     }
   }
   if (static_cast<unsigned int>(!append_file.get(*state).empty()) != 0u) {
     append_fpointer = fopen(append_file.get(*state).c_str(), "ae");
     if (append_fpointer == nullptr) {
-      LOG_ERROR("cannot append to '{}': {}", append_file.get(*state), strerror(errno));
+      LOG_ERROR("cannot append to '{}': {}", append_file.get(*state),
+                strerror(errno));
     }
   }
 }

--- a/src/output/display-file.hh
+++ b/src/output/display-file.hh
@@ -27,8 +27,8 @@
 #include <string>
 #include <type_traits>
 
-#include "display-output.hh"
 #include "../lua/luamm.hh"
+#include "display-output.hh"
 
 namespace conky {
 

--- a/src/output/display-http.cc
+++ b/src/output/display-http.cc
@@ -85,7 +85,8 @@ class out_to_http_setting : public conky::simple_config_setting<bool> {
       if (http_port.get(*state) == 10080) {
         LOG_WARNING(
             "port {} is blocked by browsers like Firefox and Chromium, "
-            "you may want to change http_port", http_port.get(*state));
+            "you may want to change http_port",
+            http_port.get(*state));
       }
       httpd =
           MHD_start_daemon(MHD_USE_SELECT_INTERNALLY, http_port.get(*state),

--- a/src/output/display-output.cc
+++ b/src/output/display-output.cc
@@ -36,9 +36,8 @@
 namespace conky {
 
 inline void log_missing(const char *name, const char *flag) {
-  LOG_DEBUG(
-      "{} display output disabled, recompile with '{}' to enable",
-      name, flag);
+  LOG_DEBUG("{} display output disabled, recompile with '{}' to enable", name,
+            flag);
 }
 #ifndef BUILD_HTTP
 template <>
@@ -83,16 +82,20 @@ bool initialize_display_outputs() {
   // Order of registration is important!
   // - Graphical outputs go before textual (e.g. X11 before NCurses).
   // - Optional outputs go before non-optional (e.g. Wayland before X11).
-  // - Newer outputs go before older (e.g. NCurses before (hypothetical) Curses).
+  // - Newer outputs go before older (e.g. NCurses before (hypothetical)
+  // Curses).
   // - Fallbacks go last (in group)
   register_output<output_t::WAYLAND>(outputs);
   register_output<output_t::X11>(outputs);
   register_output<output_t::HTTP>(outputs);
   register_output<output_t::FILE>(outputs);
   register_output<output_t::NCURSES>(outputs);
-  register_output<output_t::CONSOLE>(outputs);  // global fallback - always works
+  register_output<output_t::CONSOLE>(
+      outputs);  // global fallback - always works
 
-  for (auto out : outputs) { LOG_DEBUG("found display output '{}'", out->name); }
+  for (auto out : outputs) {
+    LOG_DEBUG("found display output '{}'", out->name);
+  }
 
   int graphical_count = 0;
 

--- a/src/output/display-output.hh
+++ b/src/output/display-output.hh
@@ -73,7 +73,7 @@ class display_output_base {
   bool is_active = false;
   bool is_graphical = false;
 
-  explicit display_output_base(const std::string &name) : name(name){};
+  explicit display_output_base(const std::string &name) : name(name) {};
 
   virtual ~display_output_base() {}
 

--- a/src/output/display-wayland.cc
+++ b/src/output/display-wayland.cc
@@ -50,11 +50,11 @@
 #include <sstream>
 
 #include "../conky.h"
-#include "display-output.hh"
 #include "../geometry.h"
-#include "gui.h"
-#include "../lua/llua.h"
 #include "../logging.h"
+#include "../lua/llua.h"
+#include "display-output.hh"
+#include "gui.h"
 
 #include "../lua/fonts.h"
 
@@ -636,7 +636,9 @@ bool display_output_wayland::main_loop_wait(double t) {
   int ep_count = epoll_wait(epoll_fd, ep, ARRAY_LENGTH(ep), ms);
 
   if (ep_count > 0) {
-    if (ep[0].events & (EPOLLERR | EPOLLHUP)) { SYSTEM_ERR("wayland output closed unexpectedly"); }
+    if (ep[0].events & (EPOLLERR | EPOLLHUP)) {
+      SYSTEM_ERR("wayland output closed unexpectedly");
+    }
   }
 
   int read_status = 0;
@@ -952,7 +954,7 @@ void display_output_wayland::clear_text(int exposures) {
                         color.blue / 255.0, color.alpha / 255.0);
   cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
   cairo_rectangle(cr, 0, 0, window->rectangle.width(),
-                    window->rectangle.height());
+                  window->rectangle.height());
   cairo_fill(cr);
   cairo_restore(cr);
 }
@@ -975,8 +977,7 @@ int display_output_wayland::font_descent(unsigned int f) {
   return pango_fonts[f].metrics.descent;
 }
 
-void display_output_wayland::setup_fonts(void) { /* Nothing to do here */
-}
+void display_output_wayland::setup_fonts(void) { /* Nothing to do here */ }
 
 void display_output_wayland::set_font(unsigned int f) {
   assert(f < pango_fonts.size());
@@ -1077,7 +1078,8 @@ static struct wl_shm_pool *make_shm_pool(struct wl_shm *shm, int size,
 
   fd = os_create_anonymous_file(size);
   if (fd < 0) {
-    LOG_ERROR("creating a buffer file for {}B failed: {}", size, strerror(errno));
+    LOG_ERROR("creating a buffer file for {}B failed: {}", size,
+              strerror(errno));
     return NULL;
   }
 
@@ -1273,7 +1275,8 @@ void window_commit_buffer(struct window *window) {
   wl_surface_set_buffer_scale(global_window->surface,
                               global_window->pending_scale);
   wl_surface_attach(window->surface,
-                    get_buffer_from_cairo_surface(window->cairo_surface.get()), 0, 0);
+                    get_buffer_from_cairo_surface(window->cairo_surface.get()),
+                    0, 0);
   /* repaint all the pixels in the surface, change size to only repaint changed
    * area*/
   wl_surface_damage(window->surface, window->rectangle.x(),

--- a/src/output/display-x11.cc
+++ b/src/output/display-x11.cc
@@ -259,7 +259,7 @@ bool display_output_x11::main_loop_wait(double t) {
 
   if (XPending(display) == 0) {
     fd_set fdsr;
-    struct timeval tv {};
+    struct timeval tv{};
     int s;
     // t = next_update_time - get_time();
 
@@ -309,18 +309,19 @@ bool display_output_x11::main_loop_wait(double t) {
         if (use_xpmdb.get(*state)) {
           XFreePixmap(display, window.back_buffer);
           unsigned int depth = window.color_depth != 0
-                                  ? window.color_depth
-                                  : DefaultDepth(display, screen);
-          window.back_buffer = XCreatePixmap(
-              display, window.window, window.geometry.width(),
-              window.geometry.height(), depth);
+                                   ? window.color_depth
+                                   : DefaultDepth(display, screen);
+          window.back_buffer =
+              XCreatePixmap(display, window.window, window.geometry.width(),
+                            window.geometry.height(), depth);
 
           if (window.back_buffer != None) {
             window.drawable = window.back_buffer;
           } else {
             // this is probably reallllly bad
             LOG_ERROR("failed to allocate back buffer for window {:#x} ({}x{})",
-                      window.window, window.geometry.width(), window.geometry.height());
+                      window.window, window.geometry.width(),
+                      window.geometry.height());
           }
           unsigned long bg = 0;
           if (window.color_depth == argb8888_color_depth) {
@@ -478,8 +479,8 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
   bool inside_geometry = window.geometry.contains(data->pos_absolute);
   bool cursor_over_conky = false;
   if (inside_geometry) {
-    Window event_window = query_x11_window_at_pos(
-        display, data->pos_absolute, data->device->master);
+    Window event_window = query_x11_window_at_pos(display, data->pos_absolute,
+                                                  data->device->master);
     if (window_top_parent == None) {
       window_top_parent = query_x11_top_parent(display, window.window);
     }
@@ -488,8 +489,8 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
     cursor_over_conky = same_window;
   }
   LOG_TRACE_WITH(({"pos", data->pos_absolute}, {"geom", window.geometry}),
-                 "xi event: type={} inside_geom={} over_conky={}",
-                 data->evtype, inside_geometry, cursor_over_conky);
+                 "xi event: type={} inside_geom={} over_conky={}", data->evtype,
+                 inside_geometry, cursor_over_conky);
 
   // XInput reports events twice on some hardware (even by 'xinput --test-xi2')
   auto hash = std::make_tuple(data->serial, data->evtype, data->event);
@@ -570,12 +571,11 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
         scroll_direction = (vertical_value * increment) < 0.0
                                ? scroll_direction_t::UP
                                : scroll_direction_t::DOWN;
-        LOG_TRACE_WITH(({"vertical", vertical_value},
-                        {"increment", increment},
-                        {"product", vertical_value * increment}),
-                       "xi scroll dir={}",
-                       scroll_direction == scroll_direction_t::UP ? "UP"
-                                                                  : "DOWN");
+        LOG_TRACE_WITH(
+            ({"vertical", vertical_value}, {"increment", increment},
+             {"product", vertical_value * increment}),
+            "xi scroll dir={}",
+            scroll_direction == scroll_direction_t::UP ? "UP" : "DOWN");
       } else {
         auto horizontal = data->valuator_relative_value(valuator_t::SCROLL_X);
         double horizontal_value = horizontal.value_or(0.0);
@@ -596,8 +596,8 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
     }
   } else if (cursor_over_conky && (data->evtype == XI_ButtonPress ||
                                    data->evtype == XI_ButtonRelease)) {
-    LOG_TRACE("xi button: detail={} type={}",
-              data->detail, data->evtype == XI_ButtonPress ? "press" : "release");
+    LOG_TRACE("xi button: detail={} type={}", data->detail,
+              data->evtype == XI_ButtonPress ? "press" : "release");
     if (data->detail >= 4 && data->detail <= 7) {
       // Fallback: use button 4-7 as scroll if this device has no independent
       // scroll valuators (e.g. Xephyr aliases scroll and move axes).
@@ -875,8 +875,9 @@ void display_output_x11::cleanup() {
 void display_output_x11::set_foreground_color(Colour c) {
   current_color = c;
   current_color.alpha = window.opacity;
-  XSetForeground(display, window.gc,
-                 current_color.to_x11_color(display, screen, window.opacity < 0xff));
+  XSetForeground(
+      display, window.gc,
+      current_color.to_x11_color(display, screen, window.opacity < 0xff));
 }
 
 int display_output_x11::calc_text_width(const char *s) {
@@ -905,7 +906,8 @@ void display_output_x11::draw_string_at(int x, int y, const char *s, int w) {
     XColor c{};
     XftColor c2{};
 
-    c.pixel = current_color.to_x11_color(display, screen, window.opacity < 0xff);
+    c.pixel =
+        current_color.to_x11_color(display, screen, window.opacity < 0xff);
     // query color on custom colormap
     XQueryColor(display, window.colourmap, &c);
 
@@ -1157,11 +1159,10 @@ void display_output_x11::load_fonts(bool utf8) {
 
 #ifdef BUILD_LUA_CAIRO_XLIB
 void display_output_x11::update_surface() {
-  current_surface.reset(
-      cairo_xlib_surface_create(display, window.drawable, window.visual,
-                                window.geometry.width(),
-                                window.geometry.height()),
-      cairo_surface_destroy);
+  current_surface.reset(cairo_xlib_surface_create(
+                            display, window.drawable, window.visual,
+                            window.geometry.width(), window.geometry.height()),
+                        cairo_surface_destroy);
 }
 #endif /* BUILD_LUA_CAIRO_XLIB */
 

--- a/src/output/display-x11.hh
+++ b/src/output/display-x11.hh
@@ -30,8 +30,8 @@
 #include <string>
 #include <type_traits>
 
-#include "display-output.hh"
 #include "../lua/luamm.hh"
+#include "display-output.hh"
 
 namespace conky {
 

--- a/src/output/gui.cc
+++ b/src/output/gui.cc
@@ -28,9 +28,9 @@
  */
 #include "gui.h"
 #include "../common.h"
-#include "config.h"
 #include "../conky.h"
 #include "../logging.h"
+#include "config.h"
 
 #ifdef BUILD_X11
 #include "../lua/x11-settings.h"
@@ -79,7 +79,8 @@ void own_window_setting::lua_setter(lua::state &l, bool init) {
   if (init) {
     if (do_convert(l, -1).first) {
 #ifndef OWN_WINDOW
-      LOG_WARNING("own_window support disabled at compile time, ignoring setting");
+      LOG_WARNING(
+          "own_window support disabled at compile time, ignoring setting");
       l.pop();
       l.pushboolean(false);
 #endif
@@ -238,9 +239,7 @@ Colour get_background_colour_preference(lua::state &l) {
   if (own_window_argb_value.get(l) < 0xff) {
     background.alpha = own_window_argb_value.get(l);
   }
-  if (set_transparent.get(l)) {
-    background.alpha = 0;
-  }
+  if (set_transparent.get(l)) { background.alpha = 0; }
 
   return background;
 }

--- a/src/output/wl.cc
+++ b/src/output/wl.cc
@@ -42,9 +42,7 @@ void out_to_wayland_setting::lua_setter(lua::state &l, bool init) {
 
   Base::lua_setter(l, init);
 
-  if (init && do_convert(l, -1).first) {
-    LOG_DEBUG("wayland output enabled");
-  }
+  if (init && do_convert(l, -1).first) { LOG_DEBUG("wayland output enabled"); }
 
   ++s;
 }

--- a/src/output/x11-color.cc
+++ b/src/output/x11-color.cc
@@ -24,7 +24,8 @@ unsigned long Colour::to_x11_color(Display *display, int screen,
     xcolor.green = this->green * 257;
     xcolor.blue = this->blue * 257;
     if (XAllocColor(display, DefaultColormap(display, screen), &xcolor) == 0) {
-      LOG_WARNING("can't allocate X color ({}, {}, {})", this->red, this->green, this->blue);
+      LOG_WARNING("can't allocate X color ({}, {}, {})", this->red, this->green,
+                  this->blue);
       return 0;
     }
 

--- a/src/output/x11.h
+++ b/src/output/x11.h
@@ -74,18 +74,19 @@ struct conky_x11_window {
   Visual *visual;
   Colormap colourmap;
   GC gc;
-  
+
   /// Background opacity of the window (0-255).
-  /// 
+  ///
   /// This is set directly by lua settings - read them directly from
   /// backend-agnostic code.
   uint8_t opacity;
   /// Window buffer color depth.
-  /// 
+  ///
   /// Value `32` means X11 supports ARGB8888 (has a compositor).
-  /// Value `24` means only full background transparency is supported (no compositor).
-  /// Value `0` means `CopyFromParent`, i.e. default value, which is always `24`.
-  /// 
+  /// Value `24` means only full background transparency is supported (no
+  /// compositor). Value `0` means `CopyFromParent`, i.e. default value, which
+  /// is always `24`.
+  ///
   /// It can be something other than those 3 values (e.g. monochrome displays),
   /// but that's exceedingly rare.
   uint8_t color_depth;
@@ -176,7 +177,8 @@ Window query_x11_top_parent(Display *display, Window child);
 /// @param y screen Y position contained by window
 /// @param device_id pointer device id to be queried
 /// @return a top-most window at provided screen coordinates, or root
-Window query_x11_window_at_pos(Display *display, conky::vec2i pos, int device_id);
+Window query_x11_window_at_pos(Display *display, conky::vec2i pos,
+                               int device_id);
 
 /// @brief Returns a list of windows overlapping provided screen coordinates.
 ///

--- a/src/update-cb.cc
+++ b/src/update-cb.cc
@@ -44,7 +44,7 @@ void callback_base::stop() {
     if (pipefd.second >= 0) {
       if (write(pipefd.second, "X", 1) != 1) {
         LOG_ERROR("can't write 'X' to pipefd {}: {}", pipefd.second,
-                 strerror(errno));
+                  strerror(errno));
       }
     }
     thread->join();

--- a/tests/test-algebra.cc
+++ b/tests/test-algebra.cc
@@ -1,7 +1,7 @@
 #include "catch2/catch.hpp"
 
-#include <content/algebra.h>
 #include <config.h>
+#include <content/algebra.h>
 
 TEST_CASE("GetMatchTypeTest - ValidOperators") {
   REQUIRE(get_match_type("a==b") == OP_EQ);

--- a/tests/test-colours.cc
+++ b/tests/test-colours.cc
@@ -1,7 +1,7 @@
 #include "catch2/catch.hpp"
 
-#include <content/colours.hh>
 #include <config.h>
+#include <content/colours.hh>
 
 TEST_CASE("parse_color correctly parses colours", "[colours][parse_color]") {
   SECTION("parsing abbreviated hex color") {

--- a/tests/test-graph.cc
+++ b/tests/test-graph.cc
@@ -50,11 +50,14 @@ struct graph {
   Colour first_colour, last_colour;
   double scale;
   char tempgrad;
+  char speedgraph;
+  char invertflag;
+  int minheight;
 };
 
 static std::pair<struct graph, bool> test_parse(const char *s) {
   struct text_object obj;
-  bool result = scan_graph(&obj, s, default_scale,FALSE);
+  bool result = scan_graph(&obj, s, default_scale, FALSE);
   auto g = static_cast<struct graph *>(obj.special_data);
   struct graph graph = *g;
   obj.callbacks.free(&obj);
@@ -195,6 +198,24 @@ TEST_CASE("scan_graph correctly parses input strings") {
       REQUIRE(g.tempgrad == true);
     }
   }
+
+  SECTION("-m location") {
+    {
+      auto [g, success] = test_parse("-m 4 21,340 red blue 0.5");
+      REQUIRE(success);
+      REQUIRE(g.minheight == 4);
+    }
+    {
+      auto [g, success] = test_parse("-m4 21,340 red blue 0.5");
+      REQUIRE(success);
+      REQUIRE(g.minheight == 4);
+    }
+    {
+      auto [g, success] = test_parse("21,340 red blue 0.5 -m 4");
+      REQUIRE(success);
+      REQUIRE(g.minheight == 4);
+    }
+  }
 }
 
 TEST_CASE("graph slot reuse across draw cycles") {
@@ -220,7 +241,8 @@ TEST_CASE("graph slot reuse across draw cycles") {
     free_specials_list();
   }
 
-  SECTION("graph data is cleared when a different text_object reuses the slot") {
+  SECTION(
+      "graph data is cleared when a different text_object reuses the slot") {
     struct text_object obj1 = {}, obj2 = {};
     scan_graph(&obj1, "2,10", 0.0, FALSE);
     scan_graph(&obj2, "2,10", 0.0, FALSE);

--- a/tests/test-linux-proc.cc
+++ b/tests/test-linux-proc.cc
@@ -59,8 +59,8 @@ void ensure_lua_state() {
 }
 
 struct sub_text_object {
-  struct text_object root {};
-  struct text_object obj {};
+  struct text_object root{};
+  struct text_object obj{};
 
   explicit sub_text_object(const char *text) {
     obj_be_plain_text(&obj, text);
@@ -181,7 +181,7 @@ TEST_CASE("cmdline_to_pid finds the current process",
   std::string cmdline = read_cmdline();
   REQUIRE_FALSE(cmdline.empty());
 
-  struct text_object obj {};
+  struct text_object obj{};
   obj.data.s = strdup(cmdline.c_str());
 
   char buf[32]{};
@@ -212,7 +212,7 @@ TEST_CASE("pid_time handles comm with spaces", "[proc][pid_time]") {
 
   std::string pid_str = std::to_string(getpid());
   sub_text_object sub(pid_str.c_str());
-  struct text_object obj {};
+  struct text_object obj{};
   obj.sub = &sub.root;
 
   char buf[64]{};
@@ -239,7 +239,7 @@ TEST_CASE("pid_time_kernelmode uses system time",
 
   std::string pid_str = std::to_string(getpid());
   sub_text_object sub(pid_str.c_str());
-  struct text_object obj {};
+  struct text_object obj{};
   obj.sub = &sub.root;
 
   char buf[64]{};
@@ -265,7 +265,7 @@ TEST_CASE("pid_time_usermode uses user time", "[proc][pid_time_usermode]") {
 
   std::string pid_str = std::to_string(getpid());
   sub_text_object sub(pid_str.c_str());
-  struct text_object obj {};
+  struct text_object obj{};
   obj.sub = &sub.root;
 
   char buf[64]{};
@@ -283,7 +283,7 @@ TEST_CASE("pid_thread_list does not overflow small buffers",
 
   std::string pid_str = std::to_string(getpid());
   sub_text_object sub(pid_str.c_str());
-  struct text_object obj {};
+  struct text_object obj{};
   obj.sub = &sub.root;
 
   constexpr size_t k_buf_size = 8;
@@ -312,7 +312,7 @@ TEST_CASE("pid_environ reads values from /proc environ",
   std::string pid_str = std::to_string(getpid());
   std::string arg = pid_str + " PATH";
   sub_text_object sub(arg.c_str());
-  struct text_object obj {};
+  struct text_object obj{};
   obj.sub = &sub.root;
 
   std::vector<char> buf(strlen(expected) + 1);
@@ -330,7 +330,7 @@ TEST_CASE("pid_state_short returns the short state",
 
   std::string pid_str = std::to_string(getpid());
   sub_text_object sub(pid_str.c_str());
-  struct text_object obj {};
+  struct text_object obj{};
   obj.sub = &sub.root;
 
   char buf[8]{};
@@ -360,7 +360,7 @@ TEST_CASE("pid_vm values map to correct status entries", "[proc][pid_vm]") {
 
   std::string pid_str = std::to_string(child);
   sub_text_object sub(pid_str.c_str());
-  struct text_object obj {};
+  struct text_object obj{};
   obj.sub = &sub.root;
 
   char buf[64]{};


### PR DESCRIPTION
## Summary

Run the repository clang-format target across the configured C and C++ source set, and fix `scan_graph()` MINHEIGHT parsing when `-m` appears at the start of the argument string.

## User Impact

Formatting now matches the current clang-format rules. Graph arguments beginning with `-m` no longer risk undefined behavior from pointer arithmetic on a null pointer.

## Root Cause

The formatter output had drifted from the source tree. Separately, `scan_graph()` detected a leading `-m` with `strncmp()` but only initialized the parse pointer from `strstr(argstr, " " MINHEIGHT)`, which is null for leading `-m` arguments.

## Fix

Apply `mise run format` across the configured source and test files. For MINHEIGHT parsing, initialize the parse pointer from the actual match location, advance past `-m`, skip optional whitespace with a bounds check, and parse digits without reading beyond the argument string. Add regression coverage for leading `-m` with and without whitespace.

## Validation

- `mise r format`
- `cmake --build build --target test-conky`
- `./build/tests/test-conky "scan_graph correctly parses input strings"`
- `mise r check-format`
- `git diff --check`
- pre-commit `cpp-linter` hook passed during commit
