### PR TITLE
feat: add lua_http_response_hook for customizable HTTP responses

### DIFF
--- a/doc/config_settings.yaml
+++ b/doc/config_settings.yaml
@@ -271,6 +271,18 @@ values:
     args:
       - function_name
       - [function arguments]
+  - name: lua_http_response_hook
+    desc: |-
+      This function, if defined, will be called by Conky on each request
+      when using the HTTP output ('out_to_http'). It should return a table
+      with a 'body' string, and optionally a 'status' number (defaults to
+      200) and a 'headers' table mapping header names to values. If unset,
+      or if the returned value can't be used, Conky falls back to its
+      default HTML page. Conky puts 'conky_' in front of function_name to
+      prevent accidental calls to the wrong function unless you place
+      'conky_' in front of it yourself.
+    args:
+      - function_name
   - name: lua_load
     desc: |-
       List of Lua script paths to load at startup in order to provide Lua

--- a/src/lua/llua.cc
+++ b/src/lua/llua.cc
@@ -142,6 +142,8 @@ conky::simple_config_setting<std::string> lua_draw_hook_post(
 // here (mirrors lua_startup_hook above), used by the HTTP display backend to
 // let users customize the HTTP response (body/status/headers) instead of the
 // hardcoded HTML in display-http.cc.
+conky::simple_config_setting<std::string> lua_http_response_hook(
+    "lua_http_response_hook", std::string(), true);
 
 }  // namespace
 
@@ -480,6 +482,83 @@ static char *llua_getstring(const char *args) {
 
   return ret;
 }
+
+// TODO(#2395): implement llua_http_response_hook() (declared in llua.h).
+// sendanswer() in display-http.cc still needs to call this (guarded by
+// builder_mutex, since this runs on microhttpd's worker thread rather than
+// the draw thread) and build its MHD_Response from the results instead of
+// always serving the hardcoded HTML page.
+//
+// bool llua_http_response_hook(body, status, headers):
+//     # 1. Bail out early if no hook is configured -- backward compatible,
+//     #    does nothing unless the user opts in, same pattern as
+//     #    llua_startup_hook().
+//     if lua_http_response_hook setting is empty string:
+//         return false
+//
+//     # 2. Call the user's Lua function by name, asking Lua to leave exactly
+//     #    1 return value on the stack. llua_do_call() handles resolving the
+//     #    "conky_" prefix and lua_pcall(); on failure it already logged the
+//     #    error and returns nullptr.
+//     func_name = llua_do_call(configured hook name, retc=1)
+//     if func_name is nullptr:
+//         return false   # Lua call itself failed; nothing left on stack
+//
+//     # 3. The one return value is now on top of the Lua stack (index -1).
+//     #    We require it to be a table: { body = ..., status = ...,
+//     #    headers = {...} }.
+//     if top-of-stack is NOT a table:
+//         log warning "did not return a table"
+//         pop 1 (discard whatever it did return)
+//         return false
+//
+//     # --- read table.body ---
+//     # 4. lua_getfield pushes table["body"] onto the stack (now at index
+//     #    -1, table dropped to -2).
+//     push table["body"]
+//     if it's a string:
+//         *body = that string
+//     else:
+//         log warning "missing 'body' field"
+//     pop 1   # remove the field value, table is back at -1
+//
+//     # --- read table.status ---
+//     # 5. Same pattern: push the field, check type, pop it back off.
+//     push table["status"]
+//     if it's a number:
+//         *status = (int) that number
+//     # (no warning if missing -- status is optional, struct default 200)
+//     pop 1
+//
+//     # --- read table.headers ---
+//     # 6. push table["headers"]; if present it should itself be a table
+//     #    mapping header-name -> header-value.
+//     push table["headers"]
+//     if it's a table:
+//         # lua_next-based table iteration: push a nil "key" first, then
+//         # each call to lua_next pops the previous key and pushes the
+//         # next key/value pair, returning 0 when there are no more
+//         # entries.
+//         push nil  # seed key for iteration
+//         while lua_next(headers_table) pops key, pushes (next_key, value):
+//             if key is string AND value is string:
+//                 headers.append( (key, value) )
+//             pop 1   # drop value, leave key on stack for next lua_next()
+//         # (lua_next itself pops the final key when iteration ends)
+//     pop 1   # remove the headers table/field, response table back at -1
+//
+//     # 7. Clean up: remove the response table itself, restoring the stack
+//     #    to how it was before this function ran (every push needs a
+//     #    matching pop, or the stack grows forever across requests).
+//     pop 1
+//
+//     return true
+//
+// NOTE: watch the lua_next() gotcha -- don't call lua_tostring() on a key
+// still needed for the next lua_next() call without care, since
+// lua_tostring() can coerce numbers to strings in place and corrupt
+// iteration. Use a duplicated stack value (lua_pushvalue) before
+// converting, or convert the value first and key last.
 
 #if 0
 /* call a function with args, and return a string from it (must be free'd) */

--- a/src/lua/llua.cc
+++ b/src/lua/llua.cc
@@ -479,9 +479,49 @@ static char *llua_getstring(const char *args) {
   return ret;
 }
 
