### PR TITLE
feat(wayland): honor own_window_hints via layer-shell

### DIFF
--- a/doc/config_settings.yaml
+++ b/doc/config_settings.yaml
@@ -427,7 +427,7 @@ values:
       - color
   - name: own_window_hints
     desc: |-
-      If [`own_window`](#own_window) is set, on X11 you may specify comma separated window
+      If [`own_window`](#own_window) is set, you may specify comma separated window
       manager hints to affect the way Conky displays.
 
       Following hints are some of the standard WM specification ones:
@@ -446,6 +446,14 @@ values:
       Notes:
       - Use `own_window_type='desktop'` setting as another way to implement many of these hints implicitly.
       - If you use `own_window_type='override'`, window manager hints have no meaning and are ignored.
+      - Under Wayland these hints are translated to a wlr-layer-shell placement
+        (the compositor must support that protocol). A `normal` or `utility`
+        window that would otherwise be a regular toplevel is instead mounted as
+        a layer surface when any of `below`, `above` or `sticky` is set:
+        `below`/`above` pick the bottom/top layer, while `sticky` (shown across
+        all workspaces), `skip_taskbar` and `skip_pager` are intrinsic to layer
+        surfaces. `undecorated` is implicit since layer surfaces are never
+        decorated.
     args:
       - hint(,hint)*
   - name: own_window_title

--- a/src/output/display-wayland.cc
+++ b/src/output/display-wayland.cc
@@ -439,11 +439,37 @@ void window_commit_buffer(window *window);
 
 void window_get_width_height(window *window, int *w, int *h);
 
-/// @brief Maps the configured `own_window_type` onto a wlr-layer-shell layer.
+/// @brief Whether `own_window_hints` request behaviour that only the layer
+/// shell can provide.
 ///
-/// Desktop widgets sit on the background, docks below regular windows, and
-/// panels above them; everything else keeps the historical bottom layer.
-static zwlr_layer_shell_v1_layer layer_for_window_type() {
+/// xdg-shell toplevels are always compositor-managed: they stack among regular
+/// windows and are bound to a single workspace. Hints asking for the opposite
+/// (`below`/`above` stacking or `sticky` across workspaces) can therefore only
+/// be honoured by mounting the surface on a wlr-layer-shell layer. (Layer
+/// surfaces are also intrinsically skipped by taskbars/pagers, so those hints
+/// need no special handling here.)
+static bool hints_require_layer_shell() {
+  uint16_t hints = own_window_hints.get(*state);
+  return TEST_HINT(hints, window_hints::BELOW) ||
+         TEST_HINT(hints, window_hints::ABOVE) ||
+         TEST_HINT(hints, window_hints::STICKY);
+}
+
+/// @brief Maps the configured `own_window_type` and `own_window_hints` onto a
+/// wlr-layer-shell layer.
+///
+/// Explicit `above`/`below` hints take precedence and pick the top/bottom
+/// layer. Otherwise the window type decides: desktop widgets sit on the
+/// background, docks below regular windows, and panels above them; everything
+/// else keeps the historical bottom layer.
+static zwlr_layer_shell_v1_layer layer_for_window() {
+  uint16_t hints = own_window_hints.get(*state);
+  if (TEST_HINT(hints, window_hints::ABOVE)) {
+    return ZWLR_LAYER_SHELL_V1_LAYER_TOP;
+  }
+  if (TEST_HINT(hints, window_hints::BELOW)) {
+    return ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM;
+  }
   switch (own_window_type.get(*state)) {
     case window_type::DESKTOP:
       return ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND;
@@ -661,23 +687,26 @@ bool display_output_wayland::initialize() {
   // An own_window of normal/utility type becomes a regular compositor-managed
   // toplevel; everything else (desktop/dock/panel, or no own_window) mounts as
   // a layer surface, falling back to an xdg toplevel when the compositor lacks
-  // wlr-layer-shell.
+  // wlr-layer-shell. own_window_hints that only a layer surface can satisfy
+  // (below/above/sticky) also force the layer path.
   window_type type = own_window_type.get(*state);
-  bool want_toplevel = own_window.get(*state) && (type == window_type::NORMAL ||
-                                                  type == window_type::UTILITY);
+  bool hints_layer_shell =
+      own_window.get(*state) &&
+      (type == window_type::NORMAL || type == window_type::UTILITY) &&
+      !hints_require_layer_shell();
   auto on_close = []() { g_sigterm_pending = 1; };
 
-  if (!want_toplevel && wl_globals.layer_shell != nullptr) {
+  if (!hints_layer_shell && wl_globals.layer_shell != nullptr) {
     global_window->shell =
         conky::create_shell_surface<conky::layer_shell_surface>({
             on_close,
             global_window->surface,
             wl_globals.layer_shell,
-            static_cast<uint32_t>(layer_for_window_type()),
+            static_cast<uint32_t>(layer_for_window()),
             "conky",
         });
   } else {
-    if (!want_toplevel) {
+    if (!hints_layer_shell) {
       LOG_WARNING(
           "compositor lacks wlr-layer-shell; falling back to an xdg-shell "
           "toplevel (desktop/dock/panel space reservation unavailable)");

--- a/src/output/gui.cc
+++ b/src/output/gui.cc
@@ -143,7 +143,7 @@ conky::lua_traits<window_type>::Map conky::lua_traits<window_type>::map = {
 };
 #endif /* OWN_WINDOW || BUILD_WAYLAND */
 
-#ifdef OWN_WINDOW
+#if defined(OWN_WINDOW) || defined(BUILD_WAYLAND)
 template <>
 conky::lua_traits<window_hints>::Map conky::lua_traits<window_hints>::map = {
     {"undecorated", window_hints::UNDECORATED},
@@ -176,7 +176,7 @@ std::pair<uint16_t, bool> window_hints_traits::convert(
   }
   return {ret, true};
 }
-#endif
+#endif /* OWN_WINDOW || BUILD_WAYLAND */
 
 #if defined(OWN_WINDOW) || defined(BUILD_WAYLAND)
 namespace {
@@ -228,10 +228,10 @@ conky::simple_config_setting<window_type> own_window_type("own_window_type",
                                                           false);
 #endif /* OWN_WINDOW || BUILD_WAYLAND */
 
-#if defined(OWN_WINDOW) && defined(BUILD_X11)
+#if defined(OWN_WINDOW) || defined(BUILD_WAYLAND)
 conky::simple_config_setting<uint16_t, window_hints_traits> own_window_hints(
     "own_window_hints", 0, false);
-#endif /* OWN_WINDOW && BUILD_X11 */
+#endif /* OWN_WINDOW || BUILD_WAYLAND */
 
 #if defined(OWN_WINDOW) || defined(BUILD_WAYLAND)
 priv::colour_setting background_colour("own_window_colour", 0);

--- a/src/output/gui.h
+++ b/src/output/gui.h
@@ -128,13 +128,14 @@ constexpr uint8_t operator*(window_type index) {
   return static_cast<uint8_t>(index);
 }
 
-#if defined(BUILD_X11) && defined(OWN_WINDOW)
-// Only works in X11 because Wayland doesn't support
-
+#if defined(OWN_WINDOW) || defined(BUILD_WAYLAND)
 /// @brief Hints are used to tell WM how it should treat a window.
 ///
-/// See: [X11 wm-spec `_NET_WM_STATE` property](
-/// https://specifications.freedesktop.org/wm-spec/1.3/ar01s05.html#idm45684324611552)
+/// On X11 these map onto the [wm-spec `_NET_WM_STATE` property](
+/// https://specifications.freedesktop.org/wm-spec/1.3/ar01s05.html#idm45684324611552).
+/// On Wayland there is no equivalent for toplevels, so they're translated into
+/// a wlr-layer-shell placement (e.g. `below`/`above` pick the layer, while
+/// `sticky`/`skip_taskbar`/`skip_pager` are intrinsic to layer surfaces).
 enum class window_hints : uint16_t {
   UNDECORATED = 0,
   BELOW,
@@ -209,7 +210,7 @@ extern conky::range_config_setting<int> border_width;
 
 extern conky::simple_config_setting<bool> forced_redraw;
 
-#if defined(OWN_WINDOW) && defined(BUILD_X11)
+#if defined(OWN_WINDOW) || defined(BUILD_WAYLAND)
 struct window_hints_traits {
   static const lua::Type type = lua::TSTRING;
   typedef uint16_t Type;
@@ -218,7 +219,7 @@ struct window_hints_traits {
 };
 extern conky::simple_config_setting<uint16_t, window_hints_traits>
     own_window_hints;
-#endif /* OWN_WINDOW && BUILD_X11 */
+#endif /* OWN_WINDOW || BUILD_WAYLAND */
 
 #if defined(OWN_WINDOW) || defined(BUILD_WAYLAND)
 extern priv::own_window_setting own_window;


### PR DESCRIPTION
Make the `window_hints` enum, helpers, and `own_window_hints` setting available on Wayland builds, and use the hints to guide the shell role: a `normal`/`utility` window with `below`/`above`/`sticky` mounts as a `wlr-layer-shell` surface (`below`/`above` choosing the layer) instead of a toplevel. Layer surfaces are intrinsically sticky and skipped by taskbars/pagers, which restores the pre-1.24.2 desktop-widget behaviour while keeping conky reasonably configurable under Wayland.

Closes #2404