### PR TITLE
fix(x11): preserve root button propagation

### DIFF
--- a/src/output/display-x11.cc
+++ b/src/output/display-x11.cc
@@ -638,14 +638,15 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
     *consumed = llua_mouse_hook(mouse_button_event(
         type, data->pos, data->pos_absolute, button.value(), mods));
   }
-  if (!cursor_over_conky) {
-    *consumed = !should_replay_off_conky_xi_event(*data);
-  }
 #else  /* !BUILD_MOUSE_EVENTS */
   // Events over conky were intercepted by our window; propagate since we have
   // no handler. Events elsewhere are already delivered by the X server.
   if (cursor_over_conky) { *consumed = false; }
 #endif /* BUILD_MOUSE_EVENTS */
+
+  if (!cursor_over_conky) {
+    *consumed = !should_replay_off_conky_xi_event(*data);
+  }
 
   LOG_TRACE("xi event pre-window-type: consumed={}", *consumed);
   if (!own_window.get(*state)) return true;

--- a/src/output/display-x11.cc
+++ b/src/output/display-x11.cc
@@ -433,9 +433,16 @@ static bool is_xi_button_event(const conky::xi_event_data &data) {
   return data.evtype == XI_ButtonPress || data.evtype == XI_ButtonRelease;
 }
 
-static bool is_xi_root_button_event(const conky::xi_event_data &data) {
+static bool is_xi_root_button3_event(const conky::xi_event_data &data) {
   return data.event == data.root && data.child == None &&
-         is_xi_button_event(data);
+         is_xi_button_event(data) && data.detail == Button3;
+}
+
+static bool should_replay_off_conky_xi_event(const conky::xi_event_data &data) {
+  // Off-Conky child-window events are already delivered by the X server.
+  // Replaying them would duplicate input. Root Button3 events are the narrow
+  // compatibility case needed by WMs that use root right-click menus.
+  return is_xi_root_button3_event(data);
 }
 
 template <x_event_handler handler>
@@ -631,12 +638,9 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
     *consumed = llua_mouse_hook(mouse_button_event(
         type, data->pos, data->pos_absolute, button.value(), mods));
   }
-  // Events not over conky are received via passive XISelectEvents on the root
-  // window; the X server already delivers child-window events to their targets,
-  // so re-propagating those would create duplicates. Root-targeted button
-  // events still need the legacy propagation path for WMs that listen for root
-  // clicks.
-  if (!cursor_over_conky) { *consumed = !is_xi_root_button_event(*data); }
+  if (!cursor_over_conky) {
+    *consumed = !should_replay_off_conky_xi_event(*data);
+  }
 #else  /* !BUILD_MOUSE_EVENTS */
   // Events over conky were intercepted by our window; propagate since we have
   // no handler. Events elsewhere are already delivered by the X server.

--- a/src/output/display-x11.cc
+++ b/src/output/display-x11.cc
@@ -429,6 +429,14 @@ enum class x_event_handler {
   DAMAGE,
 };
 
+bool is_xi_button_event(const conky::xi_event_data &data) {
+  return data.evtype == XI_ButtonPress || data.evtype == XI_ButtonRelease;
+}
+
+bool is_xi_root_button_event(const conky::xi_event_data &data) {
+  return data.child == None && is_xi_button_event(data);
+}
+
 template <x_event_handler handler>
 bool handle_event(conky::display_output_x11 *surface, Display *display,
                   XEvent &ev, bool *consumed, void **cookie) {
@@ -623,10 +631,12 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
         type, data->pos, data->pos_absolute, button.value(), mods));
   }
   // Events not over conky are received via passive XISelectEvents on the root
-  // window; the X server already delivers them to their targets, so
-  // re-propagating via XSendEvent would create duplicates.
-  if (!cursor_over_conky) { *consumed = true; }
-#else /* !BUILD_MOUSE_EVENTS */
+  // window; the X server already delivers child-window events to their targets,
+  // so re-propagating those would create duplicates. Root-targeted button
+  // events still need the legacy propagation path for WMs that listen for root
+  // clicks.
+  if (!cursor_over_conky) { *consumed = !is_xi_root_button_event(*data); }
+#else  /* !BUILD_MOUSE_EVENTS */
   // Events over conky were intercepted by our window; propagate since we have
   // no handler. Events elsewhere are already delivered by the X server.
   if (cursor_over_conky) { *consumed = false; }

--- a/src/output/display-x11.cc
+++ b/src/output/display-x11.cc
@@ -429,12 +429,13 @@ enum class x_event_handler {
   DAMAGE,
 };
 
-bool is_xi_button_event(const conky::xi_event_data &data) {
+static bool is_xi_button_event(const conky::xi_event_data &data) {
   return data.evtype == XI_ButtonPress || data.evtype == XI_ButtonRelease;
 }
 
-bool is_xi_root_button_event(const conky::xi_event_data &data) {
-  return data.child == None && is_xi_button_event(data);
+static bool is_xi_root_button_event(const conky::xi_event_data &data) {
+  return data.event == data.root && data.child == None &&
+         is_xi_button_event(data);
 }
 
 template <x_event_handler handler>


### PR DESCRIPTION
## Summary

Preserve X11 root-window button propagation for mouse events that are not over Conky. This fixes #2386.

## User Impact

Openbox users can right-click the root window to open the desktop menu again while Conky is running. Normal application-window clicks and scrolls still avoid duplicate synthetic propagation.

## Root Cause

Conky receives XI2 events from a passive selection on the root window. The previous propagation regression fix consumed every off-Conky event because child-window events are already delivered by the X server, but that also consumed root-targeted button events that window managers handle through the legacy root-click path.

## Fix

Classify XI2 button events whose `child` is `None` as root-button events and leave those eligible for the existing legacy propagation path. Continue consuming other off-Conky XI2 events to avoid duplicate delivery to child windows.

## Validation

- `clang-format --dry-run --Werror src/output/display-x11.cc`
- `mise run build`
- `mise run test`