-// TODO: implement llua_http_response_hook, call it from sendanswer() in
-// display-http.cc under builder_mutex. Watch out for the lua_next/
-// lua_tostring ordering issue when reading the headers table.
+/* call the configured http response hook; returns true and fills body/status/headers if it returned a table */
+bool llua_http_response_hook(
+std::string *body, int *status,
+  std::vector<std::pair<std::string, std::string>> *headers) {
+    if (lua_http_response_hook.get(*state).empty()) { return false; }
+
+    char *func = llua_do_call(lua_http_response_hook.get(*state).c_str(), 1);
+    if (func == nullptr) { return false; }
+    if (lua_istable(lua_L, -1) == 0){
+      LOG_WARNING("lua function '{}' did not return a table, result discard", func);
+      lua_pop(lua_L, 1);
+      return false;
+    }
+
+    lua_getfield(lua_L, -1, "body");
+    if (lua_isstring(lua_L, -1) != 0) {
+      *body = lua_tostring(lua_L, -1);
+    } else {
+      LOG_WARNING("lua function '{}' table missing string 'body' field", func);
+    }
+    lua_pop(lua_L, 1);
+
+    lua_getfield(lua_L, -1, "status");
+    if (lua_isnumber(lua_L, -1) != 0) {
+      *status = static_cast<int>(lua_tonumber(lua_L, -1));
+    }
+    lua_pop(lua_L, 1);
+
+    lua_getfield(lua_L, -1, "headers");
+    if (lua_istable(lua_L, -1) != 0) {
+      lua_pushnil(lua_L);
+      while (lua_next(lua_L, -2) != 0) {
+        if (lua_isstring(lua_L, -2) != 0 && lua_isstring(lua_L, -1) != 0) {
+          headers->emplace_back(lua_tostring(lua_L, -2), lua_tostring(lua_L, -1));
+        }
+        lua_pop(lua_L, 1);
+      }
+    }
+    lua_pop(lua_L, 1);
+
+    lua_pop(lua_L, 1);
+    return true;
+  }
 
 #if 0
 /* call a function with args, and return a string from it (must be free'd) */

--- a/src/lua/llua.cc
+++ b/src/lua/llua.cc
@@ -33,8 +33,10 @@
 #include "../geometry.h"
 #include "../logging.h"
 #include "../output/display-output.hh"
+#include "../output/display-http.hh"
 #include "build.h"
 #include "llua.h"
+
 
 #ifdef BUILD_GUI
 #include "../output/gui.h"
