### PR TITLE
chore: bump version to v1.24.3

### DIFF
--- a/cmake/Conky.cmake
+++ b/cmake/Conky.cmake
@@ -155,7 +155,7 @@ endif(OS_HAIKU)
 # Do version stuff
 set(VERSION_MAJOR "1")
 set(VERSION_MINOR "24")
-set(VERSION_PATCH "2")
+set(VERSION_PATCH "3")
 
 find_program(APP_AWK awk)
 


### PR DESCRIPTION
Bump Conky version to v1.24.3.

Validation:
- Not run; version-only change.