### PR TITLE
fix: add missing x11.h imports

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -2422,17 +2422,10 @@ void initialisation(int argc, char **argv) {
         own_window.lua_set(*state);
         break;
 #endif
-#ifdef BUILD_XDBE
       case 'b':
         state->pushboolean(true);
-        use_xdbe.lua_set(*state);
+        use_double_buffer.lua_set(*state);
         break;
-#else
-      case 'b':
-        state->pushboolean(true);
-        use_xpmdb.lua_set(*state);
-        break;
-#endif
 #endif /* BUILD_X11 */
       case 't':
         free_and_zero(global_text);

--- a/src/lua/x11-settings.h
+++ b/src/lua/x11-settings.h
@@ -13,10 +13,6 @@ extern conky::simple_config_setting<bool> out_to_x;
 extern conky::simple_config_setting<bool> use_xft;
 #endif
 
-#ifdef BUILD_XDBE
-extern conky::simple_config_setting<bool> use_xdbe;
-#else
-extern conky::simple_config_setting<bool> use_xpmdb;
-#endif
+extern conky::simple_config_setting<bool> use_double_buffer;
 
 #endif /* CONKY_X11_SETTINGS_H */

--- a/src/output/display-x11.cc
+++ b/src/output/display-x11.cc
@@ -240,19 +240,14 @@ bool display_output_x11::initialize() {
   init_x11();
   x11_init_window(*state);
 
-#if defined(BUILD_XDBE)
-  auto &double_buffer = use_xdbe;
-#else
-  auto &double_buffer = use_xpmdb;
-#endif
-  if (double_buffer.get(*state)) {
+  if (use_double_buffer.get(*state)) {
     if (!x11_set_up_double_buffer(*state)) {
       // double buffering unavailable; reflect that in the value consumers read
       state->pushboolean(false);
-      double_buffer.lua_set(*state);
+      use_double_buffer.lua_set(*state);
     }
     LOG_INFO("drawing to {} buffer",
-             double_buffer.get(*state) ? "double" : "single");
+             use_double_buffer.get(*state) ? "double" : "single");
   }
 
 #ifdef BUILD_IMLIB2
@@ -260,9 +255,7 @@ bool display_output_x11::initialize() {
 #endif /* BUILD_IMLIB2 */
 
   X11_create_window();
-#ifdef BUILD_LUA_CAIRO_XLIB
   update_surface();
-#endif /* BUILD_LUA_CAIRO_XLIB */
   return true;
 }
 
@@ -328,9 +321,9 @@ bool display_output_x11::main_loop_wait(double t) {
         set_transparent_background(&window);
 #ifdef BUILD_XDBE
         /* swap buffers */
-        xdbe_swap_buffers();
+        swap_x11_buffers();
 #else
-        if (use_xpmdb.get(*state)) {
+        if (use_double_buffer.get(*state)) {
           XFreePixmap(display, window.back_buffer);
           unsigned int depth = window.color_depth != 0
                                    ? window.color_depth
@@ -359,9 +352,7 @@ bool display_output_x11::main_loop_wait(double t) {
 #endif
 
         changed++;
-#ifdef BUILD_LUA_CAIRO_XLIB
         update_surface();
-#endif /* BUILD_LUA_CAIRO_XLIB */
       }
 
       /* move window if it isn't in right position */
@@ -386,11 +377,7 @@ bool display_output_x11::main_loop_wait(double t) {
 
     clear_text(1);
 
-#if defined(BUILD_XDBE)
-    if (use_xdbe.get(*state)) {
-#else
-    if (use_xpmdb.get(*state)) {
-#endif
+    if (use_double_buffer.get(*state)) {
       XRectangle rect = conky::rect<int>(text_start - border_total,
                                          text_size + border_total * 2)
                             .to_xrectangle();
@@ -415,11 +402,7 @@ bool display_output_x11::main_loop_wait(double t) {
    * all, then no swap happens and we can safely do nothing. */
 
   if (XEmptyRegion(window.repaint_region) == 0) {
-#if defined(BUILD_XDBE)
-    if (use_xdbe.get(*state)) {
-#else
-    if (use_xpmdb.get(*state)) {
-#endif
+    if (use_double_buffer.get(*state)) {
       XRectangle rect = conky::rect<int>(text_start - border_total,
                                          text_size + border_total * 2)
                             .to_xrectangle();
@@ -1012,23 +995,16 @@ float display_output_x11::get_dpi_scale() {
 }
 
 void display_output_x11::end_draw_stuff() {
-#if defined(BUILD_XDBE)
-  xdbe_swap_buffers();
-#else
-  xpmdb_swap_buffers();
-#endif
+  swap_x11_buffers();
 }
 
 void display_output_x11::clear_text(int exposures) {
-#ifdef BUILD_XDBE
-  if (use_xdbe.get(*state)) {
+  if (use_double_buffer.get(*state)) {
     /* The swap action is XdbeBackground, which clears */
     return;
   }
-#else
-  if (use_xpmdb.get(*state)) {
-    return;
-  } else
+#ifndef BUILD_XDBE
+  else
 #endif
   if ((display != nullptr) &&
       (window.window != 0u)) {  // make sure these are !null
@@ -1193,14 +1169,14 @@ void display_output_x11::load_fonts(bool utf8) {
   }
 }
 
-#ifdef BUILD_LUA_CAIRO_XLIB
 void display_output_x11::update_surface() {
+  #ifdef BUILD_LUA_CAIRO_XLIB
   current_surface.reset(cairo_xlib_surface_create(
                             display, window.drawable, window.visual,
                             window.geometry.width(), window.geometry.height()),
                         cairo_surface_destroy);
+  #endif /* BUILD_LUA_CAIRO_XLIB */
 }
-#endif /* BUILD_LUA_CAIRO_XLIB */
 
 std::weak_ptr<conky::draw_surface> display_output_x11::drawing_surface() {
 #ifdef BUILD_LUA_CAIRO_XLIB

--- a/src/output/display-x11.hh
+++ b/src/output/display-x11.hh
@@ -25,12 +25,8 @@
 
 #include "config.h"
 
-#include <limits>
 #include <memory>
-#include <string>
-#include <type_traits>
 
-#include "../lua/luamm.hh"
 #include "display-output.hh"
 
 namespace conky {
@@ -85,10 +81,9 @@ class display_output_x11 : public display_output_base {
 
   virtual std::weak_ptr<conky::draw_surface> drawing_surface();
 
-#ifdef BUILD_LUA_CAIRO_XLIB
-  /// (Re)create the cairo xlib surface for the current drawable/geometry.
+  /// (Re)create the cairo xlib surface for the current drawable/geometry if
+  /// `BUILD_LUA_CAIRO_XLIB` is enabled, no-op otherwise.
   void update_surface();
-#endif /* BUILD_LUA_CAIRO_XLIB */
 
   // X11-specific
  private:

--- a/src/output/x11.cc
+++ b/src/output/x11.cc
@@ -118,11 +118,7 @@ conky::simple_config_setting<bool> out_to_x("out_to_x", true, false);
 conky::simple_config_setting<bool> use_xft("use_xft", false, false);
 #endif
 conky::simple_config_setting<bool> forced_redraw("forced_redraw", false, false);
-#ifdef BUILD_XDBE
-conky::simple_config_setting<bool> use_xdbe("double_buffer", false, false);
-#else
-conky::simple_config_setting<bool> use_xpmdb("double_buffer", false, false);
-#endif
+conky::simple_config_setting<bool> use_double_buffer("double_buffer", false, false);
 
 /* local prototypes */
 static Window find_desktop_window(Window *p_root, Window *p_desktop);
@@ -1434,19 +1430,17 @@ void set_struts() {
 }
 #endif /* OWN_WINDOW */
 
+void swap_x11_buffers() {
 #ifdef BUILD_XDBE
-void xdbe_swap_buffers() {
-  if (use_xdbe.get(*state)) {
+  if (use_double_buffer.get(*state)) {
     XdbeSwapInfo swap;
 
     swap.swap_window = window.window;
     swap.swap_action = XdbeBackground;
     XdbeSwapBuffers(display, &swap, 1);
   }
-}
-#else
-void xpmdb_swap_buffers(void) {
-  if (use_xpmdb.get(*state)) {
+#else /* BUILD_XDBE */
+  if (use_double_buffer.get(*state)) {
     XCopyArea(display, window.back_buffer, window.window, window.gc, 0, 0,
               window.geometry.width(), window.geometry.height(), 0, 0);
     Colour c = get_background_colour_preference(*state);
@@ -1459,8 +1453,8 @@ void xpmdb_swap_buffers(void) {
                    window.geometry.width(), window.geometry.height());
     XFlush(display);
   }
-}
 #endif /* BUILD_XDBE */
+}
 
 void print_kdb_led(const int keybit, char *p, unsigned int p_max_size) {
   XKeyboardState x;

--- a/src/output/x11.h
+++ b/src/output/x11.h
@@ -31,7 +31,10 @@
 #error x11.h included when BUILD_X11 is disabled
 #endif
 
+extern "C" {
+#include <X11/X.h>
 #include <X11/Xatom.h>
+#include <X11/Xutil.h>
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wvariadic-macros"
 #include <X11/Xlib.h>
@@ -46,16 +49,16 @@
 #ifdef BUILD_XDAMAGE
 #include <X11/extensions/Xdamage.h>
 #endif
+#ifdef BUILD_XFIXES
+#include <X11/extensions/Xfixes.h>
+#endif
+}
 
 #include <cstdint>
 #include <functional>
 #include <vector>
 
-// TODO: remove lua requirement from x11_init_window
-#include "../lua/llua.h"
-
 #include "../geometry.h"
-#include "gui.h"
 #include "x11-event.h"
 
 #define ATOM(a) XInternAtom(display, #a, False)
@@ -67,9 +70,19 @@ extern int screen;
 
 constexpr int argb8888_color_depth = 32;
 
+#ifndef BUILD_XFIXES
+using XserverRegion = XID;
+#endif
 #ifndef BUILD_XDAMAGE
 using Damage = XID;
-using XserverRegion = XID;
+#endif
+#ifndef BUILD_XFT
+using XftDraw = void;
+#endif
+#ifdef BUILD_XDBE
+using back_buffer_t = XdbeBackBuffer;
+#else
+using back_buffer_t = Pixmap;
 #endif
 
 struct conky_x11_window {
@@ -120,14 +133,9 @@ struct conky_x11_window {
   /// is unioned into `damage_region`.
   XserverRegion damage_scratch = 0;
 
-#ifdef BUILD_XDBE
-  XdbeBackBuffer back_buffer;
-#else  /*BUILD_XDBE*/
-  Pixmap back_buffer;
-#endif /*BUILD_XDBE*/
-#ifdef BUILD_XFT
+  back_buffer_t back_buffer;
   XftDraw *xftdraw;
-#endif /*BUILD_XFT*/
+
   /// XInput2 extension opcode; 0 if unavailable.
   std::int32_t xi_opcode;
 
@@ -229,10 +237,6 @@ std::vector<Window> query_x11_windows_at_pos(
         [](XWindowAttributes &a) { return true; },
     bool eager = false);
 
-#ifdef BUILD_XDBE
-void xdbe_swap_buffers(void);
-#else
-void xpmdb_swap_buffers(void);
-#endif /* BUILD_XDBE */
+void swap_x11_buffers();
 
 #endif /* CONKY_X11_H */


### PR DESCRIPTION
Adds several includes to x11.h that were included transitively via Xft.h/extensions and that caused #2408. Went through all the types in the file, and they're now exactly the headers that define each type.

Also simplified some code by removing noisy BUILD_XDBE preprocessor guards that have identical branches.

Fixes #2408.
