### PR TITLE
fix: wayland: guard shm surfaces against invalid buffer dimensions (#…

### DIFF
--- a/src/output/display-wayland.cc
+++ b/src/output/display-wayland.cc
@@ -1244,7 +1244,19 @@ static std::shared_ptr<conky::draw_surface> create_shm_surface_from_pool(
   cairo_format = CAIRO_FORMAT_ARGB32; /*or CAIRO_FORMAT_RGB16_565 who knows??*/
 
   stride = stride_for_shm_surface(rectangle, scale);
+  if (stride < 0) {
+    LOG_ERROR("invalid buffer width {} for {}x{} window", stride,
+              rectangle->width(), rectangle->height());
+    delete data;
+    return nullptr;
+  }
   length = data_length_for_shm_surface(rectangle, scale);
+  if (length <= 0) {
+    LOG_ERROR("invalid buffer size {} for {}x{} window", length,
+              rectangle->width(), rectangle->height());
+    delete data;
+    return nullptr;
+  }
   data->pool = NULL;
   map = shm_pool_allocate(pool, length, &offset);
 
@@ -1258,8 +1270,23 @@ static std::shared_ptr<conky::draw_surface> create_shm_surface_from_pool(
       static_cast<unsigned char *>(map), cairo_format, scaled.x(), scaled.y(),
       stride);
 
-  cairo_surface_set_user_data(surface, &shm_surface_data_key, data,
-                              shm_surface_data_destroy);
+  if (cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS) {
+    LOG_ERROR("cairo image surface creation failed: {}",
+              cairo_status_to_string(cairo_surface_status(surface)));
+    cairo_surface_destroy(surface);
+    delete data;
+    return nullptr;
+  }
+
+  if (cairo_surface_set_user_data(surface, &shm_surface_data_key, data,
+                                  shm_surface_data_destroy) !=
+      CAIRO_STATUS_SUCCESS) {
+    LOG_ERROR("cairo_surface_set_user_data failed for {}x{} window",
+              rectangle->width(), rectangle->height());
+    cairo_surface_destroy(surface);
+    delete data;
+    return nullptr;
+  }
 
   format = WL_SHM_FORMAT_ARGB8888; /*or WL_SHM_FORMAT_RGB565*/
 


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [ ] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

* **The changes:** conky can segfault on the Wayland backend when a resize produces invalid buffer dimensions. `create_shm_surface_from_pool()` now rejects negative stride and non-positive length before mapping, verifies the created cairo surface is not a nil surface (`cairo_surface_status()`), and verifies the user-data attachment via `cairo_surface_set_user_data()`'s return value. On any failure it returns `nullptr` instead of building a surface with bad dimensions.

* **Why they were necessary:** cairo's `cairo_image_surface_create_for_data()` does not return an error for a bad size — it returns its nil surface (`CAIRO_STATUS_INVALID_SIZE`), on which `cairo_surface_set_user_data()` fails silently. `window_allocate_buffer()` then reads the user data back, gets NULL, and dereferences it unconditionally at `data->pool = ...` (`display-wayland.cc:1304`), a hard SIGSEGV. The existing `if (!window->shm_surface[i])` guard cannot catch it because the nil surface is a non-NULL pointer, and with both scaled dimensions negative the shm allocation itself succeeds (`stride = -1` but `length` positive).

* **How it affects existing behaviour:** a bad resize no longer crashes. The existing `!window->shm_surface[i]` guard now does what the Weston code this path was ported from does: destroys the pool, keeps the last good buffers, and retries on the next update. A bad resize logs `invalid buffer width/size ...` instead. X11 and non-Wayland builds are unaffected (this file is Wayland-only).

* **How it was tested:** the crash was reproduced three times on Arch Linux / KDE Plasma (Wayland), once captured as a coredump (PID 4008) — faulting write to `data->pool` with `data == NULL`, surface symbolised as `_cairo_surface_nil_invalid_size`. After the patch: desktop widgets ran through repeated resize/redraw churn and multiple start/stop cycles with no coredumps; the triggering path was exercised with a temporarily forced bad size, which logged the new error, kept the previous frame, and did not crash.

Closes #2431
