### PR TITLE
chore: apply clang-format

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -1191,9 +1191,7 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
 
             /* if no width was specified, current->width is set to 0 */
             w = current->width;
-            if (w <= 0 || w > max_width) {
-              w = max_width;
-            }
+            if (w <= 0 || w > max_width) { w = max_width; }
 
             if (display_output()) {
               display_output()->set_line_style(h, true);
@@ -1215,9 +1213,7 @@ int draw_each_line_inner(char *s, int special_index, int last_special_applied) {
 
             /* if no width was specified, current->width is set to 0 */
             w = current->width;
-            if (w <= 0 || w > max_width) {
-              w = max_width;
-            }
+            if (w <= 0 || w > max_width) { w = max_width; }
 
             if (display_output()) {
               display_output()->set_line_style(h, false);

--- a/src/output/display-x11.cc
+++ b/src/output/display-x11.cc
@@ -626,7 +626,7 @@ bool handle_event<x_event_handler::MOUSE_INPUT>(
   // window; the X server already delivers them to their targets, so
   // re-propagating via XSendEvent would create duplicates.
   if (!cursor_over_conky) { *consumed = true; }
-#else /* !BUILD_MOUSE_EVENTS */
+#else  /* !BUILD_MOUSE_EVENTS */
   // Events over conky were intercepted by our window; propagate since we have
   // no handler. Events elsewhere are already delivered by the X server.
   if (cursor_over_conky) { *consumed = false; }


### PR DESCRIPTION
## Summary

Applies the repository clang-format rules to the existing C++ code. The branch only changes formatting in `src/conky.cc` and `src/output/display-x11.cc`.

## User Impact

No runtime behavior should change. This keeps the codebase aligned with the expected formatter output so contributors and CI do not see avoidable formatting failures.

## Root Cause

A small amount of checked-in code did not match the current clang-format style produced by the maintainer build configuration.

## Fix

Ran the project formatting workflow through `mise run format`, which invokes the configured CMake `clang-format` target.

## Validation

- `mise run doctor`
- `mise run configure`
- `mise run format`
- `mise run check-format`
