### PR TITLE
build: remove BUILD_HSV_GRADIENT, BUILD_LIBXML2 and BUILD_MIXER_ALSA, which have no effect

### DIFF
--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -86,8 +86,6 @@
 
 #cmakedefine BUILD_HDDTEMP 1
 
-#cmakedefine BUILD_LIBXML2 1
-
 #cmakedefine BUILD_CURL 1
 
 #cmakedefine BUILD_IMLIB2 1
@@ -142,8 +140,6 @@
 #cmakedefine BUILD_CMUS 1
 
 #cmakedefine BUILD_JOURNAL 1
-
-#cmakedefine BUILD_HSV_GRADIENT 1
 
 #cmakedefine BUILD_COLOUR_NAME_MAP 1
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -146,9 +146,6 @@ static void print_version() {
 #ifdef HAVE_SOUNDCARD_H
             << _("  * OSS mixer support\n")
 #endif /* HAVE_SOUNDCARD_H */
-#ifdef BUILD_MIXER_ALSA
-            << _("  * ALSA mixer support\n")
-#endif /* BUILD_MIXER_ALSA */
 #ifdef BUILD_APCUPSD
             << _("  * apcupsd\n")
 #endif /* BUILD_APCUPSD */


### PR DESCRIPTION
# Checklist
- [x] I have described the changes
- [x] I have linked to any relevant GitHub issues, if applicable
- [x] Documentation in `doc/` has been updated. Not applicable: none of these
      flags are documented, and the runtime `graph_gradient_mode` docs at
      `doc/config_settings.yaml:192` are already correct and unchanged
- [x] All new code is licensed under GPLv3. No new code: five deletions, zero
      additions

## Description

### What changes

Three `BUILD_*` flags that cannot affect the build:

| flag | where it lives | why it has no effect |
|---|---|---|
| `BUILD_HSV_GRADIENT` | `cmake/config.h.in` | superseded by the runtime `graph_gradient_mode` setting in (#1235) |
| `BUILD_LIBXML2` | `cmake/config.h.in` | libxml2 is gated on `WANT_LIBXML2`; this is never set or tested |
| `BUILD_MIXER_ALSA` | `#ifdef` in `src/main.cc` | never definable anywhere; there is no ALSA mixer backend |

Five deletions, no additions.

### Why they were necessary

Each of these reads as a working build option. Nothing warns when you set one,
because cmake accepts unknown `-D` variables silently, so there is no way to
tell a dead flag from a live one without reading the tree.

All three flag names are in the PR title deliberately, so they are greppable
from the generated release notes. Distributions carry `-D` lines for options
like these, and they have no way to notice when one stops meaning anything.

This is not hypothetical for `BUILD_HSV_GRADIENT`. The AUR package
`conky-lua-nv` exists to provide lua and NVIDIA support. Arch's own `conky`
package has had `BUILD_NVIDIA=ON` since 2019-08-29 and the lua bindings since
2025-03-09, at which point `BUILD_HSV_GRADIENT` became the only build flag the
AUR package set that the official one did not. Its maintainer wrote on
2026-08-05 that the official package now covers everything "except maybe HSV".
That caveat is this flag, and it has done nothing since 2022. Removing it
removes the last build-flag difference between the two packages. Whether that
package is retired is its maintainer's call, but the difference it is being kept
for does not exist.

### How the changes affect existing behaviour

They do not. HSV gradients in particular are **not** being removed. (#1029)
added them behind a compile-time flag, (#1070) and (#1096) then reported crashes
and link failures when it was enabled, and (#1235) replaced the mechanism with
the runtime `graph_gradient_mode` setting. Only the leftover `#cmakedefine` goes
away.

### How I tested and validated

Built `main` before and after with `BUILD_EXTRAS`, `BUILD_WLAN`, `BUILD_XDBE`,
`BUILD_XSHAPE`, `BUILD_IMLIB2`, `BUILD_CURL`, `BUILD_RSS`, `BUILD_NVIDIA`,
`BUILD_PULSEAUDIO`, `BUILD_JOURNAL`, `BUILD_WAYLAND`, `BUILD_LUA_CAIRO`,
`BUILD_LUA_IMLIB2`, `BUILD_LUA_RSVG` and `BUILD_TESTING` on:

    cmake -S . -B build -D BUILD_TESTING=ON ...
    cmake --build build
    ctest --test-dir build --output-on-failure

- generated `config.h` differs only by the two `/* #undef ... */` comment lines
  disappearing, which is itself the evidence that neither macro was ever defined
  in this configuration
- tree-wide `git grep` over pristine `ef154d5` finds exactly four occurrences of
  the three flags, all of them the definition sites above, and no `#if`/`#ifdef`
  test, no `option()`, no `set()`, no `add_definitions`, and no `-D` in any
  workflow under `.github/`. `git grep -lni alsa -- src/` returns one file,
  `src/main.cc`, the dead banner line itself
- `clang-format --output-replacements-xml src/main.cc` reports 0 replacements
  both before and after the patch, with clang-format 22.1.8 against the repo's
  own `.clang-format`
- `conky --version` output is byte identical before and after
- `ctest`: 45 of 45 pass, both before and after
- `graph_gradient_mode = 'hsv'` still runs, and an invalid value is still
  rejected with `valid values are: 'rgb', 'hsv', 'hcl'`
- `BUILD_RSS=ON` produces a binary that links libxml2 while `BUILD_LIBXML2`
  stays undefined, confirming that flag controls nothing

### How I found them

Cross-referenced three sets: flags declared via `option()` / `dependent_option()`,
flags emitted as `#cmakedefine` in `cmake/config.h.in`, and flags actually tested
with `#if` / `#ifdef` / `defined()` under `src/`. These three are the only entries
that appear in one set and are reachable from none of the others.

Everything else that differed was legitimate and left alone: `BUILD_DOCS`,
`BUILD_EXTRAS`, `BUILD_TESTING` and `BUILD_LUA_CAIRO_XLIB` are cmake-only by
design, `BUILD_OPENSOUNDSYS` works indirectly by gating the `check_include_files`
that sets `HAVE_SOUNDCARD_H`, `BUILD_GUI` is derived with `set()` rather than
declared, and `BUILD_IPGFREQ` is tested in `src/data/os/darwin.mm`.

### Noticed while testing, not included here

`install(TARGETS conky_core ...)` sits inside `if(BUILD_TESTING)` in
`src/CMakeLists.txt`, directly under a comment reading "Create a library strictly
for testing". Turning on `BUILD_TESTING` therefore installs `libconky_core.a`, so
a testing flag changes what gets installed. Kept out of this PR to keep it to one
logical change. Filed separately as (#2439). It is also why the Arch conky
package's companion fix needs a second hunk.