@@ -90,7 +92,7 @@ class lua_load_setting : public conky::simple_config_setting<std::string> {
           if (ch == ';') { ch = '\0'; }
         }
       } else {
-        // TODO: Remove space-delimited file name handling in 3 years (2028.)
+        // TODO: Remove space-delimited file name handlisng in 3 years (2028.)
         for (auto &ch : files) {
           if (ch == ' ') { ch = '\0'; }
         }
@@ -481,23 +483,22 @@ static char *llua_getstring(const char *args) {
 
 /* call the configured http response hook; returns true and fills
  * body/status/headers if it returned a table */
-bool llua_http_response_hook(
-    std::string *body, int *status,
-    std::vector<std::pair<std::string, std::string>> *headers) {
-  if (lua_http_response_hook.get(*state).empty()) { return false; }
+std::optional<conky::http_response> llua_http_response_hook() {
+  if (lua_http_response_hook.get(*state).empty()) { return std::nullopt; }
 
   char *func = llua_do_call(lua_http_response_hook.get(*state).c_str(), 1);
-  if (func == nullptr) { return false; }
+  if (func == nullptr) { return std::nullopt; }
   if (lua_istable(lua_L, -1) == 0) {
     LOG_WARNING("lua function '{}' did not return a table, result discarded",
                 func);
     lua_pop(lua_L, 1);
-    return false;
+    return std::nullopt;
   }
+  conky::http_response response;
 
   lua_getfield(lua_L, -1, "body");
   if (lua_isstring(lua_L, -1) != 0) {
-    *body = lua_tostring(lua_L, -1);
+    response.body = lua_tostring(lua_L, -1);
   } else {
     LOG_WARNING("lua function '{}' table missing string 'body' field", func);
   }
@@ -505,7 +506,7 @@ bool llua_http_response_hook(
 
   lua_getfield(lua_L, -1, "status");
   if (lua_isnumber(lua_L, -1) != 0) {
-    *status = static_cast<int>(lua_tonumber(lua_L, -1));
+    response.status = static_cast<int>(lua_tonumber(lua_L, -1));
   }
   lua_pop(lua_L, 1);
 
@@ -514,7 +515,8 @@ bool llua_http_response_hook(
     lua_pushnil(lua_L);
     while (lua_next(lua_L, -2) != 0) {
       if (lua_type(lua_L, -2) == LUA_TSTRING && lua_isstring(lua_L, -1) != 0) {
-        headers->emplace_back(lua_tostring(lua_L, -2), lua_tostring(lua_L, -1));
+        response.headers.emplace_back(lua_tostring(lua_L, -2),
+                                      lua_tostring(lua_L, -1));
       }
       lua_pop(lua_L, 1);
     }
@@ -522,7 +524,7 @@ bool llua_http_response_hook(
   lua_pop(lua_L, 1);  // pop headers field
 
   lua_pop(lua_L, 1);  // pop the response table
-  return true;
+  return response;
 }
 
 #if 0

--- a/src/lua/llua.cc
+++ b/src/lua/llua.cc
@@ -136,8 +136,13 @@ conky::simple_config_setting<std::string> lua_draw_hook_pre("lua_draw_hook_pre",
                                                             true);
 conky::simple_config_setting<std::string> lua_draw_hook_post(
     "lua_draw_hook_post", std::string(), true);
+#endif /* BUILD_GUI */
 
-#endif
+// TODO(#2395): add `lua_http_response_hook` simple_config_setting<std::string>
+// here (mirrors lua_startup_hook above), used by the HTTP display backend to
+// let users customize the HTTP response (body/status/headers) instead of the
+// hardcoded HTML in display-http.cc.
+
 }  // namespace
 
 static int llua_conky_parse(lua_State *L) {

--- a/src/lua/llua.cc
+++ b/src/lua/llua.cc
@@ -479,49 +479,51 @@ static char *llua_getstring(const char *args) {
   return ret;
 }
 
-/* call the configured http response hook; returns true and fills body/status/headers if it returned a table */
+/* call the configured http response hook; returns true and fills
+ * body/status/headers if it returned a table */
 bool llua_http_response_hook(
-std::string *body, int *status,
-  std::vector<std::pair<std::string, std::string>> *headers) {
-    if (lua_http_response_hook.get(*state).empty()) { return false; }
+    std::string *body, int *status,
+    std::vector<std::pair<std::string, std::string>> *headers) {
+  if (lua_http_response_hook.get(*state).empty()) { return false; }
 
-    char *func = llua_do_call(lua_http_response_hook.get(*state).c_str(), 1);
-    if (func == nullptr) { return false; }
-    if (lua_istable(lua_L, -1) == 0){
-      LOG_WARNING("lua function '{}' did not return a table, result discard", func);
-      lua_pop(lua_L, 1);
-      return false;
-    }
-
-    lua_getfield(lua_L, -1, "body");
-    if (lua_isstring(lua_L, -1) != 0) {
-      *body = lua_tostring(lua_L, -1);
-    } else {
-      LOG_WARNING("lua function '{}' table missing string 'body' field", func);
-    }
+  char *func = llua_do_call(lua_http_response_hook.get(*state).c_str(), 1);
+  if (func == nullptr) { return false; }
+  if (lua_istable(lua_L, -1) == 0) {
+    LOG_WARNING("lua function '{}' did not return a table, result discarded",
+                func);
     lua_pop(lua_L, 1);
-
-    lua_getfield(lua_L, -1, "status");
-    if (lua_isnumber(lua_L, -1) != 0) {
-      *status = static_cast<int>(lua_tonumber(lua_L, -1));
-    }
-    lua_pop(lua_L, 1);
-
-    lua_getfield(lua_L, -1, "headers");
-    if (lua_istable(lua_L, -1) != 0) {
-      lua_pushnil(lua_L);
-      while (lua_next(lua_L, -2) != 0) {
-        if (lua_isstring(lua_L, -2) != 0 && lua_isstring(lua_L, -1) != 0) {
-          headers->emplace_back(lua_tostring(lua_L, -2), lua_tostring(lua_L, -1));
-        }
-        lua_pop(lua_L, 1);
-      }
-    }
-    lua_pop(lua_L, 1);
-
-    lua_pop(lua_L, 1);
-    return true;
+    return false;
   }
+
+  lua_getfield(lua_L, -1, "body");
+  if (lua_isstring(lua_L, -1) != 0) {
+    *body = lua_tostring(lua_L, -1);
+  } else {
+    LOG_WARNING("lua function '{}' table missing string 'body' field", func);
+  }
+  lua_pop(lua_L, 1);
+
+  lua_getfield(lua_L, -1, "status");
+  if (lua_isnumber(lua_L, -1) != 0) {
+    *status = static_cast<int>(lua_tonumber(lua_L, -1));
+  }
+  lua_pop(lua_L, 1);
+
+  lua_getfield(lua_L, -1, "headers");
+  if (lua_istable(lua_L, -1) != 0) {
+    lua_pushnil(lua_L);
+    while (lua_next(lua_L, -2) != 0) {
+      if (lua_isstring(lua_L, -2) != 0 && lua_isstring(lua_L, -1) != 0) {
+        headers->emplace_back(lua_tostring(lua_L, -2), lua_tostring(lua_L, -1));
+      }
+      lua_pop(lua_L, 1);
+    }
+  }
+  lua_pop(lua_L, 1);  // pop headers field
+
+  lua_pop(lua_L, 1);  // pop the response table
+  return true;
+}
 
 #if 0
 /* call a function with args, and return a string from it (must be free'd) */

--- a/src/lua/llua.cc
+++ b/src/lua/llua.cc
@@ -138,10 +138,6 @@ conky::simple_config_setting<std::string> lua_draw_hook_post(
     "lua_draw_hook_post", std::string(), true);
 #endif /* BUILD_GUI */
 
-// TODO(#2395): add `lua_http_response_hook` simple_config_setting<std::string>
-// here (mirrors lua_startup_hook above), used by the HTTP display backend to
-// let users customize the HTTP response (body/status/headers) instead of the
-// hardcoded HTML in display-http.cc.
 conky::simple_config_setting<std::string> lua_http_response_hook(
     "lua_http_response_hook", std::string(), true);
 
@@ -483,82 +479,9 @@ static char *llua_getstring(const char *args) {
   return ret;
 }
 
-// TODO(#2395): implement llua_http_response_hook() (declared in llua.h).
-// sendanswer() in display-http.cc still needs to call this (guarded by
-// builder_mutex, since this runs on microhttpd's worker thread rather than
-// the draw thread) and build its MHD_Response from the results instead of
-// always serving the hardcoded HTML page.
-//
-// bool llua_http_response_hook(body, status, headers):
-//     # 1. Bail out early if no hook is configured -- backward compatible,
-//     #    does nothing unless the user opts in, same pattern as
-//     #    llua_startup_hook().
-//     if lua_http_response_hook setting is empty string:
-//         return false
-//
-//     # 2. Call the user's Lua function by name, asking Lua to leave exactly
-//     #    1 return value on the stack. llua_do_call() handles resolving the
-//     #    "conky_" prefix and lua_pcall(); on failure it already logged the
-//     #    error and returns nullptr.
-//     func_name = llua_do_call(configured hook name, retc=1)
-//     if func_name is nullptr:
-//         return false   # Lua call itself failed; nothing left on stack
-//
-//     # 3. The one return value is now on top of the Lua stack (index -1).
-//     #    We require it to be a table: { body = ..., status = ...,
-//     #    headers = {...} }.
-//     if top-of-stack is NOT a table:
-//         log warning "did not return a table"
-//         pop 1 (discard whatever it did return)
-//         return false
-//
-//     # --- read table.body ---
-//     # 4. lua_getfield pushes table["body"] onto the stack (now at index
-//     #    -1, table dropped to -2).
-//     push table["body"]
-//     if it's a string:
-//         *body = that string
-//     else:
-//         log warning "missing 'body' field"
-//     pop 1   # remove the field value, table is back at -1
-//
-//     # --- read table.status ---
-//     # 5. Same pattern: push the field, check type, pop it back off.
-//     push table["status"]
-//     if it's a number:
-//         *status = (int) that number
-//     # (no warning if missing -- status is optional, struct default 200)
-//     pop 1
-//
-//     # --- read table.headers ---
-//     # 6. push table["headers"]; if present it should itself be a table
-//     #    mapping header-name -> header-value.
-//     push table["headers"]
-//     if it's a table:
-//         # lua_next-based table iteration: push a nil "key" first, then
-//         # each call to lua_next pops the previous key and pushes the
-//         # next key/value pair, returning 0 when there are no more
-//         # entries.
-//         push nil  # seed key for iteration
-//         while lua_next(headers_table) pops key, pushes (next_key, value):
-//             if key is string AND value is string:
-//                 headers.append( (key, value) )
-//             pop 1   # drop value, leave key on stack for next lua_next()
-//         # (lua_next itself pops the final key when iteration ends)
-//     pop 1   # remove the headers table/field, response table back at -1
-//
-//     # 7. Clean up: remove the response table itself, restoring the stack
-//     #    to how it was before this function ran (every push needs a
-//     #    matching pop, or the stack grows forever across requests).
-//     pop 1
-//
-//     return true
-//
-// NOTE: watch the lua_next() gotcha -- don't call lua_tostring() on a key
-// still needed for the next lua_next() call without care, since
-// lua_tostring() can coerce numbers to strings in place and corrupt
-// iteration. Use a duplicated stack value (lua_pushvalue) before
-// converting, or convert the value first and key last.
+// TODO: implement llua_http_response_hook, call it from sendanswer() in
+// display-http.cc under builder_mutex. Watch out for the lua_next/
+// lua_tostring ordering issue when reading the headers table.
 
 #if 0
 /* call a function with args, and return a string from it (must be free'd) */

--- a/src/lua/llua.cc
+++ b/src/lua/llua.cc
@@ -513,7 +513,7 @@ bool llua_http_response_hook(
   if (lua_istable(lua_L, -1) != 0) {
     lua_pushnil(lua_L);
     while (lua_next(lua_L, -2) != 0) {
-      if (lua_isstring(lua_L, -2) != 0 && lua_isstring(lua_L, -1) != 0) {
+      if (lua_type(lua_L, -2) == LUA_TSTRING && lua_isstring(lua_L, -1) != 0) {
         headers->emplace_back(lua_tostring(lua_L, -2), lua_tostring(lua_L, -1));
       }
       lua_pop(lua_L, 1);

--- a/src/lua/llua.h
+++ b/src/lua/llua.h
@@ -48,6 +48,13 @@ void llua_init();
 void llua_startup_hook(void);
 void llua_shutdown_hook(void);
 
+// TODO(#2395): declare llua_http_response_hook() here. Should call the
+// configured `lua_http_response_hook` Lua function and read back a table
+// (body/status/headers) so display-http.cc's sendanswer() can build a
+// customized MHD_Response instead of the hardcoded HTML page. Needs a new
+// table-reading path since llua_do_call() callers so far only expect a
+// string (llua_getstring) or number (llua_getnumber) return.
+
 #ifdef BUILD_GUI
 void llua_draw_pre_hook(void);
 void llua_draw_post_hook(void);

--- a/src/lua/llua.h
+++ b/src/lua/llua.h
@@ -30,9 +30,7 @@ extern "C" {
 #include <lualib.h>
 }
 
-#include <string>
-#include <utility>
-#include <vector>
+#include <optional>
 
 #include <config.h>
 #include "../geometry.h"
@@ -52,10 +50,14 @@ void llua_init();
 void llua_startup_hook(void);
 void llua_shutdown_hook(void);
 
-// Calls lua_http_response_hook, returns false if unset or unusable.
-bool llua_http_response_hook(
-    std::string *body, int *status,
-    std::vector<std::pair<std::string, std::string>> *headers);
+// Defined in display-http.hh; kept opaque here so this header doesn't need
+// to change if its fields do.
+namespace conky {
+struct http_response;
+}  // namespace conky
+
+// Calls lua_http_response_hook, returns nullopt if unset or unusable.
+std::optional<conky::http_response> llua_http_response_hook();
 
 #ifdef BUILD_GUI
 void llua_draw_pre_hook(void);

--- a/src/lua/llua.h
+++ b/src/lua/llua.h
@@ -30,6 +30,10 @@ extern "C" {
 #include <lualib.h>
 }
 
+#include <string>
+#include <utility>
+#include <vector>
+
 #include <config.h>
 #include "../geometry.h"
 
@@ -54,6 +58,13 @@ void llua_shutdown_hook(void);
 // customized MHD_Response instead of the hardcoded HTML page. Needs a new
 // table-reading path since llua_do_call() callers so far only expect a
 // string (llua_getstring) or number (llua_getnumber) return.
+//
+// Returns false (and leaves outputs untouched) if the hook isn't configured
+// or its return value couldn't be used, so callers know to fall back to
+// their default response.
+bool llua_http_response_hook(
+    std::string *body, int *status,
+    std::vector<std::pair<std::string, std::string>> *headers);
 
 #ifdef BUILD_GUI
 void llua_draw_pre_hook(void);

--- a/src/lua/llua.h
+++ b/src/lua/llua.h
@@ -52,16 +52,7 @@ void llua_init();
 void llua_startup_hook(void);
 void llua_shutdown_hook(void);
 
-// TODO(#2395): declare llua_http_response_hook() here. Should call the
-// configured `lua_http_response_hook` Lua function and read back a table
-// (body/status/headers) so display-http.cc's sendanswer() can build a
-// customized MHD_Response instead of the hardcoded HTML page. Needs a new
-// table-reading path since llua_do_call() callers so far only expect a
-// string (llua_getstring) or number (llua_getnumber) return.
-//
-// Returns false (and leaves outputs untouched) if the hook isn't configured
-// or its return value couldn't be used, so callers know to fall back to
-// their default response.
+// Calls lua_http_response_hook, returns false if unset or unusable.
 bool llua_http_response_hook(
     std::string *body, int *status,
     std::vector<std::pair<std::string, std::string>> *headers);

--- a/src/output/display-http.cc
+++ b/src/output/display-http.cc
@@ -71,15 +71,8 @@ MHD_Result sendanswer(void *cls, struct MHD_Connection *connection,
                       const char *url, const char *method, const char *version,
                       const char *upload_data, size_t *upload_data_size,
                       void **con_cls) {
-  // TODO(#2395): before falling back to `presented`, call
-  // llua_http_response_hook() (declared in llua.h). If it returns a
-  // populated http_response, build the MHD_Response from its body, add
-  // custom headers via MHD_add_response_header(), and queue with its status
-  // instead of the hardcoded MHD_HTTP_OK below. Calling into Lua here means
-  // this now runs on microhttpd's worker thread rather than the draw
-  // thread, so the Lua call needs to be guarded by a mutex too (reuse
-  // builder_mutex, since it already protects "what does this HTTP response
-  // look like").
+  // TODO: call llua_http_response_hook here before falling back to
+  // `presented`, use its status/headers if present.
   struct MHD_Response *response;
   {
     /* Copy the page out under the lock; MHD_RESPMEM_MUST_COPY snapshots the

--- a/src/output/display-http.cc
+++ b/src/output/display-http.cc
@@ -27,6 +27,7 @@
 #include <config.h>
 
 #include "../conky.h"
+#include "../lua/llua.h"
 #include "display-http.hh"
 
 #include <iostream>
@@ -71,10 +72,28 @@ MHD_Result sendanswer(void *cls, struct MHD_Connection *connection,
                       const char *url, const char *method, const char *version,
                       const char *upload_data, size_t *upload_data_size,
                       void **con_cls) {
-  // TODO: call llua_http_response_hook here before falling back to
-  // `presented`, use its status/headers if present.
-  struct MHD_Response *response;
+  std::string hook_body;
+  int hook_status = 200;
+  std::vector<std::pair<std::string, std::string>> hook_headers;
+  bool have_hook_response;
   {
+    /* llua_http_response_hook() may call into Lua from a non-draw thread. */
+    std::lock_guard<std::mutex> lock(builder_mutex);
+    have_hook_response =
+        llua_http_response_hook(&hook_body, &hook_status, &hook_headers);
+  }
+
+  struct MHD_Response *response;
+  int response_status = MHD_HTTP_OK;
+  if (have_hook_response) {
+    response = MHD_create_response_from_buffer(
+        hook_body.length(), (void *)hook_body.c_str(), MHD_RESPMEM_MUST_COPY);
+    for (const auto &header : hook_headers) {
+      MHD_add_response_header(response, header.first.c_str(),
+                              header.second.c_str());
+    }
+    response_status = hook_status;
+  } else {
     /* Copy the page out under the lock; MHD_RESPMEM_MUST_COPY snapshots the
      * bytes so we don't hand MHD a pointer into a string the draw thread may
      * reallocate. */
@@ -82,7 +101,8 @@ MHD_Result sendanswer(void *cls, struct MHD_Connection *connection,
     response = MHD_create_response_from_buffer(
         presented.length(), (void *)presented.c_str(), MHD_RESPMEM_MUST_COPY);
   }
-  MHD_Result ret = MHD_queue_response(connection, MHD_HTTP_OK, response);
+
+  MHD_Result ret = MHD_queue_response(connection, response_status, response);
   MHD_destroy_response(response);
   if (cls || url || method || version || upload_data || upload_data_size ||
       con_cls) {}  // make compiler happy

--- a/src/output/display-http.cc
+++ b/src/output/display-http.cc
@@ -72,27 +72,24 @@ MHD_Result sendanswer(void *cls, struct MHD_Connection *connection,
                       const char *url, const char *method, const char *version,
                       const char *upload_data, size_t *upload_data_size,
                       void **con_cls) {
-  std::string hook_body;
-  int hook_status = 200;
-  std::vector<std::pair<std::string, std::string>> hook_headers;
-  bool have_hook_response;
+  std::optional<conky::http_response> hook_response;
   {
     /* llua_http_response_hook() may call into Lua from a non-draw thread. */
     std::lock_guard<std::mutex> lock(builder_mutex);
-    have_hook_response =
-        llua_http_response_hook(&hook_body, &hook_status, &hook_headers);
+    hook_response = llua_http_response_hook();
   }
 
   struct MHD_Response *response;
   int response_status = MHD_HTTP_OK;
-  if (have_hook_response) {
+  if (hook_response) {
     response = MHD_create_response_from_buffer(
-        hook_body.length(), (void *)hook_body.c_str(), MHD_RESPMEM_MUST_COPY);
-    for (const auto &header : hook_headers) {
+        hook_response->body.length(), (void *)hook_response->body.c_str(),
+        MHD_RESPMEM_MUST_COPY);
+    for (const auto &header : hook_response->headers) {
       MHD_add_response_header(response, header.first.c_str(),
                               header.second.c_str());
     }
-    response_status = hook_status;
+    response_status = hook_response->status;
   } else {
     /* Copy the page out under the lock; MHD_RESPMEM_MUST_COPY snapshots the
      * bytes so we don't hand MHD a pointer into a string the draw thread may

--- a/src/output/display-http.cc
+++ b/src/output/display-http.cc
@@ -71,6 +71,15 @@ MHD_Result sendanswer(void *cls, struct MHD_Connection *connection,
                       const char *url, const char *method, const char *version,
                       const char *upload_data, size_t *upload_data_size,
                       void **con_cls) {
+  // TODO(#2395): before falling back to `presented`, call
+  // llua_http_response_hook() (declared in llua.h). If it returns a
+  // populated http_response, build the MHD_Response from its body, add
+  // custom headers via MHD_add_response_header(), and queue with its status
+  // instead of the hardcoded MHD_HTTP_OK below. Calling into Lua here means
+  // this now runs on microhttpd's worker thread rather than the draw
+  // thread, so the Lua call needs to be guarded by a mutex too (reuse
+  // builder_mutex, since it already protects "what does this HTTP response
+  // look like").
   struct MHD_Response *response;
   {
     /* Copy the page out under the lock; MHD_RESPMEM_MUST_COPY snapshots the

--- a/src/output/display-http.hh
+++ b/src/output/display-http.hh
@@ -63,6 +63,11 @@ class display_output_http : public display_output_base {
 
 std::string html_escape(const std::string &input);
 
+// TODO(#2395): add an http_response struct here (body, status, headers as
+// vector<pair<string,string>>) returned by the new llua_http_response_hook()
+// so sendanswer() in display-http.cc can build a customized MHD_Response
+// instead of always serving the hardcoded HTML page.
+
 }  // namespace conky
 
 #endif /* DISPLAY_HTTP_HH */

--- a/src/output/display-http.hh
+++ b/src/output/display-http.hh
@@ -65,21 +65,12 @@ class display_output_http : public display_output_base {
 
 std::string html_escape(const std::string &input);
 
-/*
- * Result of the user-defined `lua_http_response_hook`, used to customize the
- * response the HTTP backend serves instead of the hardcoded HTML page.
- */
+// Response built from the user's lua_http_response_hook, if configured.
 struct http_response {
   std::string body;
   int status = 200;
   std::vector<std::pair<std::string, std::string>> headers;
 };
-
-// TODO(#2395): add llua_http_response_hook() (declared in llua.h) that calls
-// the configured `lua_http_response_hook` Lua function and fills in an
-// http_response from its returned table. Then wire it into sendanswer() in
-// display-http.cc, guarded by builder_mutex since it'll run on microhttpd's
-// worker thread.
 
 }  // namespace conky
 

--- a/src/output/display-http.hh
+++ b/src/output/display-http.hh
@@ -28,6 +28,8 @@
 #include <limits>
 #include <string>
 #include <type_traits>
+#include <utility>
+#include <vector>
 
 #include "../lua/luamm.hh"
 #include "display-output.hh"
@@ -63,10 +65,21 @@ class display_output_http : public display_output_base {
 
 std::string html_escape(const std::string &input);
 
-// TODO(#2395): add an http_response struct here (body, status, headers as
-// vector<pair<string,string>>) returned by the new llua_http_response_hook()
-// so sendanswer() in display-http.cc can build a customized MHD_Response
-// instead of always serving the hardcoded HTML page.
+/*
+ * Result of the user-defined `lua_http_response_hook`, used to customize the
+ * response the HTTP backend serves instead of the hardcoded HTML page.
+ */
+struct http_response {
+  std::string body;
+  int status = 200;
+  std::vector<std::pair<std::string, std::string>> headers;
+};
+
+// TODO(#2395): add llua_http_response_hook() (declared in llua.h) that calls
+// the configured `lua_http_response_hook` Lua function and fills in an
+// http_response from its returned table. Then wire it into sendanswer() in
+// display-http.cc, guarded by builder_mutex since it'll run on microhttpd's
+// worker thread.
 
 }  // namespace conky
 

--- a/tests/test-http.cc
+++ b/tests/test-http.cc
@@ -34,6 +34,7 @@
 #include <conky.h>
 #include <lua/llua.h>
 #include <lua/lua-config.hh>
+#include <output/display-http.hh>
 
 // lua_L (llua.cc) is the VM llua_do_call() uses, distinct from `state`.
 extern lua_State *lua_L;
@@ -53,19 +54,12 @@ TEST_CASE("llua_http_response_hook", "[http][lua]") {
   conky::export_symbols(*state);
   llua_init();
 
-  std::string body;
-  int status = 200;
-  std::vector<std::pair<std::string, std::string>> headers;
-
-  SECTION("returns false when hook is not configured") {
+  SECTION("returns nullopt when hook is not configured") {
     set_hook_setting("");
 
-    bool result = llua_http_response_hook(&body, &status, &headers);
+    auto result = llua_http_response_hook();
 
-    REQUIRE_FALSE(result);
-    REQUIRE(body.empty());
-    REQUIRE(status == 200);
-    REQUIRE(headers.empty());
+    REQUIRE_FALSE(result.has_value());
   }
 
   SECTION("fills body/status/headers from a full table") {
@@ -79,14 +73,14 @@ TEST_CASE("llua_http_response_hook", "[http][lua]") {
                           "  }\n"
                           "end") == 0);
 
-    bool result = llua_http_response_hook(&body, &status, &headers);
+    auto result = llua_http_response_hook();
 
-    REQUIRE(result);
-    REQUIRE(body == "hello");
-    REQUIRE(status == 201);
-    REQUIRE(headers.size() == 1);
-    REQUIRE(headers[0].first == "X-Test");
-    REQUIRE(headers[0].second == "yes");
+    REQUIRE(result.has_value());
+    REQUIRE(result->body == "hello");
+    REQUIRE(result->status == 201);
+    REQUIRE(result->headers.size() == 1);
+    REQUIRE(result->headers[0].first == "X-Test");
+    REQUIRE(result->headers[0].second == "yes");
   }
 
   SECTION("defaults status and headers when only body is returned") {
@@ -96,27 +90,24 @@ TEST_CASE("llua_http_response_hook", "[http][lua]") {
                           "  return { body = 'just the body' }\n"
                           "end") == 0);
 
-    bool result = llua_http_response_hook(&body, &status, &headers);
+    auto result = llua_http_response_hook();
 
-    REQUIRE(result);
-    REQUIRE(body == "just the body");
-    REQUIRE(status == 200);
-    REQUIRE(headers.empty());
+    REQUIRE(result.has_value());
+    REQUIRE(result->body == "just the body");
+    REQUIRE(result->status == 200);
+    REQUIRE(result->headers.empty());
   }
 
-  SECTION("returns false when hook returns a non-table value") {
+  SECTION("returns nullopt when hook returns a non-table value") {
     set_hook_setting("test_not_table");
     REQUIRE(luaL_dostring(lua_L,
                           "function conky_test_not_table()\n"
                           "  return 'not a table'\n"
                           "end") == 0);
 
-    bool result = llua_http_response_hook(&body, &status, &headers);
+    auto result = llua_http_response_hook();
 
-    REQUIRE_FALSE(result);
-    REQUIRE(body.empty());
-    REQUIRE(status == 200);
-    REQUIRE(headers.empty());
+    REQUIRE_FALSE(result.has_value());
   }
 
   SECTION("warns and continues when body field is missing") {
@@ -126,12 +117,12 @@ TEST_CASE("llua_http_response_hook", "[http][lua]") {
                           "  return { status = 204 }\n"
                           "end") == 0);
 
-    bool result = llua_http_response_hook(&body, &status, &headers);
+    auto result = llua_http_response_hook();
 
-    REQUIRE(result);
-    REQUIRE(body.empty());
-    REQUIRE(status == 204);
-    REQUIRE(headers.empty());
+    REQUIRE(result.has_value());
+    REQUIRE(result->body.empty());
+    REQUIRE(result->status == 204);
+    REQUIRE(result->headers.empty());
   }
 
   SECTION("ignores non-string entries in the headers table") {
@@ -145,11 +136,11 @@ TEST_CASE("llua_http_response_hook", "[http][lua]") {
                           "  }\n"
                           "end") == 0);
 
-    bool result = llua_http_response_hook(&body, &status, &headers);
+    auto result = llua_http_response_hook();
 
-    REQUIRE(result);
-    REQUIRE(headers.size() == 1);
-    REQUIRE(headers[0].first == "Good");
+    REQUIRE(result.has_value());
+    REQUIRE(result->headers.size() == 1);
+    REQUIRE(result->headers[0].first == "Good");
   }
 }
 #endif

--- a/tests/test-http.cc
+++ b/tests/test-http.cc
@@ -1,0 +1,158 @@
+/*
+ *
+ * Conky, a system monitor, based on torsmo
+ *
+ * Please see COPYING for details
+ *
+ * Copyright (c) 2005-2024 Brenden Matthews, Philip Kovacs, et. al.
+ *	(see AUTHORS)
+ * All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "catch2/catch.hpp"
+
+#include <config.h>
+
+#ifdef BUILD_HTTP
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <conky.h>
+#include <lua/lua-config.hh>
+#include <lua/llua.h>
+
+// lua_L is defined in llua.cc but never declared in a header; it's the
+// separate Lua VM that llua_do_call() (and therefore llua_http_response_hook)
+// actually calls into, distinct from `state`, which only parses the config
+// file itself.
+extern lua_State *lua_L;
+
+namespace {
+// Sets conky.config.lua_http_response_hook in `state`, which is what
+// simple_config_setting::get() reads from.
+void set_hook_setting(const std::string &value) {
+  state->loadstring(
+      ("conky.config.lua_http_response_hook = '" + value + "'").c_str());
+  state->call(0, 0);
+}
+}  // namespace
+
+TEST_CASE("llua_http_response_hook", "[http][lua]") {
+  state = std::make_unique<lua::state>();
+  conky::export_symbols(*state);
+  llua_init();
+
+  std::string body;
+  int status = 200;
+  std::vector<std::pair<std::string, std::string>> headers;
+
+  SECTION("returns false when hook is not configured") {
+    set_hook_setting("");
+
+    bool result = llua_http_response_hook(&body, &status, &headers);
+
+    REQUIRE_FALSE(result);
+    REQUIRE(body.empty());
+    REQUIRE(status == 200);
+    REQUIRE(headers.empty());
+  }
+
+  SECTION("fills body/status/headers from a full table") {
+    set_hook_setting("test_full");
+    REQUIRE(luaL_dostring(lua_L,
+                          "function conky_test_full()\n"
+                          "  return {\n"
+                          "    body = 'hello',\n"
+                          "    status = 201,\n"
+                          "    headers = { ['X-Test'] = 'yes' }\n"
+                          "  }\n"
+                          "end") == 0);
+
+    bool result = llua_http_response_hook(&body, &status, &headers);
+
+    REQUIRE(result);
+    REQUIRE(body == "hello");
+    REQUIRE(status == 201);
+    REQUIRE(headers.size() == 1);
+    REQUIRE(headers[0].first == "X-Test");
+    REQUIRE(headers[0].second == "yes");
+  }
+
+  SECTION("defaults status and headers when only body is returned") {
+    set_hook_setting("test_body_only");
+    REQUIRE(luaL_dostring(lua_L,
+                          "function conky_test_body_only()\n"
+                          "  return { body = 'just the body' }\n"
+                          "end") == 0);
+
+    bool result = llua_http_response_hook(&body, &status, &headers);
+
+    REQUIRE(result);
+    REQUIRE(body == "just the body");
+    REQUIRE(status == 200);
+    REQUIRE(headers.empty());
+  }
+
+  SECTION("returns false when hook returns a non-table value") {
+    set_hook_setting("test_not_table");
+    REQUIRE(luaL_dostring(lua_L,
+                          "function conky_test_not_table()\n"
+                          "  return 'not a table'\n"
+                          "end") == 0);
+
+    bool result = llua_http_response_hook(&body, &status, &headers);
+
+    REQUIRE_FALSE(result);
+    REQUIRE(body.empty());
+    REQUIRE(status == 200);
+    REQUIRE(headers.empty());
+  }
+
+  SECTION("warns and continues when body field is missing") {
+    set_hook_setting("test_no_body");
+    REQUIRE(luaL_dostring(lua_L,
+                          "function conky_test_no_body()\n"
+                          "  return { status = 204 }\n"
+                          "end") == 0);
+
+    bool result = llua_http_response_hook(&body, &status, &headers);
+
+    REQUIRE(result);
+    REQUIRE(body.empty());
+    REQUIRE(status == 204);
+    REQUIRE(headers.empty());
+  }
+
+  SECTION("ignores non-string entries in the headers table") {
+    set_hook_setting("test_mixed_headers");
+    REQUIRE(luaL_dostring(lua_L,
+                          "function conky_test_mixed_headers()\n"
+                          "  return {\n"
+                          "    body = 'ok',\n"
+                          "    headers = { ['Good'] = 'yes', [42] = 'skip me' "
+                          "}\n"
+                          "  }\n"
+                          "end") == 0);
+
+    bool result = llua_http_response_hook(&body, &status, &headers);
+
+    REQUIRE(result);
+    REQUIRE(headers.size() == 1);
+    REQUIRE(headers[0].first == "Good");
+  }
+}
+#endif

--- a/tests/test-http.cc
+++ b/tests/test-http.cc
@@ -32,13 +32,10 @@
 #include <vector>
 
 #include <conky.h>
-#include <lua/lua-config.hh>
 #include <lua/llua.h>
+#include <lua/lua-config.hh>
 
-// lua_L is defined in llua.cc but never declared in a header; it's the
-// separate Lua VM that llua_do_call() (and therefore llua_http_response_hook)
-// actually calls into, distinct from `state`, which only parses the config
-// file itself.
+// lua_L (llua.cc) is the VM llua_do_call() uses, distinct from `state`.
 extern lua_State *lua_L;
 
 namespace {


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [x] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

Fixes #2395. This PR introduces a `lua_http_response_hook` that allows users to fully customize the HTTP backend's response (body, status, and headers) via a Lua table.

## Problem

Previously, the HTTP backend's response in `display-http.cc` was locked into a hardcoded HTML format. Users wanting to interface with it programmatically had no way to get structured output like JSON, or set custom headers. They'd have to parse HTML.

## What this PR does

**Response Hook**: Added `llua_http_response_hook()` to call Lua and extract body, status, and headers. If the hook isn't set, fails, or returns junk, it falls back gracefully to default responses.

**Thread Safety**: Integrated into `sendanswer()` under `builder_mutex` so Lua runs safely on microhttpd worker threads.

**Fixes & Testing**: Added unit tests covering edge cases. This caught a fatal panic caused by `lua_tostring()` corrupting `lua_next()` iteration on numeric header keys, which is now fixed by explicitly checking for string types.

**Docs**: Updated `config_settings.yaml`.