### PR TITLE
fix(text): honor use_spacer for percentage values (#2078)

### DIFF
--- a/doc/config_settings.yaml
+++ b/doc/config_settings.yaml
@@ -505,7 +505,13 @@ values:
     args:
       - (normal|desktop|dock|panel|utility|override)
   - name: pad_percents
-    desc: Pad percentages to this many decimals (0 = no padding).
+    desc: |-
+      Minimum field width for percentage values when
+      [`use_spacer`](#use_spacer) is `left` or `right`. Values are still
+      printed as whole numbers (`%u`); there are no fractional decimals.
+      When spacer alignment is enabled, width is at least 3 so that
+      `1`/`10`/`100` align. `0` means no extra width beyond that minimum
+      (or no padding at all when `use_spacer` is `none`).
   - name: pop3
     desc: |-
       Default global POP3 server. Arguments are: `host user pass

--- a/src/conky.cc
+++ b/src/conky.cc
@@ -389,7 +389,7 @@ conky::range_config_setting<unsigned int> text_buffer_size(
     "text_buffer_size", DEFAULT_TEXT_BUFFER_SIZE,
     std::numeric_limits<unsigned int>::max(), DEFAULT_TEXT_BUFFER_SIZE, false);
 
-/* pad percentages to decimals? */
+/* Width for percent_print when use_spacer is enabled (see percent_print). */
 static conky::simple_config_setting<int> pad_percents("pad_percents", 0, false);
 
 static char *global_text = nullptr;
@@ -508,9 +508,15 @@ int spaced_print(char *buf, int size, const char *format, int width, ...) {
 /* print percentage values
  *
  * - i.e., unsigned values between 0 and 100
- * - respect the value of pad_percents */
+ * - when use_spacer is left/right, pad to at least 3 columns so values
+ *   align like other spaced sensors (1% / 10% / 100%)
+ * - pad_percents can widen further; it is unused when use_spacer is none */
 int percent_print(char *buf, int size, unsigned value) {
-  return spaced_print(buf, size, "%u", pad_percents.get(*state), value);
+  int width = pad_percents.get(*state);
+  if (use_spacer.get(*state) != NO_SPACER) {
+    width = std::max(width, 3);
+  }
+  return spaced_print(buf, size, "%u", width, value);
 }
 
 /* converts from bytes to human readable format (K, M, G, T)


### PR DESCRIPTION
## Summary
- `percent_print` now pads to at least 3 columns when `use_spacer` is `left`/`right`, so `${cpu}` aligns like other spaced sensors.
- Corrects `pad_percents` docs: it is a field width, not a decimal precision.

Fixes #2078

## Test plan
- [ ] Config with `use_spacer = left` and `${cpu}` / `${memperc}` — single-digit values should be left-padded to width 3
- [ ] `use_spacer = none` — no padding change
- [ ] Optional: `pad_percents = 4` with spacer enabled — width becomes 4