### PR TITLE
feat: wayland improvements

### DIFF
--- a/doc/config_settings.yaml
+++ b/doc/config_settings.yaml
@@ -454,8 +454,10 @@ values:
     default: 'conky (<hostname>)'
   - name: own_window_type
     desc: |-
-      If `own_window` is set, under X11 you can specify type of window conky
-      displayed as:
+      Specifies the type of window conky is displayed as. Under X11 this
+      requires `own_window` to be set; under Wayland it selects the
+      wlr-layer-shell layer the surface is mounted on (and, for `dock`/`panel`,
+      whether it reserves screen space via an exclusive zone). Available types:
 
       - `normal` mode makes conky show as normal window. This mode can be
         configured with use of [`own_window_hints`](#own_window_hints) setting.
@@ -475,7 +477,9 @@ values:
         position and size, and workarea dimensions, to ensure normal windows
         have most free space available. For WMs that "cut out" entirely covered
         screens from reserved area, the edge will be chosen based on `alignment`
-        setting.
+        setting. Under Wayland the reserved edge is always derived from
+        `alignment`; a fully centered (`mm`) alignment has no edge to reserve
+        against, so use an edge-aligned value (e.g. `tm`, `bm`, `ml`, `mr`).
       - `utility` windows are persistent utility windows (e.g. a palette or
         toolbox). They appear on top of other windows (in the same group), but
         otherwise behave much like `normal` windows.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -369,6 +369,8 @@ if(BUILD_WAYLAND)
   set(wl_sources
     output/wl.cc
     output/wl.h
+    output/wl-shell.cc
+    output/wl-shell.h
     output/display-wayland.cc
     output/display-wayland.hh
     xdg-shell-protocol.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -384,6 +384,8 @@ if(BUILD_WAYLAND)
       "${CMAKE_CURRENT_SOURCE_DIR}/wl_protocols" # first for reproducibility
       "${Wayland_PROTOCOLS_DIR}/stable/${name}"
       "${Wayland_PROTOCOLS_DIR}/stable"
+      "${Wayland_PROTOCOLS_DIR}/staging/${name}"
+      "${Wayland_PROTOCOLS_DIR}/staging"
       "${Wayland_PROTOCOLS_DIR}/unstable/${name}"
       "${Wayland_PROTOCOLS_DIR}/unstable"
     )
@@ -430,6 +432,10 @@ if(BUILD_WAYLAND)
   
   add_protocol(xdg-shell)
   add_protocol(wlr-layer-shell v1)
+  add_protocol(viewporter)
+  # fractional-scale-v1 is vendored in wl_protocols/ (found first), so the build
+  # doesn't require a recent (>=1.31) system wayland-protocols package.
+  add_protocol(fractional-scale v1)
 
   set(optional_sources ${optional_sources} ${wl_sources})
 endif(BUILD_WAYLAND)

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -362,6 +362,48 @@ struct vec {
   operator std::array<T, Length>() const { return this->to_array(); }
 };
 
+/// @brief Component-wise `Vc::floor` of a floating-point vector.
+///
+/// Uses Vc's SIMD `floor` rather than the scalar `std::floor`. The vec storage
+/// is a `Vc::array` (no SIMD math), so the values are routed through a
+/// `Vc::SimdArray` for the operation.
+template <typename T, size_t Length,
+          std::enable_if_t<std::is_floating_point_v<T>, int> = 0>
+inline vec<T, Length> floor(const vec<T, Length> &v) {
+  std::array<T, Length> data = v.to_array();
+  Vc::SimdArray<T, Length> simd(data.data(), Vc::Unaligned);
+  Vc::floor(simd).store(data.data(), Vc::Unaligned);
+  return vec<T, Length>(data);
+}
+
+/// @brief No-op `floor` for integral vectors; they are already whole numbers.
+template <typename T, size_t Length,
+          std::enable_if_t<!std::is_floating_point_v<T>, int> = 0>
+inline vec<T, Length> floor(const vec<T, Length> &v) {
+  return v;
+}
+
+/// @brief Component-wise `Vc::ceil` of a floating-point vector.
+///
+/// Uses Vc's SIMD `ceil` rather than the scalar `std::ceil`. The vec storage is
+/// a `Vc::array` (no SIMD math), so the values are routed through a
+/// `Vc::SimdArray` for the operation.
+template <typename T, size_t Length,
+          std::enable_if_t<std::is_floating_point_v<T>, int> = 0>
+inline vec<T, Length> ceil(const vec<T, Length> &v) {
+  std::array<T, Length> data = v.to_array();
+  Vc::SimdArray<T, Length> simd(data.data(), Vc::Unaligned);
+  Vc::ceil(simd).store(data.data(), Vc::Unaligned);
+  return vec<T, Length>(data);
+}
+
+/// @brief No-op `ceil` for integral vectors; they are already whole numbers.
+template <typename T, size_t Length,
+          std::enable_if_t<!std::is_floating_point_v<T>, int> = 0>
+inline vec<T, Length> ceil(const vec<T, Length> &v) {
+  return v;
+}
+
 template <typename T>
 using vec2 = vec<T, 2>;
 using vec2f = vec2<float>;

--- a/src/lua/setting.cc
+++ b/src/lua/setting.cc
@@ -84,6 +84,9 @@ priv::config_setting_base *get_setting(lua::state &l, int index) {
 const std::vector<std::string> settings_ordering{
     "display",
     "out_to_x",
+    // out_to_wayland must precede own_window: own_window's setter checks the
+    // active GUI output (out_to_gui) and disables itself when none is set yet.
+    "out_to_wayland",
     "use_xft",
     "font",
     "font0",
@@ -123,7 +126,6 @@ const std::vector<std::string> settings_ordering{
     "own_window_colour",
     "own_window",
     "double_buffer",
-    "out_to_wayland",
     "imlib_cache_size",
 };
 

--- a/src/output/display-wayland.cc
+++ b/src/output/display-wayland.cc
@@ -258,16 +258,16 @@ bool display_output_wayland::detect() {
 }
 
 static int epoll_fd;
-static struct epoll_event ep[1];
+static epoll_event ep[1];
 
-static struct window *global_window;
+static window *global_window;
 static wl_display *global_display;
 
 struct window {
-  struct rect<size_t> rectangle;
-  struct wl_shm *shm;
-  struct wl_surface *surface;
-  struct zwlr_layer_surface_v1 *layer_surface;
+  rect<size_t> rectangle;
+  wl_shm *shm;
+  wl_surface *surface;
+  zwlr_layer_surface_v1 *layer_surface;
   int scale = 1;
   int pending_scale = 1;
   int current_buffer;
@@ -280,27 +280,26 @@ struct window {
 };
 
 struct {
-  struct wl_registry *registry;
-  struct wl_compositor *compositor;
-  struct wl_shm *shm;
-  struct wl_surface *surface;
-  struct wl_seat *seat;
-  struct wl_pointer *pointer;
-  struct wl_output *output;
-  struct xdg_wm_base *shell;
-  struct zwlr_layer_shell_v1 *layer_shell;
+  wl_registry *registry;
+  wl_compositor *compositor;
+  wl_shm *shm;
+  wl_surface *surface;
+  wl_seat *seat;
+  wl_pointer *pointer;
+  wl_output *output;
+  xdg_wm_base *shell;
+  zwlr_layer_shell_v1 *layer_shell;
 } wl_globals;
 
-static void xdg_wm_base_ping(void *data, struct xdg_wm_base *shell,
-                             uint32_t serial) {
+static void xdg_wm_base_ping(void *data, xdg_wm_base *shell, uint32_t serial) {
   xdg_wm_base_pong(shell, serial);
 }
 
-static const struct xdg_wm_base_listener xdg_wm_base_listener = {
+static const xdg_wm_base_listener xdg_wm_base_listener = {
     /*.ping =*/&xdg_wm_base_ping,
 };
 
-static void output_geometry(void *data, struct wl_output *wl_output, int32_t x,
+static void output_geometry(void *data, wl_output *wl_output, int32_t x,
                             int32_t y, int32_t physical_width,
                             int32_t physical_height, int32_t subpixel,
                             const char *make, const char *model,
@@ -316,29 +315,29 @@ static void output_geometry(void *data, struct wl_output *wl_output, int32_t x,
             y + physical_height));  // TODO: use xdg_output.logical_position
 }
 
-static void output_mode(void *data, struct wl_output *wl_output, uint32_t flags,
+static void output_mode(void *data, wl_output *wl_output, uint32_t flags,
                         int32_t width, int32_t height, int32_t refresh) {}
 
 #ifdef WL_OUTPUT_DONE_SINCE_VERSION
-static void output_done(void *data, struct wl_output *wl_output) {}
+static void output_done(void *data, wl_output *wl_output) {}
 #endif
 
 #ifdef WL_OUTPUT_SCALE_SINCE_VERSION
-void output_scale(void *data, struct wl_output *wl_output, int32_t factor) {
+void output_scale(void *data, wl_output *wl_output, int32_t factor) {
   /* For now, assume we have one output and adopt its scale unconditionally. */
   /* We should also re-render immediately when scale changes. */
   global_window->pending_scale = factor;
-  LOG_TRACE_WITH(({"window->scale", global_window->scale}), "recieved scale event: {}", factor);
+  LOG_TRACE_WITH(({"window->scale", global_window->scale}),
+                 "recieved scale event: {}", factor);
 }
 #endif
 
 #ifdef WL_OUTPUT_NAME_SINCE_VERSION
-static void output_name(void *data, struct wl_output *wl_output,
-                        const char *name) {}
+static void output_name(void *data, wl_output *wl_output, const char *name) {}
 #endif
 
 #ifdef WL_OUTPUT_DESCRIPTION_SINCE_VERSION
-static void output_description(void *data, struct wl_output *wl_output,
+static void output_description(void *data, wl_output *wl_output,
                                const char *description) {}
 #endif
 
@@ -359,9 +358,8 @@ static const wl_output_listener output_listener = {
 #endif
 };
 
-void registry_handle_global(void *data, struct wl_registry *registry,
-                            uint32_t name, const char *interface,
-                            uint32_t version) {
+void registry_handle_global(void *data, wl_registry *registry, uint32_t name,
+                            const char *interface, uint32_t version) {
   if (strcmp(interface, "wl_compositor") == 0) {
     wl_globals.compositor = static_cast<wl_compositor *>(
         wl_registry_bind(registry, name, &wl_compositor_interface, 3));
@@ -385,41 +383,40 @@ void registry_handle_global(void *data, struct wl_registry *registry,
   }
 }
 
-void registry_handle_global_remove(void *data, struct wl_registry *registry,
+void registry_handle_global_remove(void *data, wl_registry *registry,
                                    uint32_t name) {}
 
 static const wl_registry_listener registry_listener = {
     registry_handle_global, registry_handle_global_remove};
 
 static void layer_surface_configure(void *data,
-                                    struct zwlr_layer_surface_v1 *layer_surface,
+                                    zwlr_layer_surface_v1 *layer_surface,
                                     uint32_t serial, uint32_t width,
                                     uint32_t height) {
   zwlr_layer_surface_v1_ack_configure(layer_surface, serial);
 }
 
 static void layer_surface_closed(void *data,
-                                 struct zwlr_layer_surface_v1 *layer_surface) {}
+                                 zwlr_layer_surface_v1 *layer_surface) {}
 
 static const zwlr_layer_surface_v1_listener layer_surface_listener = {
     /*.configure =*/&layer_surface_configure,
     /*.closed =*/&layer_surface_closed,
 };
 
-struct window *window_create(struct wl_surface *surface, struct wl_shm *shm,
-                             int width, int height);
+window *window_create(wl_surface *surface, wl_shm *shm, int width, int height);
 
-void window_resize(struct window *window, int width, int height);
+void window_resize(window *window, int width, int height);
 
-void window_allocate_buffer(struct window *window);
+void window_allocate_buffer(window *window);
 
-void window_destroy(struct window *window);
+void window_destroy(window *window);
 
-void window_commit_buffer(struct window *window);
+void window_commit_buffer(window *window);
 
-void window_get_width_height(struct window *window, int *w, int *h);
+void window_get_width_height(window *window, int *w, int *h);
 
-void window_layer_surface_set_size(struct window *window) {
+void window_layer_surface_set_size(window *window) {
   zwlr_layer_surface_v1_set_size(global_window->layer_surface,
                                  global_window->rectangle.width(),
                                  global_window->rectangle.height());
@@ -431,7 +428,7 @@ static std::map<wl_pointer *, vec2<size_t>> last_known_positions{};
 static void on_pointer_enter(void *data, wl_pointer *pointer,
                              std::uint32_t serial, wl_surface *surface,
                              wl_fixed_t surface_x, wl_fixed_t surface_y) {
-  auto w = reinterpret_cast<struct window *>(data);
+  auto w = reinterpret_cast<window *>(data);
 
   auto pos =
       vec2d(wl_fixed_to_double(surface_x), wl_fixed_to_double(surface_y));
@@ -442,9 +439,9 @@ static void on_pointer_enter(void *data, wl_pointer *pointer,
   llua_mouse_hook(event);
 }
 
-static void on_pointer_leave(void *data, struct wl_pointer *pointer,
-                             std::uint32_t serial, struct wl_surface *surface) {
-  auto w = reinterpret_cast<struct window *>(data);
+static void on_pointer_leave(void *data, wl_pointer *pointer,
+                             std::uint32_t serial, wl_surface *surface) {
+  auto w = reinterpret_cast<window *>(data);
 
   auto pos = last_known_positions[pointer];
   auto pos_abs = w->rectangle.pos() + pos;
@@ -453,10 +450,10 @@ static void on_pointer_leave(void *data, struct wl_pointer *pointer,
   llua_mouse_hook(event);
 }
 
-static void on_pointer_motion(void *data, struct wl_pointer *pointer,
+static void on_pointer_motion(void *data, wl_pointer *pointer,
                               std::uint32_t _time, wl_fixed_t surface_x,
                               wl_fixed_t surface_y) {
-  auto w = reinterpret_cast<struct window *>(data);
+  auto w = reinterpret_cast<window *>(data);
 
   auto pos =
       vec2d(wl_fixed_to_double(surface_x), wl_fixed_to_double(surface_y));
@@ -467,10 +464,10 @@ static void on_pointer_motion(void *data, struct wl_pointer *pointer,
   llua_mouse_hook(event);
 }
 
-static void on_pointer_button(void *data, struct wl_pointer *pointer,
+static void on_pointer_button(void *data, wl_pointer *pointer,
                               std::uint32_t serial, std::uint32_t time,
                               std::uint32_t button, std::uint32_t state) {
-  auto w = reinterpret_cast<struct window *>(data);
+  auto w = reinterpret_cast<window *>(data);
 
   auto pos = last_known_positions[pointer];
   auto pos_abs = w->rectangle.pos() + pos;
@@ -495,11 +492,11 @@ static void on_pointer_button(void *data, struct wl_pointer *pointer,
   llua_mouse_hook(event);
 }
 
-void on_pointer_axis(void *data, struct wl_pointer *pointer, std::uint32_t time,
+void on_pointer_axis(void *data, wl_pointer *pointer, std::uint32_t time,
                      std::uint32_t axis, wl_fixed_t value) {
   if (value == 0) return;
 
-  auto w = reinterpret_cast<struct window *>(data);
+  auto w = reinterpret_cast<window *>(data);
 
   auto pos = last_known_positions[pointer];
   auto pos_abs = w->rectangle.pos() + pos;
@@ -545,8 +542,8 @@ static void seat_capability_listener(void *data, wl_seat *seat,
     }
   }
 }
-static void seat_name_listener(void *data, struct wl_seat *wl_seat,
-                               const char *name) {}
+static void seat_name_listener(void *data, wl_seat *wl_seat, const char *name) {
+}
 
 static const wl_seat_listener seat_listener = {
     .capabilities = seat_capability_listener,
@@ -577,8 +574,7 @@ bool display_output_wayland::initialize() {
         "conky");
   }
 
-  struct wl_surface *surface =
-      wl_compositor_create_surface(wl_globals.compositor);
+  wl_surface *surface = wl_compositor_create_surface(wl_globals.compositor);
   global_window = window_create(surface, wl_globals.shm, 1, 1);
   window_allocate_buffer(global_window);
 
@@ -600,10 +596,10 @@ bool display_output_wayland::initialize() {
   return true;
 }
 
-typedef void (*display_global_handler_t)(struct display *display, uint32_t name,
+typedef void (*display_global_handler_t)(display *display, uint32_t name,
                                          const char *interface,
                                          uint32_t version, void *data);
-typedef void (*display_output_handler_t)(struct output *output, void *data);
+typedef void (*display_output_handler_t)(output *output, void *data);
 
 bool display_output_wayland::shutdown() { return false; }
 
@@ -824,7 +820,7 @@ void display_output_wayland::set_foreground_color(Colour c) {
 }
 
 int display_output_wayland::calc_text_width(const char *s) {
-  struct window *window = global_window;
+  window *window = global_window;
   size_t slen = strlen(s);
   pango_layout_set_text(window->layout, s, slen);
   PangoRectangle margin_rect;
@@ -844,7 +840,7 @@ static void adjust_coords(int &x, int &y) {
 
 void display_output_wayland::draw_string_at(int x, int y, const char *s,
                                             int w) {
-  struct window *window = global_window;
+  window *window = global_window;
   auto cr = window->cr.get();
   y -= pango_fonts[selected_font].metrics.ascent;
   adjust_coords(x, y);
@@ -861,7 +857,7 @@ void display_output_wayland::draw_string_at(int x, int y, const char *s,
 }
 
 void display_output_wayland::set_line_style(int w, bool solid) {
-  struct window *window = global_window;
+  window *window = global_window;
   auto cr = window->cr.get();
   static double dashes[2] = {1.0, 1.0};
   if (solid)
@@ -872,7 +868,7 @@ void display_output_wayland::set_line_style(int w, bool solid) {
 }
 
 void display_output_wayland::set_dashes(char *s) {
-  struct window *window = global_window;
+  window *window = global_window;
   auto cr = window->cr.get();
   size_t len = strlen(s);
   double *dashes = new double[len];
@@ -882,7 +878,7 @@ void display_output_wayland::set_dashes(char *s) {
 }
 
 void display_output_wayland::draw_line(int x1, int y1, int x2, int y2) {
-  struct window *window = global_window;
+  window *window = global_window;
   auto cr = window->cr.get();
   adjust_coords(x1, y1);
   adjust_coords(x2, y2);
@@ -927,7 +923,7 @@ void display_output_wayland::fill_rect(int x, int y, int w, int h) {
 
 void display_output_wayland::draw_arc(int x, int y, int w, int h, int a1,
                                       int a2) {
-  struct window *window = global_window;
+  window *window = global_window;
   auto cr = window->cr.get();
   adjust_coords(x, y);
   cairo_save(cr);
@@ -952,7 +948,7 @@ void display_output_wayland::end_draw_stuff() {
 }
 
 void display_output_wayland::clear_text(int exposures) {
-  struct window *window = global_window;
+  window *window = global_window;
   auto cr = window->cr.get();
   cairo_save(cr);
 
@@ -1049,49 +1045,48 @@ void display_output_wayland::load_fonts(bool utf8) {
 }
 
 struct shm_pool {
-  struct wl_shm_pool *pool;
+  wl_shm_pool *pool;
   size_t size;
   size_t used;
   void *data;
 };
 
 struct shm_surface_data {
-  struct wl_buffer *buffer;
-  struct shm_pool *pool;
+  wl_buffer *buffer;
+  shm_pool *pool;
   bool busy;
 };
 
 static const cairo_user_data_key_t shm_surface_data_key = {0};
 
-static void buffer_release(void *data, struct wl_buffer *wl_buffer) {
-  auto *surface_data = static_cast<struct shm_surface_data *>(data);
+static void buffer_release(void *data, wl_buffer *wl_buffer) {
+  auto *surface_data = static_cast<shm_surface_data *>(data);
   surface_data->busy = false;
 }
 
-static const struct wl_buffer_listener buffer_listener = {buffer_release};
+static const wl_buffer_listener buffer_listener = {buffer_release};
 
-struct wl_buffer *get_buffer_from_cairo_surface(cairo_surface_t *surface) {
-  struct shm_surface_data *data;
+wl_buffer *get_buffer_from_cairo_surface(cairo_surface_t *surface) {
+  shm_surface_data *data;
 
-  data = static_cast<struct shm_surface_data *>(
+  data = static_cast<shm_surface_data *>(
       cairo_surface_get_user_data(surface, &shm_surface_data_key));
 
   return data->buffer;
 }
 
-static void shm_pool_destroy(struct shm_pool *pool);
+static void shm_pool_destroy(shm_pool *pool);
 
 static void shm_surface_data_destroy(void *p) {
-  struct shm_surface_data *data = static_cast<struct shm_surface_data *>(p);
+  shm_surface_data *data = static_cast<shm_surface_data *>(p);
   wl_buffer_destroy(data->buffer);
   if (data->pool) shm_pool_destroy(data->pool);
 
   delete data;
 }
 
-static struct wl_shm_pool *make_shm_pool(struct wl_shm *shm, int size,
-                                         void **data) {
-  struct wl_shm_pool *pool;
+static wl_shm_pool *make_shm_pool(wl_shm *shm, int size, void **data) {
+  wl_shm_pool *pool;
   int fd;
 
   fd = os_create_anonymous_file(size);
@@ -1115,8 +1110,8 @@ static struct wl_shm_pool *make_shm_pool(struct wl_shm *shm, int size,
   return pool;
 }
 
-static struct shm_pool *shm_pool_create(struct wl_shm *shm, size_t size) {
-  struct shm_pool *pool = new struct shm_pool;
+static shm_pool *shm_pool_create(wl_shm *shm, size_t size) {
+  shm_pool *pool = new shm_pool;
 
   if (!pool) return NULL;
 
@@ -1132,8 +1127,7 @@ static struct shm_pool *shm_pool_create(struct wl_shm *shm, size_t size) {
   return pool;
 }
 
-static void *shm_pool_allocate(struct shm_pool *pool, size_t size,
-                               int *offset) {
+static void *shm_pool_allocate(shm_pool *pool, size_t size, int *offset) {
   if (pool->used + size > pool->size) return NULL;
 
   *offset = pool->used;
@@ -1143,7 +1137,7 @@ static void *shm_pool_allocate(struct shm_pool *pool, size_t size,
 }
 
 /* destroy the pool. this does not unmap the memory though */
-static void shm_pool_destroy(struct shm_pool *pool) {
+static void shm_pool_destroy(shm_pool *pool) {
   munmap(pool->data, pool->size);
   wl_shm_pool_destroy(pool->pool);
   delete pool;
@@ -1162,15 +1156,15 @@ static int data_length_for_shm_surface(rect<size_t> *rect, int scale) {
 }
 
 static std::shared_ptr<conky::draw_surface> create_shm_surface_from_pool(
-    void *none, rect<size_t> *rectangle, struct shm_pool *pool, int scale) {
-  struct shm_surface_data *data;
+    void *none, rect<size_t> *rectangle, shm_pool *pool, int scale) {
+  shm_surface_data *data;
   uint32_t format;
   cairo_surface_t *surface;
   cairo_format_t cairo_format;
   int stride, length, offset;
   void *map;
 
-  data = new struct shm_surface_data;
+  data = new shm_surface_data;
   if (data == NULL) return NULL;
 
   cairo_format = CAIRO_FORMAT_ARGB32; /*or CAIRO_FORMAT_RGB16_565 who knows??*/
@@ -1205,11 +1199,11 @@ static std::shared_ptr<conky::draw_surface> create_shm_surface_from_pool(
   });
 }
 
-void window_allocate_buffer(struct window *window) {
+void window_allocate_buffer(window *window) {
   assert(window->shm != nullptr);
 
   int scale = window->scale;
-  struct shm_pool *pool;
+  shm_pool *pool;
   pool = shm_pool_create(
       window->shm, data_length_for_shm_surface(&window->rectangle, scale) * 2);
   if (!pool) {
@@ -1231,8 +1225,7 @@ void window_allocate_buffer(struct window *window) {
     cairo_surface_set_device_scale(cs, scale, scale);
 
     /* make sure we destroy the pool when the surface is destroyed */
-    struct shm_surface_data *data;
-    data = static_cast<struct shm_surface_data *>(
+    auto data = static_cast<shm_surface_data *>(
         cairo_surface_get_user_data(cs, &shm_surface_data_key));
     data->pool = (i == 1) ? pool : nullptr;
   }
@@ -1262,8 +1255,7 @@ void window_allocate_buffer(struct window *window) {
   window->pango_context = pango_cairo_create_context(window->cr.get());
 }
 
-struct window *window_create(struct wl_surface *surface, struct wl_shm *shm,
-                             int width, int height) {
+window *window_create(wl_surface *surface, wl_shm *shm, int width, int height) {
   window *result;
   result = new window();
 
@@ -1278,12 +1270,11 @@ struct window *window_create(struct wl_surface *surface, struct wl_shm *shm,
   return result;
 }
 
-void window_free_buffer(struct window *window) {
+void window_free_buffer(window *window) {
   for (int i = 0; i < 2; ++i) {
     if (!window->shm_surface[i]) continue;
-    auto *data =
-        static_cast<struct shm_surface_data *>(cairo_surface_get_user_data(
-            window->shm_surface[i].get(), &shm_surface_data_key));
+    auto *data = static_cast<shm_surface_data *>(cairo_surface_get_user_data(
+        window->shm_surface[i].get(), &shm_surface_data_key));
     while (data && data->busy) { wl_display_dispatch(global_display); }
   }
   for (int i = 0; i < 2; ++i) { window->shm_surface[i] = nullptr; }
@@ -1296,7 +1287,7 @@ void window_free_buffer(struct window *window) {
   window->private_buffer.reset();
 }
 
-void window_destroy(struct window *window) {
+void window_destroy(window *window) {
   window_free_buffer(window);
   zwlr_layer_surface_v1_destroy(window->layer_surface);
   wl_surface_attach(window->surface, nullptr, 0, 0);
@@ -1307,15 +1298,16 @@ void window_destroy(struct window *window) {
   delete window;
 }
 
-void window_resize(struct window *window, int width, int height) {
-  LOG_TRACE("resizing conky display ({}) to {}x{}", window->rectangle, width, height);
+void window_resize(window *window, int width, int height) {
+  LOG_TRACE("resizing conky display ({}) to {}x{}", window->rectangle, width,
+            height);
   window_free_buffer(window);
   window->rectangle.set_size(width, height);
   window_allocate_buffer(window);
   window_layer_surface_set_size(window);
 }
 
-void window_commit_buffer(struct window *window) {
+void window_commit_buffer(window *window) {
   assert(window->shm_surface[window->current_buffer] != nullptr);
 
   cairo_surface_flush(window->cairo_surface.get());
@@ -1337,17 +1329,17 @@ void window_commit_buffer(struct window *window) {
                     window->rectangle.y(), window->rectangle.width(),
                     window->rectangle.height());
   wl_surface_commit(window->surface);
-  struct shm_surface_data *data = static_cast<struct shm_surface_data *>(
+  shm_surface_data *data = static_cast<shm_surface_data *>(
       cairo_surface_get_user_data(shm_surf, &shm_surface_data_key));
   data->busy = true;
   window->current_buffer = 1 - window->current_buffer;
   auto next_surf = window->shm_surface[window->current_buffer].get();
-  struct shm_surface_data *next_data = static_cast<struct shm_surface_data *>(
+  shm_surface_data *next_data = static_cast<shm_surface_data *>(
       cairo_surface_get_user_data(next_surf, &shm_surface_data_key));
   while (next_data->busy) { wl_display_dispatch(global_display); }
 }
 
-void window_get_width_height(struct window *window, int *w, int *h) {
+void window_get_width_height(window *window, int *w, int *h) {
   *w = window->rectangle.width();
   *h = window->rectangle.height();
 }

--- a/src/output/display-wayland.cc
+++ b/src/output/display-wayland.cc
@@ -41,10 +41,13 @@
 #include <unistd.h>
 
 #include <wayland-client-protocol.h>
+#include <fractional-scale-client-protocol.h>
+#include <viewporter-client-protocol.h>
 #include <wlr-layer-shell-client-protocol.h>
 #include <xdg-shell-client-protocol.h>
 
 #include <cerrno>
+#include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <iostream>
@@ -260,6 +263,7 @@ bool display_output_wayland::detect() {
 static int epoll_fd;
 static epoll_event ep[1];
 
+struct window;
 static window *global_window;
 static wl_display *global_display;
 
@@ -268,8 +272,22 @@ struct window {
   wl_shm *shm;
   wl_surface *surface;
   zwlr_layer_surface_v1 *layer_surface;
-  int scale = 1;
-  int pending_scale = 1;
+  /// @brief Surface viewport mapping the device-pixel buffer onto the logical
+  /// surface size; null when the compositor lacks wp_viewporter.
+  wp_viewport *viewport = nullptr;
+  /// @brief Object reporting the compositor's preferred fractional scale; null
+  /// when the compositor lacks wp_fractional_scale_v1.
+  wp_fractional_scale_v1 *fractional_scale = nullptr;
+  /// @brief Logical-to-device scale factor currently applied to the buffers.
+  ///
+  /// Fractional when the compositor supports wp_fractional_scale_v1, otherwise
+  /// the integer wl_output.scale.
+  float scale = 1.0f;
+  /// @brief Scale most recently advertised by the compositor.
+  ///
+  /// Updated asynchronously by the scale listeners and copied into @ref scale
+  /// when the window is reallocated (see window_resize).
+  float pending_scale = 1.0f;
   int current_buffer;
   std::shared_ptr<cairo_surface_t> shm_surface[2];
   std::unique_ptr<uint8_t[]> private_buffer;
@@ -289,6 +307,8 @@ struct {
   wl_output *output;
   xdg_wm_base *shell;
   zwlr_layer_shell_v1 *layer_shell;
+  wp_viewporter *viewporter;
+  wp_fractional_scale_manager_v1 *fractional_scale_manager;
 } wl_globals;
 
 static void xdg_wm_base_ping(void *data, xdg_wm_base *shell, uint32_t serial) {
@@ -326,9 +346,13 @@ static void output_done(void *data, wl_output *wl_output) {}
 void output_scale(void *data, wl_output *wl_output, int32_t factor) {
   /* For now, assume we have one output and adopt its scale unconditionally. */
   /* We should also re-render immediately when scale changes. */
+  // wl_output.scale only carries integer scales. When the compositor supports
+  // wp_fractional_scale_v1 we get a more precise value from that instead, so
+  // ignore the legacy event to avoid clobbering the fractional scale.
+  if (wl_globals.fractional_scale_manager != nullptr) { return; }
   global_window->pending_scale = factor;
   LOG_TRACE_WITH(({"window->scale", global_window->scale}),
-                 "recieved scale event: {}", factor);
+                 "received output scale event: {}", factor);
 }
 #endif
 
@@ -358,6 +382,17 @@ static const wl_output_listener output_listener = {
 #endif
 };
 
+static void fractional_scale_preferred(
+    void *data, wp_fractional_scale_v1 *fractional_scale, uint32_t scale) {
+  // scale is expressed in 1/120ths of the logical pixel size.
+  global_window->pending_scale = static_cast<float>(scale) / 120.0f;
+  LOG_TRACE_WITH(({"window->scale", global_window->scale}),
+                 "received fractional scale event: {}/120", scale);
+}
+
+static const wp_fractional_scale_v1_listener fractional_scale_listener = {
+    /*.preferred_scale =*/&fractional_scale_preferred};
+
 void registry_handle_global(void *data, wl_registry *registry, uint32_t name,
                             const char *interface, uint32_t version) {
   if (strcmp(interface, "wl_compositor") == 0) {
@@ -380,6 +415,14 @@ void registry_handle_global(void *data, wl_registry *registry, uint32_t name,
   } else if (strcmp(interface, "zwlr_layer_shell_v1") == 0) {
     wl_globals.layer_shell = static_cast<zwlr_layer_shell_v1 *>(
         wl_registry_bind(registry, name, &zwlr_layer_shell_v1_interface, 1));
+  } else if (strcmp(interface, wp_viewporter_interface.name) == 0) {
+    wl_globals.viewporter = static_cast<wp_viewporter *>(
+        wl_registry_bind(registry, name, &wp_viewporter_interface, 1));
+  } else if (strcmp(interface, wp_fractional_scale_manager_v1_interface.name) ==
+             0) {
+    wl_globals.fractional_scale_manager =
+        static_cast<wp_fractional_scale_manager_v1 *>(wl_registry_bind(
+            registry, name, &wp_fractional_scale_manager_v1_interface, 1));
   }
 }
 
@@ -596,10 +639,10 @@ bool display_output_wayland::initialize() {
   return true;
 }
 
-typedef void (*display_global_handler_t)(display *display, uint32_t name,
+typedef void (*display_global_handler_t)(wl_display *display, uint32_t name,
                                          const char *interface,
                                          uint32_t version, void *data);
-typedef void (*display_output_handler_t)(output *output, void *data);
+typedef void (*display_output_handler_t)(wl_output *output, void *data);
 
 bool display_output_wayland::shutdown() { return false; }
 
@@ -675,7 +718,13 @@ bool display_output_wayland::main_loop_wait(double t) {
 
     int fixed_size = 0;
 
-    bool scale_changed = global_window->scale != global_window->pending_scale;
+    // Scales are quantised to 1/120 (fractional-scale) or whole integers, so a
+    // genuine change is always >= 1/120; half a step is comfortably above any
+    // float-representation noise and below the smallest real change.
+    constexpr float scale_change_threshold = 1.0f / 240.0f;
+    bool scale_changed =
+        std::abs(global_window->scale - global_window->pending_scale) >
+        scale_change_threshold;
     if (scale_changed)
       LOG_TRACE("scale changed from {} to {}", global_window->scale,
                 global_window->pending_scale);
@@ -686,7 +735,8 @@ bool display_output_wayland::main_loop_wait(double t) {
          text_size.y() + 2 * border_total != height || scale_changed)) {
       /* clamp text_width to configured maximum */
       if (maximum_width.get(*state)) {
-        int mw = global_window->scale * maximum_width.get(*state);
+        int mw =
+            static_cast<int>(global_window->scale * maximum_width.get(*state));
         if (mw > 0) { text_size.set_x(std::min(mw, text_size.x())); }
       }
 
@@ -1143,20 +1193,26 @@ static void shm_pool_destroy(shm_pool *pool) {
   delete pool;
 }
 
-static int stride_for_shm_surface(rect<size_t> *rect, int scale) {
-  return cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32,
-                                       rect->width() * scale);
+/// @brief Physical (device-pixel) dimensions of the buffer backing a logical
+/// rectangle.
+///
+/// The scale may be fractional, so the result is rounded up to guarantee the
+/// buffer is large enough to cover the logical area.
+static vec2i scaled_size(rect<size_t> *rect, float scale) {
+  return conky::ceil(rect->size().cast<float>() * scale).cast<int>();
 }
 
-static int data_length_for_shm_surface(rect<size_t> *rect, int scale) {
-  int stride;
+static int stride_for_shm_surface(rect<size_t> *rect, float scale) {
+  return cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32,
+                                       scaled_size(rect, scale).x());
+}
 
-  stride = stride_for_shm_surface(rect, scale);
-  return stride * rect->height() * scale;
+static int data_length_for_shm_surface(rect<size_t> *rect, float scale) {
+  return stride_for_shm_surface(rect, scale) * scaled_size(rect, scale).y();
 }
 
 static std::shared_ptr<conky::draw_surface> create_shm_surface_from_pool(
-    void *none, rect<size_t> *rectangle, shm_pool *pool, int scale) {
+    void *none, rect<size_t> *rectangle, shm_pool *pool, float scale) {
   shm_surface_data *data;
   uint32_t format;
   cairo_surface_t *surface;
@@ -1179,7 +1235,7 @@ static std::shared_ptr<conky::draw_surface> create_shm_surface_from_pool(
     return NULL;
   }
 
-  auto scaled = rectangle->size() * scale;
+  auto scaled = scaled_size(rectangle, scale);
   surface = cairo_image_surface_create_for_data(
       static_cast<unsigned char *>(map), cairo_format, scaled.x(), scaled.y(),
       stride);
@@ -1202,7 +1258,7 @@ static std::shared_ptr<conky::draw_surface> create_shm_surface_from_pool(
 void window_allocate_buffer(window *window) {
   assert(window->shm != nullptr);
 
-  int scale = window->scale;
+  float scale = window->scale;
   shm_pool *pool;
   pool = shm_pool_create(
       window->shm, data_length_for_shm_surface(&window->rectangle, scale) * 2);
@@ -1235,7 +1291,7 @@ void window_allocate_buffer(window *window) {
   int length = data_length_for_shm_surface(&window->rectangle, scale);
 
   window->private_buffer = std::make_unique<uint8_t[]>(length);
-  auto scaled = window->rectangle.size() * scale;
+  auto scaled = scaled_size(&window->rectangle, scale);
 
   window->cairo_surface = std::shared_ptr<conky::draw_surface>(
       cairo_image_surface_create_for_data(window->private_buffer.get(),
@@ -1261,11 +1317,25 @@ window *window_create(wl_surface *surface, wl_shm *shm, int width, int height) {
 
   result->rectangle.set_pos(vec2<size_t>::Zero());
   result->rectangle.set_size(width, height);
-  result->scale = 1;
-  result->pending_scale = 1;
+  result->scale = 1.0f;
+  result->pending_scale = 1.0f;
 
   result->surface = surface;
   result->shm = shm;
+
+  // When the compositor supports viewporter we scale via a wp_viewport
+  // destination rather than wl_surface.set_buffer_scale, which lets us honour
+  // fractional scales reported through wp_fractional_scale_v1.
+  if (wl_globals.viewporter != nullptr) {
+    result->viewport =
+        wp_viewporter_get_viewport(wl_globals.viewporter, surface);
+  }
+  if (wl_globals.fractional_scale_manager != nullptr) {
+    result->fractional_scale = wp_fractional_scale_manager_v1_get_fractional_scale(
+        wl_globals.fractional_scale_manager, surface);
+    wp_fractional_scale_v1_add_listener(result->fractional_scale,
+                                        &fractional_scale_listener, nullptr);
+  }
 
   return result;
 }
@@ -1289,6 +1359,10 @@ void window_free_buffer(window *window) {
 
 void window_destroy(window *window) {
   window_free_buffer(window);
+  if (window->fractional_scale) {
+    wp_fractional_scale_v1_destroy(window->fractional_scale);
+  }
+  if (window->viewport) { wp_viewport_destroy(window->viewport); }
   zwlr_layer_surface_v1_destroy(window->layer_surface);
   wl_surface_attach(window->surface, nullptr, 0, 0);
   wl_surface_commit(window->surface);
@@ -1312,7 +1386,7 @@ void window_commit_buffer(window *window) {
 
   cairo_surface_flush(window->cairo_surface.get());
 
-  int scale = window->scale;
+  float scale = window->scale;
   int length = data_length_for_shm_surface(&window->rectangle, scale);
 
   auto shm_surf = window->shm_surface[window->current_buffer].get();
@@ -1320,7 +1394,17 @@ void window_commit_buffer(window *window) {
 
   std::memcpy(shm_data, window->private_buffer.get(), length);
 
-  wl_surface_set_buffer_scale(global_window->surface, global_window->scale);
+  if (window->viewport != nullptr) {
+    // The buffer is rendered at device resolution; the viewport maps it back
+    // down to the logical surface size, which is what carries the (possibly
+    // fractional) scale to the compositor.
+    wp_viewport_set_destination(window->viewport, window->rectangle.width(),
+                                window->rectangle.height());
+  } else {
+    // No viewporter: fall back to integer buffer scaling.
+    wl_surface_set_buffer_scale(window->surface,
+                                static_cast<int>(std::lround(scale)));
+  }
   wl_surface_attach(window->surface, get_buffer_from_cairo_surface(shm_surf), 0,
                     0);
   /* repaint all the pixels in the surface, change size to only repaint changed

--- a/src/output/display-wayland.cc
+++ b/src/output/display-wayland.cc
@@ -40,19 +40,18 @@
 #include <sys/timerfd.h>
 #include <unistd.h>
 
-#include <wayland-client-protocol.h>
 #include <fractional-scale-client-protocol.h>
 #include <viewporter-client-protocol.h>
+#include <wayland-client-protocol.h>
 #include <wlr-layer-shell-client-protocol.h>
 #include <xdg-shell-client-protocol.h>
 
 #include <cerrno>
 #include <cmath>
+#include <csignal>
 #include <cstdint>
 #include <cstring>
-#include <iostream>
 #include <memory>
-#include <sstream>
 
 #include "../conky.h"
 #include "../geometry.h"
@@ -60,6 +59,7 @@
 #include "../lua/llua.h"
 #include "display-output.hh"
 #include "gui.h"
+#include "wl-shell.h"
 
 #include "../lua/fonts.h"
 
@@ -174,6 +174,10 @@ int get_border_total();
 extern conky::range_config_setting<int> maximum_width;
 extern Colour current_color;
 
+/* set from the main loop's signal handler; used to request a clean shutdown
+ * when the compositor closes our shell surface. */
+extern volatile sig_atomic_t g_sigterm_pending;
+
 /* for pango_fonts */
 struct pango_font {
   PangoFontDescription *desc;
@@ -260,7 +264,8 @@ struct window {
   rect<size_t> rectangle;
   wl_shm *shm;
   wl_surface *surface;
-  zwlr_layer_surface_v1 *layer_surface;
+  /// @brief Shell role (layer-shell or xdg-shell) bound to @ref surface.
+  std::unique_ptr<conky::shell_surface> shell;
   /// @brief Surface viewport mapping the device-pixel buffer onto the logical
   /// surface size; null when the compositor lacks wp_viewporter.
   wp_viewport *viewport = nullptr;
@@ -371,8 +376,9 @@ static const wl_output_listener output_listener = {
 #endif
 };
 
-static void fractional_scale_preferred(
-    void *data, wp_fractional_scale_v1 *fractional_scale, uint32_t scale) {
+static void fractional_scale_preferred(void *data,
+                                       wp_fractional_scale_v1 *fractional_scale,
+                                       uint32_t scale) {
   // scale is expressed in 1/120ths of the logical pixel size.
   global_window->pending_scale = static_cast<float>(scale) / 120.0f;
   LOG_TRACE_WITH(({"window->scale", global_window->scale}),
@@ -421,21 +427,6 @@ void registry_handle_global_remove(void *data, wl_registry *registry,
 static const wl_registry_listener registry_listener = {
     registry_handle_global, registry_handle_global_remove};
 
-static void layer_surface_configure(void *data,
-                                    zwlr_layer_surface_v1 *layer_surface,
-                                    uint32_t serial, uint32_t width,
-                                    uint32_t height) {
-  zwlr_layer_surface_v1_ack_configure(layer_surface, serial);
-}
-
-static void layer_surface_closed(void *data,
-                                 zwlr_layer_surface_v1 *layer_surface) {}
-
-static const zwlr_layer_surface_v1_listener layer_surface_listener = {
-    /*.configure =*/&layer_surface_configure,
-    /*.closed =*/&layer_surface_closed,
-};
-
 window *window_create(wl_surface *surface, wl_shm *shm, int width, int height);
 
 void window_resize(window *window, int width, int height);
@@ -447,12 +438,6 @@ void window_destroy(window *window);
 void window_commit_buffer(window *window);
 
 void window_get_width_height(window *window, int *w, int *h);
-
-void window_layer_surface_set_size(window *window) {
-  zwlr_layer_surface_v1_set_size(global_window->layer_surface,
-                                 global_window->rectangle.width(),
-                                 global_window->rectangle.height());
-}
 
 /// @brief Maps the configured `own_window_type` onto a wlr-layer-shell layer.
 ///
@@ -472,20 +457,18 @@ static zwlr_layer_shell_v1_layer layer_for_window_type() {
   }
 }
 
-/// @brief Updates the layer surface anchor, margin and exclusive zone.
+/// @brief Updates the shell surface anchoring and reserved space (struts).
 ///
 /// Docks and panels reserve a strip along a screen edge so other surfaces
-/// (e.g. maximized windows) don't overlap them. The wlr-layer-shell exclusive
-/// zone is only honoured when the surface is anchored to a single edge, so
-/// collapse the alignment to one dominant edge and reserve the size
-/// perpendicular to it; the exclusive zone includes the gap/margin from the
-/// edge. Other window types keep the alignment-derived anchor and reserve no
-/// space.
+/// (e.g. maximized windows) don't overlap them; other window types anchor
+/// where they're aligned and reserve nothing.
 ///
-/// @param window window whose layer surface should be updated
+/// @param window window whose shell surface should be updated
 /// @param width current window width in surface-local pixels
 /// @param height current window height in surface-local pixels
 static void window_update_struts(window *window, int width, int height) {
+  if (!window->shell->supports_struts()) { return; }
+
   LOG_DEBUG("defining struts");
 
   alignment text_align = text_alignment.get(*state);
@@ -495,55 +478,34 @@ static void window_update_struts(window *window, int width, int height) {
   window_type type = own_window_type.get(*state);
   bool reserve_space = type == window_type::DOCK || type == window_type::PANEL;
 
-  int anchor = 0;
+  conky::screen_edge edge = conky::screen_edge::NONE;
   int exclusive_zone = 0;
 
   if (reserve_space) {
+    // Reservation only works against a single edge, so collapse the alignment
+    // to one dominant edge and reserve the perpendicular size (plus margin).
     if (valign == axis_align::START) {
-      anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP;
+      edge = conky::screen_edge::TOP;
       exclusive_zone = height + gap_y.get(*state);
     } else if (valign == axis_align::END) {
-      anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM;
+      edge = conky::screen_edge::BOTTOM;
       exclusive_zone = height + gap_y.get(*state);
     } else if (halign == axis_align::START) {
-      anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT;
+      edge = conky::screen_edge::LEFT;
       exclusive_zone = width + gap_x.get(*state);
     } else if (halign == axis_align::END) {
-      anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT;
+      edge = conky::screen_edge::RIGHT;
       exclusive_zone = width + gap_x.get(*state);
     }
     // A fully centered (mm) dock/panel has no edge to reserve against, so the
     // exclusive zone stays zero.
   } else {
-    switch (valign) {
-      case axis_align::START:
-        anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP;
-        break;
-      case axis_align::END:
-        anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM;
-        break;
-      default:
-        break;
-    }
-    switch (halign) {
-      case axis_align::START:
-        anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT;
-        break;
-      case axis_align::END:
-        anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT;
-        break;
-      default:
-        break;
-    }
-    // middle anchor alignment is the default and requires no special handling.
+    // Normal windows anchor exactly where they're aligned.
+    edge = static_cast<conky::screen_edge>(*text_align);
   }
 
-  zwlr_layer_surface_v1_set_anchor(window->layer_surface, anchor);
-  zwlr_layer_surface_v1_set_margin(window->layer_surface, gap_y.get(*state),
-                                   gap_x.get(*state), gap_y.get(*state),
-                                   gap_x.get(*state));
-  zwlr_layer_surface_v1_set_exclusive_zone(window->layer_surface,
-                                           exclusive_zone);
+  window->shell->reserve_space(edge, exclusive_zone, gap_x.get(*state),
+                               gap_y.get(*state));
 }
 
 #ifdef BUILD_MOUSE_EVENTS
@@ -691,23 +653,50 @@ bool display_output_wayland::initialize() {
   wl_registry_add_listener(wl_globals.registry, &registry_listener, NULL);
 
   wl_display_roundtrip(global_display);
-  if (wl_globals.layer_shell == nullptr) {
-    // TODO: Implement OWN_WINDOW and XDG Shell support
-    SYSTEM_ERR(
-        "compositor doesn't support wlr-layer-shell-unstable-v1, can't run "
-        "conky");
-  }
 
   wl_surface *surface = wl_compositor_create_surface(wl_globals.compositor);
   global_window = window_create(surface, wl_globals.shm, 1, 1);
   window_allocate_buffer(global_window);
 
-  global_window->layer_surface = zwlr_layer_shell_v1_get_layer_surface(
-      wl_globals.layer_shell, global_window->surface, nullptr,
-      layer_for_window_type(), "conky_namespace");
-  window_layer_surface_set_size(global_window);
-  zwlr_layer_surface_v1_add_listener(global_window->layer_surface,
-                                     &layer_surface_listener, nullptr);
+  // An own_window of normal/utility type becomes a regular compositor-managed
+  // toplevel; everything else (desktop/dock/panel, or no own_window) mounts as
+  // a layer surface, falling back to an xdg toplevel when the compositor lacks
+  // wlr-layer-shell.
+  window_type type = own_window_type.get(*state);
+  bool want_toplevel = own_window.get(*state) && (type == window_type::NORMAL ||
+                                                  type == window_type::UTILITY);
+  auto on_close = []() { g_sigterm_pending = 1; };
+
+  if (!want_toplevel && wl_globals.layer_shell != nullptr) {
+    global_window->shell =
+        conky::create_shell_surface<conky::layer_shell_surface>({
+            on_close,
+            global_window->surface,
+            wl_globals.layer_shell,
+            static_cast<uint32_t>(layer_for_window_type()),
+            "conky",
+        });
+  } else {
+    if (!want_toplevel) {
+      LOG_WARNING(
+          "compositor lacks wlr-layer-shell; falling back to an xdg-shell "
+          "toplevel (desktop/dock/panel space reservation unavailable)");
+    }
+    if (wl_globals.shell == nullptr) {
+      SYSTEM_ERR("compositor supports neither wlr-layer-shell nor xdg-shell");
+      return false;
+    }
+    global_window->shell =
+        conky::create_shell_surface<conky::xdg_shell_surface>({
+            on_close,
+            global_window->surface,
+            wl_globals.shell,
+            own_window_title.get(*state),
+            own_window_class.get(*state),
+        });
+  }
+  global_window->shell->set_size(global_window->rectangle.width(),
+                                 global_window->rectangle.height());
 
 #ifdef BUILD_MOUSE_EVENTS
   wl_seat_add_listener(wl_globals.seat, &seat_listener, global_window);
@@ -1326,8 +1315,9 @@ window *window_create(wl_surface *surface, wl_shm *shm, int width, int height) {
         wp_viewporter_get_viewport(wl_globals.viewporter, surface);
   }
   if (wl_globals.fractional_scale_manager != nullptr) {
-    result->fractional_scale = wp_fractional_scale_manager_v1_get_fractional_scale(
-        wl_globals.fractional_scale_manager, surface);
+    result->fractional_scale =
+        wp_fractional_scale_manager_v1_get_fractional_scale(
+            wl_globals.fractional_scale_manager, surface);
     wp_fractional_scale_v1_add_listener(result->fractional_scale,
                                         &fractional_scale_listener, nullptr);
   }
@@ -1358,7 +1348,8 @@ void window_destroy(window *window) {
     wp_fractional_scale_v1_destroy(window->fractional_scale);
   }
   if (window->viewport) { wp_viewport_destroy(window->viewport); }
-  zwlr_layer_surface_v1_destroy(window->layer_surface);
+  // Destroy the shell role before the wl_surface it is bound to.
+  window->shell.reset();
   wl_surface_attach(window->surface, nullptr, 0, 0);
   wl_surface_commit(window->surface);
   wl_display_roundtrip(global_display);
@@ -1373,7 +1364,8 @@ void window_resize(window *window, int width, int height) {
   window_free_buffer(window);
   window->rectangle.set_size(width, height);
   window_allocate_buffer(window);
-  window_layer_surface_set_size(window);
+  window->shell->set_size(window->rectangle.width(),
+                          window->rectangle.height());
 }
 
 void window_commit_buffer(window *window) {

--- a/src/output/display-wayland.cc
+++ b/src/output/display-wayland.cc
@@ -465,6 +465,98 @@ void window_layer_surface_set_size(window *window) {
                                  global_window->rectangle.height());
 }
 
+/// @brief Maps the configured `own_window_type` onto a wlr-layer-shell layer.
+///
+/// Desktop widgets sit on the background, docks below regular windows, and
+/// panels above them; everything else keeps the historical bottom layer.
+static zwlr_layer_shell_v1_layer layer_for_window_type() {
+  switch (own_window_type.get(*state)) {
+    case window_type::DESKTOP:
+      return ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND;
+    case window_type::PANEL:
+      return ZWLR_LAYER_SHELL_V1_LAYER_TOP;
+    case window_type::DOCK:
+    case window_type::NORMAL:
+    case window_type::UTILITY:
+    default:
+      return ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM;
+  }
+}
+
+/// @brief Updates the layer surface anchor, margin and exclusive zone.
+///
+/// Docks and panels reserve a strip along a screen edge so other surfaces
+/// (e.g. maximized windows) don't overlap them. The wlr-layer-shell exclusive
+/// zone is only honoured when the surface is anchored to a single edge, so
+/// collapse the alignment to one dominant edge and reserve the size
+/// perpendicular to it; the exclusive zone includes the gap/margin from the
+/// edge. Other window types keep the alignment-derived anchor and reserve no
+/// space.
+///
+/// @param window window whose layer surface should be updated
+/// @param width current window width in surface-local pixels
+/// @param height current window height in surface-local pixels
+static void window_update_struts(window *window, int width, int height) {
+  LOG_DEBUG("defining struts");
+
+  alignment text_align = text_alignment.get(*state);
+  axis_align valign = vertical_alignment(text_align);
+  axis_align halign = horizontal_alignment(text_align);
+
+  window_type type = own_window_type.get(*state);
+  bool reserve_space = type == window_type::DOCK || type == window_type::PANEL;
+
+  int anchor = 0;
+  int exclusive_zone = 0;
+
+  if (reserve_space) {
+    if (valign == axis_align::START) {
+      anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP;
+      exclusive_zone = height + gap_y.get(*state);
+    } else if (valign == axis_align::END) {
+      anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM;
+      exclusive_zone = height + gap_y.get(*state);
+    } else if (halign == axis_align::START) {
+      anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT;
+      exclusive_zone = width + gap_x.get(*state);
+    } else if (halign == axis_align::END) {
+      anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT;
+      exclusive_zone = width + gap_x.get(*state);
+    }
+    // A fully centered (mm) dock/panel has no edge to reserve against, so the
+    // exclusive zone stays zero.
+  } else {
+    switch (valign) {
+      case axis_align::START:
+        anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP;
+        break;
+      case axis_align::END:
+        anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM;
+        break;
+      default:
+        break;
+    }
+    switch (halign) {
+      case axis_align::START:
+        anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT;
+        break;
+      case axis_align::END:
+        anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT;
+        break;
+      default:
+        break;
+    }
+    // middle anchor alignment is the default and requires no special handling.
+  }
+
+  zwlr_layer_surface_v1_set_anchor(window->layer_surface, anchor);
+  zwlr_layer_surface_v1_set_margin(window->layer_surface, gap_y.get(*state),
+                                   gap_x.get(*state), gap_y.get(*state),
+                                   gap_x.get(*state));
+  zwlr_layer_surface_v1_set_exclusive_zone(window->layer_surface,
+                                           exclusive_zone);
+}
+
 #ifdef BUILD_MOUSE_EVENTS
 static std::map<wl_pointer *, vec2<size_t>> last_known_positions{};
 
@@ -623,7 +715,7 @@ bool display_output_wayland::initialize() {
 
   global_window->layer_surface = zwlr_layer_shell_v1_get_layer_surface(
       wl_globals.layer_shell, global_window->surface, nullptr,
-      ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM, "conky_namespace");
+      layer_for_window_type(), "conky_namespace");
   window_layer_surface_set_size(global_window);
   zwlr_layer_surface_v1_add_listener(global_window->layer_surface,
                                      &layer_surface_listener, nullptr);
@@ -710,7 +802,7 @@ bool display_output_wayland::main_loop_wait(double t) {
     selected_font = 0;
     update_text_area();
 
-    int changed = 0;
+    bool bounds_changed = false;
     int border_total = get_border_total();
 
     int width, height;
@@ -747,7 +839,7 @@ bool display_output_wayland::main_loop_wait(double t) {
       height = text_size.y() + 2 * border_total;
       window_resize(global_window, width, height); /* resize window */
 
-      changed++;
+      bounds_changed |= true;
     }
 
 /* move window if it isn't in right position */
@@ -759,42 +851,7 @@ bool display_output_wayland::main_loop_wait(double t) {
 #endif
 
     /* update struts */
-    if (changed != 0) {
-      int anchor = 0;
-
-      LOG_DEBUG("defining struts");
-
-      alignment text_align = text_alignment.get(*state);
-      switch (vertical_alignment(text_align)) {
-        case axis_align::START:
-          anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP;
-          break;
-        case axis_align::END:
-          anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM;
-          break;
-        default:
-          break;
-      }
-      switch (horizontal_alignment(text_align)) {
-        case axis_align::START:
-          anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT;
-          break;
-        case axis_align::END:
-          anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT;
-          break;
-        default:
-          break;
-      }
-      // middle anchor alignment is the default and requires no special
-      // handling.
-
-      if (anchor != -1) {
-        zwlr_layer_surface_v1_set_anchor(global_window->layer_surface, anchor);
-        zwlr_layer_surface_v1_set_margin(global_window->layer_surface,
-                                         gap_y.get(*state), gap_x.get(*state),
-                                         gap_y.get(*state), gap_x.get(*state));
-      }
-    }
+    if (bounds_changed) { window_update_struts(global_window, width, height); }
 
     /* update lua window globals */
     llua_update_window_table(conky::vec2i(width, height),

--- a/src/output/display-wayland.cc
+++ b/src/output/display-wayland.cc
@@ -222,17 +222,6 @@ static void wayland_create_window() {
   load_fonts(utf8_mode.get(*state));
   update_text_area(); /* to position text/window on screen */
 
-#ifdef OWN_WINDOW
-  if (own_window.get(*state)) {
-    if (fixed_pos == 0) {
-      // XMoveWindow(display, window.window, window.x, window.y);
-      // TODO
-    }
-
-    // set_transparent_background(window.window);
-  }
-#endif
-
   selected_font = 0;
   update_text_area(); /* to get initial size of the window */
 }
@@ -842,14 +831,6 @@ bool display_output_wayland::main_loop_wait(double t) {
       bounds_changed |= true;
     }
 
-/* move window if it isn't in right position */
-#ifdef POSITION
-    if ((fixed_pos == 0) && (window.x != wx || window.y != wy)) {
-      // XMoveWindow(display, window.window, window.x, window.y);
-      changed++;
-    }
-#endif
-
     /* update struts */
     if (bounds_changed) { window_update_struts(global_window, width, height); }
 
@@ -862,48 +843,7 @@ bool display_output_wayland::main_loop_wait(double t) {
   }
   wl_display_flush(global_display);
 
-#ifdef INPUT
-#ifdef X_EVENT
-  case ButtonPress:
-    if (own_window.get(*state)) {
-      /* if an ordinary window with decorations */
-      if ((own_window_type.get(*state) == TYPE_NORMAL &&
-           !TEST_HINT(own_window_hints.get(*state), HINT_UNDECORATED)) ||
-          own_window_type.get(*state) == TYPE_DESKTOP) {
-        /* allow conky to hold input focus. */
-        break;
-      }
-      /* forward the click to the desktop window */
-      XUngrabPointer(display, ev.xbutton.time);
-      ev.xbutton.window = window.desktop;
-      ev.xbutton.x = ev.xbutton.x_root;
-      ev.xbutton.y = ev.xbutton.y_root;
-      XSendEvent(display, ev.xbutton.window, False, ButtonPressMask, &ev);
-      XSetInputFocus(display, ev.xbutton.window, RevertToParent,
-                     ev.xbutton.time);
-    }
-    break;
-
-  case ButtonRelease:
-    if (own_window.get(*state)) {
-      /* if an ordinary window with decorations */
-      if ((own_window_type.get(*state) == TYPE_NORMAL) &&
-          !TEST_HINT(own_window_hints.get(*state), HINT_UNDECORATED)) {
-        /* allow conky to hold input focus. */
-        break;
-      }
-      /* forward the release to the desktop window */
-      ev.xbutton.window = window.desktop;
-      ev.xbutton.x = ev.xbutton.x_root;
-      ev.xbutton.y = ev.xbutton.y_root;
-      XSendEvent(display, ev.xbutton.window, False, ButtonReleaseMask, &ev);
-    }
-    break;
-#endif /*X_EVENT*/
-#endif /*INPUT*/
-
-    // handled
-    return true;
+  return true;
 }
 
 void display_output_wayland::sigterm_cleanup() {}

--- a/src/output/display-wayland.cc
+++ b/src/output/display-wayland.cc
@@ -814,12 +814,11 @@ bool display_output_wayland::main_loop_wait(double t) {
     if ((fixed_size == 0) &&
         (text_size.x() + 2 * border_total != width ||
          text_size.y() + 2 * border_total != height || scale_changed)) {
-      /* clamp text_width to configured maximum */
-      if (maximum_width.get(*state)) {
-        int mw =
-            static_cast<int>(global_window->scale * maximum_width.get(*state));
-        if (mw > 0) { text_size.set_x(std::min(mw, text_size.x())); }
-      }
+      /* clamp text_width to configured maximum; maximum_width is in logical
+       * pixels like text_size, the compositor scale is applied later at the
+       * cairo/viewport level. */
+      int mw = maximum_width.get(*state);
+      if (mw > 0) { text_size.set_x(std::min(mw, text_size.x())); }
 
       /* pending scale will be applied by resizing the window */
       global_window->scale = global_window->pending_scale;
@@ -988,7 +987,6 @@ void display_output_wayland::move_win(int x, int y) {
   // window.y = y;
   // TODO
 }
-float display_output_wayland::get_dpi_scale() { return 1.0; }
 
 void display_output_wayland::end_draw_stuff() {
   window_commit_buffer(global_window);

--- a/src/output/display-wayland.hh
+++ b/src/output/display-wayland.hh
@@ -72,7 +72,6 @@ class display_output_wayland : public display_output_base {
   virtual void fill_rect(int, int, int, int);
   virtual void draw_arc(int, int, int, int, int, int);
   virtual void move_win(int, int);
-  virtual float get_dpi_scale();
 
   virtual void end_draw_stuff();
   virtual void clear_text(int);

--- a/src/output/gui.cc
+++ b/src/output/gui.cc
@@ -128,13 +128,19 @@ conky::lua_traits<alignment>::Map conky::lua_traits<alignment>::map = {
     {"mr", alignment::MIDDLE_RIGHT},
     {"none", alignment::NONE}};
 
-#ifdef OWN_WINDOW
+#if defined(OWN_WINDOW) || defined(BUILD_WAYLAND)
 template <>
 conky::lua_traits<window_type>::Map conky::lua_traits<window_type>::map = {
-    {"normal", window_type::NORMAL},   {"dock", window_type::DOCK},
-    {"panel", window_type::PANEL},     {"desktop", window_type::DESKTOP},
-    {"utility", window_type::UTILITY}, {"override", window_type::OVERRIDE}};
+    {"normal", window_type::NORMAL},     {"dock", window_type::DOCK},
+    {"panel", window_type::PANEL},       {"desktop", window_type::DESKTOP},
+    {"utility", window_type::UTILITY},
+#ifdef BUILD_X11
+    {"override", window_type::OVERRIDE},
+#endif /* BUILD_X11 */
+};
+#endif /* OWN_WINDOW || BUILD_WAYLAND */
 
+#ifdef OWN_WINDOW
 template <>
 conky::lua_traits<window_hints>::Map conky::lua_traits<window_hints>::map = {
     {"undecorated", window_hints::UNDECORATED},
@@ -209,12 +215,15 @@ conky::range_config_setting<int> border_width("border_width", 0,
 #ifdef OWN_WINDOW
 conky::simple_config_setting<std::string> own_window_title(
     "own_window_title", PACKAGE_NAME " (" + gethostnamecxx() + ")", false);
-conky::simple_config_setting<window_type> own_window_type("own_window_type",
-                                                          window_type::NORMAL,
-                                                          false);
 conky::simple_config_setting<std::string> own_window_class("own_window_class",
                                                            PACKAGE_NAME, false);
 #endif /* OWN_WINDOW */
+
+#if defined(OWN_WINDOW) || defined(BUILD_WAYLAND)
+conky::simple_config_setting<window_type> own_window_type("own_window_type",
+                                                          window_type::NORMAL,
+                                                          false);
+#endif /* OWN_WINDOW || BUILD_WAYLAND */
 
 #if defined(OWN_WINDOW) && defined(BUILD_X11)
 conky::simple_config_setting<uint16_t, window_hints_traits> own_window_hints(

--- a/src/output/gui.cc
+++ b/src/output/gui.cc
@@ -78,7 +78,7 @@ void own_window_setting::lua_setter(lua::state &l, bool init) {
 
   if (init) {
     if (do_convert(l, -1).first) {
-#ifndef OWN_WINDOW
+#if !defined(OWN_WINDOW) && !defined(BUILD_WAYLAND)
       LOG_WARNING(
           "own_window support disabled at compile time, ignoring setting");
       l.pop();
@@ -88,10 +88,13 @@ void own_window_setting::lua_setter(lua::state &l, bool init) {
 
     if (out_to_gui(l)) {
 #ifdef BUILD_X11
-      x11_init_window(l, do_convert(l, -1).first);
+      // X11 window setup only applies when actually drawing to X; a
+      // Wayland-only run in a combined build must not touch the (uninitialized)
+      // X display.
+      if (out_to_x.get(l)) { x11_init_window(l, do_convert(l, -1).first); }
 #endif /*BUILD_X11*/
     } else {
-      // own_window makes no sense when not drawing to X
+      // own_window makes no sense when not drawing to a GUI output
       l.pop();
       l.pushboolean(false);
     }
@@ -175,7 +178,7 @@ std::pair<uint16_t, bool> window_hints_traits::convert(
 }
 #endif
 
-#ifdef OWN_WINDOW
+#if defined(OWN_WINDOW) || defined(BUILD_WAYLAND)
 namespace {
 // used to set the default value for own_window_title
 std::string gethostnamecxx() {
@@ -183,7 +186,7 @@ std::string gethostnamecxx() {
   return info.uname_s.nodename;
 }
 }  // namespace
-#endif /* OWN_WINDOW */
+#endif /* OWN_WINDOW || BUILD_WAYLAND */
 
 /*
  * The order of these settings cannot be completely arbitrary. Some of them
@@ -212,12 +215,12 @@ conky::range_config_setting<int> border_width("border_width", 0,
                                               std::numeric_limits<int>::max(),
                                               1, true);
 
-#ifdef OWN_WINDOW
+#if defined(OWN_WINDOW) || defined(BUILD_WAYLAND)
 conky::simple_config_setting<std::string> own_window_title(
     "own_window_title", PACKAGE_NAME " (" + gethostnamecxx() + ")", false);
 conky::simple_config_setting<std::string> own_window_class("own_window_class",
                                                            PACKAGE_NAME, false);
-#endif /* OWN_WINDOW */
+#endif /* OWN_WINDOW || BUILD_WAYLAND */
 
 #if defined(OWN_WINDOW) || defined(BUILD_WAYLAND)
 conky::simple_config_setting<window_type> own_window_type("own_window_type",

--- a/src/output/gui.h
+++ b/src/output/gui.h
@@ -212,14 +212,19 @@ extern conky::simple_config_setting<bool> forced_redraw;
 #ifdef OWN_WINDOW
 extern priv::own_window_setting own_window;
 extern conky::simple_config_setting<std::string> own_window_title;
-
-/// @brief Window type.
-///
-/// @see window_type
-extern conky::simple_config_setting<window_type> own_window_type;
 /// @brief X11 window class; Wayland XDG Shell app_id.
 extern conky::simple_config_setting<std::string> own_window_class;
 #endif /* OWN_WINDOW */
+
+#if defined(OWN_WINDOW) || defined(BUILD_WAYLAND)
+/// @brief Window type.
+///
+/// On Wayland this selects the wlr-layer-shell layer and, for dock/panel
+/// types, whether the surface reserves screen space via an exclusive zone.
+///
+/// @see window_type
+extern conky::simple_config_setting<window_type> own_window_type;
+#endif /* OWN_WINDOW || BUILD_WAYLAND */
 
 #if defined(OWN_WINDOW) && defined(BUILD_X11)
 struct window_hints_traits {

--- a/src/output/gui.h
+++ b/src/output/gui.h
@@ -209,23 +209,6 @@ extern conky::range_config_setting<int> border_width;
 
 extern conky::simple_config_setting<bool> forced_redraw;
 
-#ifdef OWN_WINDOW
-extern priv::own_window_setting own_window;
-extern conky::simple_config_setting<std::string> own_window_title;
-/// @brief X11 window class; Wayland XDG Shell app_id.
-extern conky::simple_config_setting<std::string> own_window_class;
-#endif /* OWN_WINDOW */
-
-#if defined(OWN_WINDOW) || defined(BUILD_WAYLAND)
-/// @brief Window type.
-///
-/// On Wayland this selects the wlr-layer-shell layer and, for dock/panel
-/// types, whether the surface reserves screen space via an exclusive zone.
-///
-/// @see window_type
-extern conky::simple_config_setting<window_type> own_window_type;
-#endif /* OWN_WINDOW || BUILD_WAYLAND */
-
 #if defined(OWN_WINDOW) && defined(BUILD_X11)
 struct window_hints_traits {
   static const lua::Type type = lua::TSTRING;
@@ -238,6 +221,20 @@ extern conky::simple_config_setting<uint16_t, window_hints_traits>
 #endif /* OWN_WINDOW && BUILD_X11 */
 
 #if defined(OWN_WINDOW) || defined(BUILD_WAYLAND)
+extern priv::own_window_setting own_window;
+/// @brief X11 window title; Wayland XDG Shell toplevel title.
+extern conky::simple_config_setting<std::string> own_window_title;
+/// @brief X11 window class; Wayland XDG Shell app_id.
+extern conky::simple_config_setting<std::string> own_window_class;
+
+/// @brief Window type.
+///
+/// On Wayland this selects the wlr-layer-shell layer and, for dock/panel
+/// types, whether the surface reserves screen space via an exclusive zone.
+///
+/// @see window_type
+extern conky::simple_config_setting<window_type> own_window_type;
+
 extern priv::colour_setting background_colour;
 
 Colour get_background_colour_preference(lua::state &l);

--- a/src/output/wl-shell.cc
+++ b/src/output/wl-shell.cc
@@ -1,0 +1,173 @@
+/*
+ *
+ * Conky, a system monitor, based on torsmo
+ *
+ * Please see COPYING for details
+ *
+ * Copyright (c) 2005-2024 Brenden Matthews, Philip Kovacs, et. al.
+ *	(see AUTHORS)
+ * All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "wl-shell.h"
+
+#include <wayland-client.h>
+
+#include <wlr-layer-shell-client-protocol.h>
+#include <xdg-shell-client-protocol.h>
+
+namespace conky {
+namespace {
+
+uint32_t to_layer_anchor(screen_edge edge) {
+  auto align = static_cast<alignment>(static_cast<uint8_t>(edge));
+  uint32_t anchor = 0;
+  switch (vertical_alignment(align)) {
+    case axis_align::START:
+      anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP;
+      break;
+    case axis_align::END:
+      anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM;
+      break;
+    default:
+      break;
+  }
+  switch (horizontal_alignment(align)) {
+    case axis_align::START:
+      anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT;
+      break;
+    case axis_align::END:
+      anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT;
+      break;
+    default:
+      break;
+  }
+  return anchor;
+}
+
+}  // namespace
+
+// --- layer_shell_surface ---------------------------------------------------
+
+const zwlr_layer_surface_v1_listener layer_shell_surface::listener = {
+    .configure = &layer_shell_surface::handle_configure,
+    .closed = &layer_shell_surface::handle_closed,
+};
+
+layer_shell_surface::layer_shell_surface(const params &p)
+    : m_on_close(p.on_close) {
+  m_layer_surface = zwlr_layer_shell_v1_get_layer_surface(
+      p.layer_shell, p.surface, nullptr, p.layer, p.m_namespace);
+  zwlr_layer_surface_v1_add_listener(m_layer_surface, &listener, this);
+}
+
+layer_shell_surface::~layer_shell_surface() {
+  if (m_layer_surface != nullptr) {
+    zwlr_layer_surface_v1_destroy(m_layer_surface);
+  }
+}
+
+void layer_shell_surface::set_size(uint32_t width, uint32_t height) {
+  zwlr_layer_surface_v1_set_size(m_layer_surface, width, height);
+}
+
+void layer_shell_surface::reserve_space(screen_edge edge, int exclusive_zone,
+                                        int margin_x, int margin_y) {
+  zwlr_layer_surface_v1_set_anchor(m_layer_surface, to_layer_anchor(edge));
+  zwlr_layer_surface_v1_set_margin(m_layer_surface, margin_y, margin_x,
+                                   margin_y, margin_x);
+  zwlr_layer_surface_v1_set_exclusive_zone(m_layer_surface, exclusive_zone);
+}
+
+void layer_shell_surface::handle_configure(void *data,
+                                           zwlr_layer_surface_v1 *surface,
+                                           uint32_t serial, uint32_t width,
+                                           uint32_t height) {
+  (void)data;
+  (void)width;
+  (void)height;
+  zwlr_layer_surface_v1_ack_configure(surface, serial);
+}
+
+void layer_shell_surface::handle_closed(void *data,
+                                        zwlr_layer_surface_v1 *surface) {
+  (void)surface;
+  auto *self = static_cast<layer_shell_surface *>(data);
+  if (self->m_on_close) { self->m_on_close(); }
+}
+
+// --- xdg_shell_surface -----------------------------------------------------
+
+const xdg_surface_listener xdg_shell_surface::surface_listener = {
+    .configure = &xdg_shell_surface::handle_surface_configure,
+};
+const xdg_toplevel_listener xdg_shell_surface::toplevel_listener = {
+    .configure = &xdg_shell_surface::handle_toplevel_configure,
+    .close = &xdg_shell_surface::handle_toplevel_close,
+};
+
+xdg_shell_surface::xdg_shell_surface(const params &p) : m_on_close(p.on_close) {
+  m_xdg_surface = xdg_wm_base_get_xdg_surface(p.xdg_shell, p.surface);
+  xdg_surface_add_listener(m_xdg_surface, &surface_listener, this);
+  m_xdg_toplevel = xdg_surface_get_toplevel(m_xdg_surface);
+  xdg_toplevel_add_listener(m_xdg_toplevel, &toplevel_listener, this);
+  if (!p.title.empty()) {
+    xdg_toplevel_set_title(m_xdg_toplevel, p.title.c_str());
+  }
+  if (!p.app_id.empty()) {
+    xdg_toplevel_set_app_id(m_xdg_toplevel, p.app_id.c_str());
+  }
+}
+
+xdg_shell_surface::~xdg_shell_surface() {
+  if (m_xdg_toplevel != nullptr) { xdg_toplevel_destroy(m_xdg_toplevel); }
+  if (m_xdg_surface != nullptr) { xdg_surface_destroy(m_xdg_surface); }
+}
+
+void xdg_shell_surface::set_size(uint32_t width, uint32_t height) {
+  // Fixed-size window: pin min == max to the requested logical size.
+  xdg_toplevel_set_min_size(m_xdg_toplevel, width, height);
+  xdg_toplevel_set_max_size(m_xdg_toplevel, width, height);
+  xdg_surface_set_window_geometry(m_xdg_surface, 0, 0, width, height);
+}
+
+void xdg_shell_surface::handle_surface_configure(void *data,
+                                                 xdg_surface *surface,
+                                                 uint32_t serial) {
+  (void)data;
+  xdg_surface_ack_configure(surface, serial);
+}
+
+void xdg_shell_surface::handle_toplevel_configure(void *data,
+                                                  xdg_toplevel *toplevel,
+                                                  int32_t width, int32_t height,
+                                                  wl_array *states) {
+  // Fixed-size window: ignore compositor-suggested dimensions and states.
+  (void)data;
+  (void)toplevel;
+  (void)width;
+  (void)height;
+  (void)states;
+}
+
+void xdg_shell_surface::handle_toplevel_close(void *data,
+                                              xdg_toplevel *toplevel) {
+  (void)toplevel;
+  auto *self = static_cast<xdg_shell_surface *>(data);
+  if (self->m_on_close) { self->m_on_close(); }
+}
+
+}  // namespace conky

--- a/src/output/wl-shell.h
+++ b/src/output/wl-shell.h
@@ -1,0 +1,179 @@
+/*
+ *
+ * Conky, a system monitor, based on torsmo
+ *
+ * Please see COPYING for details
+ *
+ * Copyright (c) 2005-2024 Brenden Matthews, Philip Kovacs, et. al.
+ *	(see AUTHORS)
+ * All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef CONKY_WL_SHELL_H
+#define CONKY_WL_SHELL_H
+
+#include "config.h"
+
+#ifndef BUILD_WAYLAND
+#error wl-shell.h included when BUILD_WAYLAND is disabled
+#endif
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <type_traits>
+
+#include "gui.h"
+
+struct wl_array;
+struct wl_surface;
+struct zwlr_layer_shell_v1;
+struct zwlr_layer_surface_v1;
+struct zwlr_layer_surface_v1_listener;
+struct xdg_surface;
+struct xdg_surface_listener;
+struct xdg_toplevel;
+struct xdg_toplevel_listener;
+struct xdg_wm_base;
+
+namespace conky {
+
+/// @brief Edge(s) a surface anchors to / reserves against.
+///
+/// Aliases the cardinal `alignment` constants, so a `screen_edge` and an
+/// `alignment` share an encoding and are (almost) freely castable.
+enum class screen_edge : uint8_t {
+  NONE = *alignment::NONE,
+  TOP = *alignment::TOP_MIDDLE,
+  LEFT = *alignment::MIDDLE_LEFT,
+  RIGHT = *alignment::MIDDLE_RIGHT,
+  BOTTOM = *alignment::BOTTOM_MIDDLE,
+};
+
+/// @brief Abstracts a Wayland shell role bound to a `wl_surface`.
+///
+/// Concrete shells (wlr-layer-shell, xdg-shell, and Iron Man suit AR shell)
+/// translate conky's desired geometry into role-specific protocol requests.
+class shell_surface {
+ public:
+  virtual ~shell_surface() = default;
+
+  /// @brief Push the desired logical surface size to the role.
+  virtual void set_size(uint32_t width, uint32_t height) = 0;
+
+  /// @brief Reserve screen space along an edge (struts).
+  ///
+  /// Only honoured by roles that support it (see @ref supports_struts); the
+  /// default is a no-op so e.g. xdg toplevels can ignore it.
+  ///
+  /// @param edge edge(s) to anchor the surface to
+  /// @param exclusive_zone perpendicular size to reserve, including the margin
+  /// @param margin_x horizontal distance from the anchored edge
+  /// @param margin_y vertical distance from the anchored edge
+  virtual void reserve_space(screen_edge edge, int exclusive_zone, int margin_x,
+                             int margin_y) {
+    (void)edge;
+    (void)exclusive_zone;
+    (void)margin_x;
+    (void)margin_y;
+  }
+
+  /// @brief Whether the role can reserve screen space (struts/anchoring).
+  virtual bool supports_struts() const { return false; }
+};
+
+/// @brief Called when the compositor closes the shell surface (toplevel close
+/// button, layer surface closed).
+using close_shell_handler = void (*)();
+
+struct shell_params {
+  close_shell_handler on_close = nullptr;
+};
+
+/// @brief wlr-layer-shell role: a surface mounted on a compositor layer, able
+/// to anchor to edges and reserve screen space.
+class layer_shell_surface final : public shell_surface {
+ public:
+  struct params : public shell_params {
+    wl_surface *surface = nullptr;
+    zwlr_layer_shell_v1 *layer_shell = nullptr;
+    uint32_t layer = 0;  ///< ZWLR_LAYER_SHELL_V1_LAYER_* value
+    const char *m_namespace = "conky";
+  };
+
+  explicit layer_shell_surface(const params &p);
+  ~layer_shell_surface() override;
+
+  void set_size(uint32_t width, uint32_t height) override;
+  void reserve_space(screen_edge edge, int exclusive_zone, int margin_x,
+                     int margin_y) override;
+  bool supports_struts() const override { return true; }
+
+ private:
+  static void handle_configure(void *data, zwlr_layer_surface_v1 *surface,
+                               uint32_t serial, uint32_t width,
+                               uint32_t height);
+  static void handle_closed(void *data, zwlr_layer_surface_v1 *surface);
+  static const zwlr_layer_surface_v1_listener listener;
+
+  zwlr_layer_surface_v1 *m_layer_surface = nullptr;
+  close_shell_handler m_on_close = nullptr;
+};
+
+/// @brief xdg-shell role: a normal, compositor-managed toplevel window.
+///
+/// conky has a fixed content size, so the toplevel is pinned to that size.
+class xdg_shell_surface final : public shell_surface {
+ public:
+  struct params : public shell_params {
+    wl_surface *surface = nullptr;
+    xdg_wm_base *xdg_shell = nullptr;
+    std::string title;
+    std::string app_id;
+  };
+
+  explicit xdg_shell_surface(const params &p);
+  ~xdg_shell_surface() override;
+
+  void set_size(uint32_t width, uint32_t height) override;
+
+ private:
+  static void handle_surface_configure(void *data, xdg_surface *surface,
+                                       uint32_t serial);
+  static void handle_toplevel_configure(void *data, xdg_toplevel *toplevel,
+                                        int32_t width, int32_t height,
+                                        wl_array *states);
+  static void handle_toplevel_close(void *data, xdg_toplevel *toplevel);
+  static const xdg_surface_listener surface_listener;
+  static const xdg_toplevel_listener toplevel_listener;
+
+  xdg_surface *m_xdg_surface = nullptr;
+  xdg_toplevel *m_xdg_toplevel = nullptr;
+  close_shell_handler m_on_close = nullptr;
+};
+
+/// @brief Constructs a shell role of type @p Shell from its `params`.
+template <typename Shell>
+std::unique_ptr<shell_surface> create_shell_surface(
+    const typename Shell::params &params) {
+  static_assert(std::is_base_of_v<shell_surface, Shell>,
+                "Shell must derive from conky::shell_surface");
+  return std::make_unique<Shell>(params);
+}
+
+}  // namespace conky
+
+#endif /* CONKY_WL_SHELL_H */

--- a/src/wl_protocols/fractional-scale-v1.xml
+++ b/src/wl_protocols/fractional-scale-v1.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="fractional_scale_v1">
+  <copyright>
+    Copyright © 2022 Kenny Levinsen
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="Protocol for requesting fractional surface scales">
+    This protocol allows a compositor to suggest for surfaces to render at
+    fractional scales.
+
+    A client can submit scaled content by utilizing wp_viewport. This is done by
+    creating a wp_viewport object for the surface and setting the destination
+    rectangle to the surface size before the scale factor is applied.
+
+    The buffer size is calculated by multiplying the surface size by the
+    intended scale.
+
+    The wl_surface buffer scale should remain set to 1.
+
+    If a surface has a surface-local size of 100 px by 50 px and wishes to
+    submit buffers with a scale of 1.5, then a buffer of 150px by 75 px should
+    be used and the wp_viewport destination rectangle should be 100 px by 50 px.
+
+    For toplevel surfaces, the size is rounded halfway away from zero. The
+    rounding algorithm for subsurface position and size is not defined.
+  </description>
+
+  <interface name="wp_fractional_scale_manager_v1" version="1">
+    <description summary="fractional surface scale information">
+      A global interface for requesting surfaces to use fractional scales.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="unbind the fractional surface scale interface">
+        Informs the server that the client will not be using this protocol
+        object anymore. This does not affect any other objects,
+        wp_fractional_scale_v1 objects included.
+      </description>
+    </request>
+
+    <enum name="error">
+      <entry name="fractional_scale_exists" value="0"
+        summary="the surface already has a fractional_scale object associated"/>
+    </enum>
+
+    <request name="get_fractional_scale">
+      <description summary="extend surface interface for scale information">
+        Create an add-on object for the the wl_surface to let the compositor
+        request fractional scales. If the given wl_surface already has a
+        wp_fractional_scale_v1 object associated, the fractional_scale_exists
+        protocol error is raised.
+      </description>
+      <arg name="id" type="new_id" interface="wp_fractional_scale_v1"
+           summary="the new surface scale info interface id"/>
+      <arg name="surface" type="object" interface="wl_surface"
+           summary="the surface"/>
+    </request>
+  </interface>
+
+  <interface name="wp_fractional_scale_v1" version="1">
+    <description summary="fractional scale interface to a wl_surface">
+      An additional interface to a wl_surface object which allows the compositor
+      to inform the client of the preferred scale.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="remove surface scale information for surface">
+        Destroy the fractional scale object. When this object is destroyed,
+        preferred_scale events will no longer be sent.
+      </description>
+    </request>
+
+    <event name="preferred_scale">
+      <description summary="notify of new preferred scale">
+        Notification of a new preferred scale for this surface that the
+        compositor suggests that the client should use.
+
+        The sent scale is the numerator of a fraction with a denominator of 120.
+      </description>
+      <arg name="scale" type="uint" summary="the new preferred scale"/>
+    </event>
+  </interface>
+</protocol>


### PR DESCRIPTION
This PR builds on #2382 and adds some missing Wayland protocol support.

- Cleaned up Wayland code.
- Added support for fractional scaling.
  - The initial scaling support was the first/minimal support. Many modern compositors no longer use it (e.g. Hyprland doesn't notify us of scale change), but it's kept for completeness. 
  - [x] Tested with 2.5 display scale on Hyprland, the window is crisp.
- Added support for `own_window_type` on Wayland.
  - Some types do the same thing but should retain placement that was expected in X11 configs.
  - Added support for exclusive zones (closes #2029)-
  - [x] Tested layer placement, alignment rules, and reservation. Plays nice with Waybar.
- Added support for `own_window` on Wayland as XDG Shell.
  - Conky can now run on GNOME as a normal window.
    - Not something most people go for, but there is a real use case were someone might want to just run Conky as a normal window to output system information in one place.
    - Almost completes feature parity with X11 window management, maintenance cost is extremely low for this on Wayland.