### PR TITLE
X11: keep window alive during SIGUSR1 reload (no flash)

### DIFF
--- a/src/conky.cc
+++ b/src/conky.cc
@@ -263,6 +263,11 @@ extern kvm_t *kd;
 static void signal_handler(int /*sig*/);
 static void reload_config();
 
+/* Set by reload_config() so X11 cleanup/initialise can skip window+display
+ * teardown.  The window stays alive and the X connection stays open during
+ * the reload — avoids the flash-on-reload that plagues X11. */
+int g_is_reloading = 0;
+
 static const char *suffixes[] = {_nop("B"),   _nop("KiB"), _nop("MiB"),
                                  _nop("GiB"), _nop("TiB"), _nop("PiB"),
                                  ""};
@@ -2100,11 +2105,13 @@ static void reload_config() {
         current_config, getpid());
     return;
   }
+  g_is_reloading = 1;
   clean_up();
   state = std::make_unique<lua::state>();
   conky::export_symbols(*state);
   sleep(1); /* slight pause */
   initialisation(argc_copy, argv_copy);
+  g_is_reloading = 0;
 }
 
 void free_specials(special_node *&current) {

--- a/src/conky.h
+++ b/src/conky.h
@@ -451,6 +451,8 @@ void main_loop();
 extern volatile sig_atomic_t g_sigterm_pending, g_sighup_pending,
     g_sigusr2_pending;
 
+extern int g_is_reloading;
+
 extern int first_pass;
 extern int argc_copy;
 extern char **argv_copy;

--- a/src/output/display-x11.cc
+++ b/src/output/display-x11.cc
@@ -883,7 +883,7 @@ void display_output_x11::cleanup() {
                text_start.y() - border_total, text_size.x() + 2 * border_total,
                text_size.y() + 2 * border_total, 0);
   }
-  destroy_window();
+  if (!g_is_reloading) { destroy_window(); }
   free_fonts(utf8_mode.get(*state));
   if (window.repaint_region != nullptr) {
     XDestroyRegion(window.repaint_region);

--- a/src/output/x11.cc
+++ b/src/output/x11.cc
@@ -294,7 +294,7 @@ void init_x11() {
 }
 
 void deinit_x11() {
-  if (display) {
+  if (display && !g_is_reloading) {
     auto _scope = LOG_SCOPE("deinit_x11");
     XCloseDisplay(display);
     display = nullptr;
@@ -550,12 +550,31 @@ void x11_init_window(lua::state &l) {
   }
   window.desktop = find_desktop_window(window.root);
 
+  /* Defaults — overridden below for own_window reuse (real window attrs)
+   * and for own_window create (ARGB visual if available). */
   window.visual = DefaultVisual(display, screen);
   window.opacity = 0xff;
   window.colourmap = DefaultColormap(display, screen);
 
 #ifdef OWN_WINDOW
   if (own_window.get(l)) {
+    if (window.window != None) {
+      /* Reload path: window already alive — query its real attributes
+       * instead of destroying and recreating. */
+      XWindowAttributes attr;
+      if (XGetWindowAttributes(display, window.window, &attr) != 0) {
+        window.visual = attr.visual;
+        window.colourmap = attr.colormap;
+        window.geometry.set_size(attr.width, attr.height);
+        LOG_INFO("reusing existing window {:#x} {}x{} (reload)",
+                 window.window, attr.width, attr.height);
+      } else {
+        LOG_WARNING("XGetWindowAttributes failed for {:#x}", window.window);
+        window.visual = DefaultVisual(display, screen);
+        window.colourmap = DefaultColormap(display, screen);
+      }
+      window.opacity = 0xff;
+    } else {
     int flags = CWOverrideRedirect | CWBackingStore;
     window.color_depth = CopyFromParent;
 
@@ -844,6 +863,7 @@ void x11_init_window(lua::state &l) {
         }
       }
     }
+    } /* end of else (window.window == None) — create new window */
 
     LOG_INFO("drawing to created window {:#x}", window.window);
     XMapWindow(display, window.window);
@@ -980,6 +1000,7 @@ static Window find_desktop_window_impl(Window win, int w, int h) {
 }
 
 void create_gc() {
+  if (window.gc != nullptr) { XFreeGC(display, window.gc); }
   XGCValues values;
 
   values.graphics_exposures = 0;


### PR DESCRIPTION
## Problem

On X11, sending SIGUSR1 (or inotify-triggered reload) causes conky to destroy and recreate the X window and display connection. This produces a visible flash and can cause widget content to disappear entirely — the window goes blank and never recovers.

## Root Cause

`reload_config()` calls `clean_up()` → `destroy_window()` (zeros the entire window struct including the X window handle) → `XCloseDisplay()`, then `initialisation()` recreates everything from scratch. The window is destroyed and recreated, which:

1. Produces a visible flash (brief blank window)
2. Can fail to properly restore the ARGB visual ( `DefaultVisual` overwrites the ARGB visual before `try_set_argb_visual` runs in the create path)
3. Leaks the old double-buffer pixmap

Note: Wayland already reloads cleanly because `display_output_wayland::cleanup()` doesn't tear down the display connection.

## Solution

Add a `g_is_reloading` flag set during the reload cycle:

- **`display_output_x11::cleanup()`** — skips `destroy_window()` so the X window stays alive; fonts and repaint_region are still freed normally
- **`deinit_x11()`** — skips `XCloseDisplay()` so the X connection stays open  
- **`x11_init_window()`** — detects the existing window (`window.window != None`) and reuses it, querying the real visual/geometry/colormap via `XGetWindowAttributes()` instead of resetting to defaults
- **`create_gc()`** — frees the old GC before creating a new one to prevent resource leaks

The X window, display connection, and visual settings all survive the reload cycle. The window content is redrawn in place without any flash.