### PR TITLE
fix(wayland): blocking forever in wl_display_dispatch.

### DIFF
--- a/src/output/display-wayland.cc
+++ b/src/output/display-wayland.cc
@@ -1143,7 +1143,12 @@ static void shm_pool_destroy(shm_pool *pool);
 static void shm_surface_data_destroy(void *p) {
   shm_surface_data *data = static_cast<shm_surface_data *>(p);
   wl_buffer_destroy(data->buffer);
-  if (data->pool) shm_pool_destroy(data->pool);
+
+  if (data->pool) { shm_pool_destroy(data->pool); }
+
+  // Make sure the wayland server knows about the buffer destroy and the pool
+  // destroy.
+  wl_display_roundtrip(global_display);
 
   delete data;
 }
@@ -1355,13 +1360,7 @@ window *window_create(wl_surface *surface, wl_shm *shm, int width, int height) {
 }
 
 void window_free_buffer(window *window) {
-  for (int i = 0; i < 2; ++i) {
-    if (!window->shm_surface[i]) continue;
-    auto *data = static_cast<shm_surface_data *>(cairo_surface_get_user_data(
-        window->shm_surface[i].get(), &shm_surface_data_key));
-    while (data && data->busy) { wl_display_dispatch(global_display); }
-  }
-  for (int i = 0; i < 2; ++i) { window->shm_surface[i] = nullptr; }
+  for (int i = 0; i < 2; ++i) { window->shm_surface[i].reset(); }
   window->cr = nullptr;
   window->cairo_surface = nullptr;
   if (window->layout) g_object_unref(window->layout);


### PR DESCRIPTION
The documentation for wl_display_dispatch says that it will block waiting on events from the display fd. As best as I can tell, because of the busy loop, nothing changes the state of the display so the Wayland server has no reason to send the buffer release event. The buffer release event is what the busy loop is waiting for hence blocking forever.

The fix moves Wayland communication into the destructor chain for window->shm_surface. The window->shm_surface[i].reset() does the following:
  1. It calls the lambda set in create_shm_surface_from_pool.
  2. The lambda calls cairo_surface_destroy.
  3. cairo_surface_destroy calls shm_surface_data_destroy
  4. shm_surface_data_destroy destroys its buffer and its pool and then calls wl_display_roundtrip which will wait for the Wayland server to acknowledge the buffer destroy and the pool destroy.

Fixes #2411.
