### PR TITLE
Fix BUILD_LUA_CAIRO not adding cairo to conky_libs

### DIFF
--- a/cmake/ConkyPlatformChecks.cmake
+++ b/cmake/ConkyPlatformChecks.cmake
@@ -732,9 +732,10 @@ if(BUILD_LUA_CAIRO)
     pkg_check_modules(CAIROXLIB REQUIRED cairo-xlib)
     set(luacairo_libs ${CAIROXLIB_LINK_LIBRARIES} ${luacairo_libs})
     set(luacairo_includes ${CAIROXLIB_INCLUDE_DIRS} ${luacairo_includes})
-    set(conky_libs ${conky_libs} ${luacairo_libs})
-    set(conky_includes ${conky_includes} ${luacairo_includes})
   endif(BUILD_LUA_CAIRO_XLIB)
+
+  set(conky_libs ${conky_libs} ${luacairo_libs})
+  set(conky_includes ${conky_includes} ${luacairo_includes})
 
   find_program(APP_PATCH patch)
 


### PR DESCRIPTION
When BUILD_LUA_CAIRO=ON but BUILD_LUA_CAIRO_XLIB=OFF, Cairo wasn't being added to conky_libs even though llua.cc needs it.

- [x] Can build with BUILD_LUA_CAIRO=ON + BUILD_LUA_CAIRO_XLIB=OFF now.