### PR TITLE
Fix event propagation

### DIFF
--- a/src/output/display-x11.cc
+++ b/src/output/display-x11.cc
@@ -516,9 +516,6 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
   }
 
 #ifdef BUILD_MOUSE_EVENTS
-  // Events not over conky should always propagate to underlying windows.
-  if (!cursor_over_conky) { *consumed = false; }
-
   // query_result is not window.window in some cases.
   modifier_state_t mods = x11_modifier_state(data->mods.effective);
 
@@ -625,10 +622,14 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
     *consumed = llua_mouse_hook(mouse_button_event(
         type, data->pos, data->pos_absolute, button.value(), mods));
   }
-#endif /* BUILD_MOUSE_EVENTS */
-#ifndef BUILD_MOUSE_EVENTS
-  // always propagate mouse input if not handling mouse events
-  *consumed = false;
+  // Events not over conky are received via passive XISelectEvents on the root
+  // window; the X server already delivers them to their targets, so
+  // re-propagating via XSendEvent would create duplicates.
+  if (!cursor_over_conky) { *consumed = true; }
+#else /* !BUILD_MOUSE_EVENTS */
+  // Events over conky were intercepted by our window; propagate since we have
+  // no handler. Events elsewhere are already delivered by the X server.
+  if (cursor_over_conky) { *consumed = false; }
 #endif /* BUILD_MOUSE_EVENTS */
 
   LOG_TRACE("xi event pre-window-type: consumed={}", *consumed);


### PR DESCRIPTION
Fixed a mouse event propagation regression introduced by 1fd63f44 in display-x11.cc causing duplicate clicks and scroll events on other windows.

- [x] Closes #2367
- [x] Closes #2375