### PR TITLE
fix(lua/rsvg): fix RSVG Lua bindings: set/get typo, GError leak, GType crash, add positioning helper

### DIFF
--- a/lua/CMakeLists.txt
+++ b/lua/CMakeLists.txt
@@ -106,6 +106,7 @@ if(BUILD_LUA_RSVG)
 
   add_library(conky-rsvg MODULE ${luarsvg_src})
   set_target_properties(conky-rsvg PROPERTIES OUTPUT_NAME "rsvg")
+  target_link_options(conky-rsvg PRIVATE "LINKER:-z,nodelete")
 
   target_link_libraries(conky-rsvg ${luarsvg_libs} toluapp_lib_static)
   set(lua_libs ${lua_libs} conky-rsvg)

--- a/lua/librsvg-helper.h
+++ b/lua/librsvg-helper.h
@@ -57,17 +57,6 @@ void rsvg_dimension_data_set(RsvgDimensionData *dd, int width, int height,
   }
 }
 
-RsvgPositionData *rsvgPositionDataCreate(void) {
-  return (RsvgPositionData *)calloc(1, sizeof(RsvgPositionData));
-}
-
-void rsvgPositionDataGet(RsvgPositionData *pd, int *x, int *y) {
-  if (pd) {
-    *x = pd->x;
-    *y = pd->y;
-  }
-}
-
 RsvgHandle *rsvg_create_handle_from_file(const char *filename) {
   GFile *gfile = g_file_new_for_path(filename);
 
@@ -76,7 +65,7 @@ RsvgHandle *rsvg_create_handle_from_file(const char *filename) {
       gfile, RSVG_HANDLE_FLAGS_NONE, NULL, &error);
 
   if (error) {
-    g_object_unref(error);
+    g_error_free(error);
     if (handle) g_object_unref(handle);
     handle = NULL;
   }
@@ -116,6 +105,16 @@ void rsvg_rectangle_get(RsvgRectangle *rect, double *x, double *y,
     *width = rect->width;
     *height = rect->height;
   }
+}
+
+void rsvg_render_document_at(RsvgHandle *handle, cairo_t *cr,
+                             double x, double y, double w, double h) {
+  if (!handle || !cr) return;
+  cairo_save(cr);
+  cairo_translate(cr, x, y);
+  RsvgRectangle viewport = {0, 0, w, h};
+  rsvg_handle_render_document(handle, cr, &viewport, NULL);
+  cairo_restore(cr);
 }
 
 #endif /* _LIBRSVG_HELPER_H_ */

--- a/lua/rsvg.pkg
+++ b/lua/rsvg.pkg
@@ -65,7 +65,7 @@ typedef struct _RsvgDimensionData {
     static tolua_outside void rsvg_dimension_data_destroy @ destroy(RsvgDimensionData *);
     tolua_outside void rsvg_dimension_data_get @ get(int * width, int * height,
                                                   double * em, double * ex);
-    tolua_outside void rsvg_dimension_data_set @ get(int width, int height,
+    tolua_outside void rsvg_dimension_data_set @ set(int width, int height,
                                                   double em, double ex);
 } RsvgDimensionData;
 
@@ -127,6 +127,9 @@ void g_object_unref(gpointer object);
 
 RsvgHandle * rsvg_create_handle_from_file(const char *);
 int rsvg_destroy_handle(RsvgHandle *);
+
+void rsvg_render_document_at(RsvgHandle *handle, cairo_t *cr,
+                             double x, double y, double w, double h);
 
 RsvgHandle *rsvg_handle_new_with_flags (RsvgHandleFlags flags);
 


### PR DESCRIPTION
## Four fixes in the Lua RSVG bindings

### 1. RsvgDimensionData:set() typo (rsvg.pkg:68)

The setter was bound as `@ get` instead of `@ set`, making it inaccessible from Lua. Introduced by PR #1263 / commit 589b2403 (2022-10-16).

### 2. GError memory leak (librsvg-helper.h)

`g_object_unref()` was called on `GError` in `rsvg_create_handle_from_file()`, but `GError` is not a GObject. This caused undefined behavior / memory corruption on every SVG load failure. Fixed to `g_error_free()`.

### 3. rsvg_render_document_at() convenience wrapper (librsvg-helper.h + rsvg.pkg)

Added a new C helper function that combines `cairo_save/translate/restore` with `rsvg_handle_render_document()`, providing a single-call `x/y/w/h` positioning API. This replaces the removed `rsvg_handle_render_cairo` and makes it easy to render SVGs at arbitrary positions from Lua.

### 4. GType crash prevention (CMakeLists.txt)

Added `-z,nodelete` linker flag to the `conky-rsvg` module to prevent GType re-registration crashes on Conky reload (SIGUSR1). The Rust-based librsvg registers GType `RsvgHandle` in the process-global GLib type table. On reload, `dlclose` + re-open triggers a panic: `Type RsvgHandle has already been registered`. The nodelete flag prevents the shared library from being unloaded.

### Cleanup

Removed dead `rsvgPositionData` helper code (unused since the librsvg >= 2.52 migration).

---

**Tested on:** Arch Linux (Conky 1.24.3-pre, Lua 5.5, librsvg 2.60)
**Builds:** ✓ cmake + make succeeds
**Runtimes:** ✓ SVG rendering works, tint/alpha/rotation/clip all functional, SIGUSR1 reload no longer crashes