### PR TITLE
build: install lefthook hooks on enter

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,11 +7,11 @@ pre-commit:
           && git add {staged_files}
       root: web/
       glob: '*.{ts,tsx,js,jsx}'
-    cpp-linter:
+    cpp-formatter:
       run: |
         clang-format -i {staged_files} \
           && git add {staged_files}
-      glob: '*.{c,cc,cxx,h,hh,cpp}'
+      glob: '*.{c,cc,cxx,cpp,h,hh,hpp,hxx}'
     misc-linter:
       run: |
         bunx --bun prettier --write {staged_files} \

--- a/mise.toml
+++ b/mise.toml
@@ -10,7 +10,7 @@ ninja = "1.13.2"
 uv = "0.11.16"
 
 [hooks]
-enter = "mise i -q"
+enter = "mise i -q && lefthook install >/dev/null"
 
 [tasks.doctor]
 description = "Check developer tools and common native build dependencies"


### PR DESCRIPTION
## Summary

Install Lefthook git hooks automatically when entering the repository through mise, and extend the pre-commit C/C++ formatter job to cover additional C++ header extensions.

## User Impact

Contributors who use mise get the repository's git hooks installed without a separate setup step, so staged source formatting runs consistently before commits. The enter hook keeps the hook installation quiet to avoid repeated terminal noise when entering the repo.

## Root Cause

The mise enter hook only installed pinned tools, leaving Lefthook installation as a manual `mise run install-hooks` step. The existing C/C++ pre-commit formatter also omitted `.hpp` and `.hxx` files from its staged-file glob.

## Fix

The mise enter hook now runs `mise i -q && lefthook install >/dev/null`, preserving quiet tool installation while silently syncing Lefthook hooks. The Lefthook C/C++ formatter command was renamed to `cpp-formatter` and its glob now includes `.hpp` and `.hxx` alongside the existing C/C++ extensions.

## Validation

- `lefthook validate`
- `mise i -q && lefthook install >/dev/null`
- `mise tasks ls | rg "install-hooks|configure|doctor"`
