### PR TITLE
feat: add own_window_namespace config setting for wlr-layer-shell

### DIFF
--- a/doc/config_settings.yaml
+++ b/doc/config_settings.yaml
@@ -513,7 +513,9 @@ values:
       are treated as a normal window. When unset, 'conky' is used. To keep
       conky visible during Show Desktop while staying above the wallpaper,
       set this to 'desktop' and keep [`own_window_type`](#own_window_type)
-      at 'normal'.
+      at 'normal'. On KDE Plasma, 'dock' is elevated by the slide effect
+      (shouldElevate() in slide.cpp) while switching virtual desktops,
+      so 'desktop' keeps conky in the background throughout.
     default: 'conky'
   - name: pad_percents
     desc: Pad percentages to this many decimals (0 = no padding).

--- a/doc/config_settings.yaml
+++ b/doc/config_settings.yaml
@@ -456,6 +456,19 @@ values:
         decorated.
     args:
       - hint(,hint)*
+  - name: own_window_namespace
+    desc: |-
+      Set the wlr-layer-shell namespace of the Wayland window. Compositors
+      such as KWin classify the surface from this (lowercased); KWin
+      recognizes 'desktop', 'dock', 'notification', 'tooltip',
+      'on-screen-display', 'dialog', 'splash' and 'utility'. Other values
+      are treated as a normal window. When unset, 'conky' is used. To keep
+      conky visible during Show Desktop while staying above the wallpaper,
+      set this to 'desktop' and keep [`own_window_type`](#own_window_type)
+      at 'normal'. On KDE Plasma, 'dock' is elevated by the slide effect
+      (shouldElevate() in slide.cpp) while switching virtual desktops,
+      so 'desktop' keeps conky in the background throughout.
+    default: 'conky'
   - name: own_window_title
     desc: |-
       Allows overriding conky window name.
@@ -504,19 +517,6 @@ values:
     default: normal
     args:
       - (normal|desktop|dock|panel|utility|override)
-  - name: own_window_namespace
-    desc: |-
-      Set the wlr-layer-shell namespace of the Wayland window. Compositors
-      such as KWin classify the surface from this (lowercased); KWin
-      recognizes 'desktop', 'dock', 'notification', 'tooltip',
-      'on-screen-display', 'dialog', 'splash' and 'utility'. Other values
-      are treated as a normal window. When unset, 'conky' is used. To keep
-      conky visible during Show Desktop while staying above the wallpaper,
-      set this to 'desktop' and keep [`own_window_type`](#own_window_type)
-      at 'normal'. On KDE Plasma, 'dock' is elevated by the slide effect
-      (shouldElevate() in slide.cpp) while switching virtual desktops,
-      so 'desktop' keeps conky in the background throughout.
-    default: 'conky'
   - name: pad_percents
     desc: Pad percentages to this many decimals (0 = no padding).
   - name: pop3

--- a/doc/config_settings.yaml
+++ b/doc/config_settings.yaml
@@ -504,6 +504,17 @@ values:
     default: normal
     args:
       - (normal|desktop|dock|panel|utility|override)
+  - name: own_window_namespace
+    desc: |-
+      Set the wlr-layer-shell namespace of the Wayland window. Compositors
+      such as KWin classify the surface from this (lowercased); KWin
+      recognizes 'desktop', 'dock', 'notification', 'tooltip',
+      'on-screen-display', 'dialog', 'splash' and 'utility'. Other values
+      are treated as a normal window. When unset, 'conky' is used. To keep
+      conky visible during Show Desktop while staying above the wallpaper,
+      set this to 'desktop' and keep [`own_window_type`](#own_window_type)
+      at 'normal'.
+    default: 'conky'
   - name: pad_percents
     desc: Pad percentages to this many decimals (0 = no padding).
   - name: pop3

--- a/src/output/display-wayland.cc
+++ b/src/output/display-wayland.cc
@@ -696,6 +696,14 @@ bool display_output_wayland::initialize() {
       !hints_require_layer_shell();
   auto on_close = []() { g_sigterm_pending = 1; };
 
+  // KWin classifies the layer-shell surface from its namespace. Keep the
+  // classic namespace unless the user opts into another via
+  // own_window_namespace, so existing configs are unaffected.
+  std::string namespace_str = own_window_namespace.get(*state);
+  if (namespace_str.empty()) {
+    namespace_str = PACKAGE_NAME;
+  }
+
   if (!hints_layer_shell && wl_globals.layer_shell != nullptr) {
     global_window->shell =
         conky::create_shell_surface<conky::layer_shell_surface>({
@@ -703,9 +711,7 @@ bool display_output_wayland::initialize() {
             global_window->surface,
             wl_globals.layer_shell,
             static_cast<uint32_t>(layer_for_window()),
-            own_window_type.get(*state) == window_type::DESKTOP
-                ? "desktop"
-                : "conky",
+            namespace_str.c_str(),
         });
   } else {
     if (!hints_layer_shell) {

--- a/src/output/display-wayland.cc
+++ b/src/output/display-wayland.cc
@@ -703,7 +703,9 @@ bool display_output_wayland::initialize() {
             global_window->surface,
             wl_globals.layer_shell,
             static_cast<uint32_t>(layer_for_window()),
-            "conky",
+            own_window_type.get(*state) == window_type::DESKTOP
+                ? "desktop"
+                : "conky",
         });
   } else {
     if (!hints_layer_shell) {

--- a/src/output/display-wayland.cc
+++ b/src/output/display-wayland.cc
@@ -700,9 +700,6 @@ bool display_output_wayland::initialize() {
   // classic namespace unless the user opts into another via
   // own_window_namespace, so existing configs are unaffected.
   std::string namespace_str = own_window_namespace.get(*state);
-  if (namespace_str.empty()) {
-    namespace_str = PACKAGE_NAME;
-  }
 
   if (!hints_layer_shell && wl_globals.layer_shell != nullptr) {
     global_window->shell =

--- a/src/output/gui.cc
+++ b/src/output/gui.cc
@@ -189,6 +189,11 @@ conky::simple_config_setting<window_type> own_window_type("own_window_type",
                                                           false);
 #endif /* OWN_WINDOW || BUILD_WAYLAND */
 
+#if defined(BUILD_WAYLAND)
+conky::simple_config_setting<std::string> own_window_namespace(
+    "own_window_namespace", "", false);
+#endif /* BUILD_WAYLAND */
+
 #if defined(OWN_WINDOW) || defined(BUILD_WAYLAND)
 conky::simple_config_setting<uint16_t, window_hints_traits> own_window_hints(
     "own_window_hints", 0, false);

--- a/src/output/gui.cc
+++ b/src/output/gui.cc
@@ -191,7 +191,7 @@ conky::simple_config_setting<window_type> own_window_type("own_window_type",
 
 #if defined(BUILD_WAYLAND)
 conky::simple_config_setting<std::string> own_window_namespace(
-    "own_window_namespace", "", false);
+    "own_window_namespace", PACKAGE_NAME, false);
 #endif /* BUILD_WAYLAND */
 
 #if defined(OWN_WINDOW) || defined(BUILD_WAYLAND)

--- a/src/output/gui.h
+++ b/src/output/gui.h
@@ -224,7 +224,15 @@ extern conky::simple_config_setting<std::string> own_window_class;
 /// @see window_type
 extern conky::simple_config_setting<window_type> own_window_type;
 
+#ifdef BUILD_WAYLAND
+/// @brief Layer-shell namespace hint (Wayland only).
+///
+/// The namespace passed to the wlr-layer-shell protocol. KWin classifies
+/// the surface from this (see scopeToType() in layershellv1window.cpp);
+/// unlisted names like the default "conky" are treated as a normal window.
+/// Other compositors interpret the namespace per their own rules.
 extern conky::simple_config_setting<std::string> own_window_namespace;
+#endif /* BUILD_WAYLAND */
 
 extern priv::colour_setting background_colour;
 

--- a/src/output/gui.h
+++ b/src/output/gui.h
@@ -224,6 +224,8 @@ extern conky::simple_config_setting<std::string> own_window_class;
 /// @see window_type
 extern conky::simple_config_setting<window_type> own_window_type;
 
+extern conky::simple_config_setting<std::string> own_window_namespace;
+
 extern priv::colour_setting background_colour;
 
 Colour get_background_colour_preference(lua::state &l);


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [x] Documentation in `doc/` has been updated
- [x] All new code is licensed under GPLv3

## Description

**The changes:** a new `own_window_namespace` config setting for the `namespace` passed to `get_layer_surface()`. It defaults to `"conky"` (unchanged behaviour for every existing config); a user can opt in to another classification, e.g. `own_window_namespace = 'desktop'` for desktop-widget behaviour. The setting is guarded by `BUILD_WAYLAND` only.

**Why they were necessary:** on KDE Plasma (Wayland), KWin derives the window type from the layer-shell namespace via `scopeToType()`. `"conky"` is not in its map, so every conky surface is classified `WindowType::Normal` regardless of the layer it is on. Normal windows are what `Workspace::setShowingDesktop()` hides, so Show Desktop (Meta+D) hides conky desktop widgets even though they sit on the `BACKGROUND` layer. The setting also lets dock/normal users decouple classification from the layer, e.g. keep `own_window_type = 'normal'` on the bottom layer while KWin still treats the surface as a desktop window.

**How it affects existing behaviour:** nothing changes for existing configs: the namespace stays `"conky"` unless `own_window_namespace` is set explicitly. Configs that set `own_window_namespace = 'desktop'` stay visible during Show Desktop on KDE Plasma, matching the X11 backend.

**How it was tested:** built and shipped as a patched AppImage (`v1.24.3-patched.2`); verified interactively on KDE Plasma 6 (Wayland): desktop widgets stay on screen through repeated Meta+D cycles with `own_window_namespace = 'desktop'`. The X11 backend is untouched.

Closes #2432