### PR TITLE
hwmon/i2c/platform: properly handle power entries

### DIFF
--- a/doc/variables.yaml
+++ b/doc/variables.yaml
@@ -813,12 +813,13 @@ values:
       name is `k10temp`.
       3. Omitted. Then the first hwmon device (hwmon0) will be used.
 
-      Parameter type is either `in` or `vol` meaning voltage; `fan` meaning fan;
-      `temp` meaning temperature. Parameter n is number of the sensor. See
-      `/sys/class/hwmon/` on your local computer.  The optional arguments `factor`
-      and `offset` allow precalculation of the raw input, which is being modified
-      as follows: `input = input * factor + offset`. Note that they have to be
-      given as decimal values (i.e. contain at least one decimal place).
+      Parameter type is either `in` or `vol` meaning voltage; `power` meaning
+      power; `fan` meaning fan; `temp` meaning temperature. Parameter n is
+      number of the sensor. See `/sys/class/hwmon/` on your local computer.
+      The optional arguments `factor` and `offset` allow precalculation of the
+      raw input, which is being modified as follows:
+      `input = input * factor + offset`. Note that they have to be given as
+      decimal values (i.e. contain at least one decimal place).
     args:
       - (dev)
       - type
@@ -845,12 +846,12 @@ values:
     desc: |-
       I2C sensor from sysfs (Linux 2.6). Parameter dev may be omitted if you have
       only one I2C device. Parameter type is either `in` or `vol` meaning voltage;
-      `fan` meaning fan; `temp` meaning temperature. Parameter n is number of the
-      sensor. See `/sys/bus/i2c/devices/` on your local computer. The optional
-      arguments `factor` and `offset` allow precalculation of the raw input, which
-      is being modified as follows: `input = input * factor + offset`. Note that
-      they have to be given as decimal values (i.e. contain at least one decimal
-      place).
+      `power` meaning power; `fan` meaning fan; `temp` meaning temperature.
+      Parameter n is number of the sensor. See `/sys/bus/i2c/devices/` on your
+      local computer. The optional arguments `factor` and `offset` allow
+      precalculation of the raw input, which is being modified as follows:
+      `input = input * factor + offset`. Note that they have to be given as
+      decimal values (i.e. contain at least one decimal place).
     args:
       - (dev)
       - type
@@ -1877,12 +1878,13 @@ values:
     desc: |-
       Platform sensor from sysfs (Linux 2.6). Parameter dev may be omitted if you
       have only one platform device. Platform type is either `in` or `vol` meaning
-      voltage; `fan` meaning fan; `temp` meaning temperature. Parameter n is
-      number of the sensor. See `/sys/bus/platform/devices/` on your local
-      computer. The optional arguments `factor` and `offset` allow precalculation
-      of the raw input, which is being modified as follows: `input = input *
-      factor + offset`. Note that they have to be given as decimal values (i.e.
-      contain at least one decimal place).
+      voltage; `power` meaning power; `fan` meaning fan; `temp` meaning
+      temperature. Parameter n is number of the sensor. See
+      `/sys/bus/platform/devices/` on your local computer. The optional
+      arguments `factor` and `offset` allow precalculation of the raw input,
+      which is being modified as follows: `input = input * factor + offset`.
+      Note that they have to be given as decimal values (i.e. contain at least
+      one decimal place).
     args:
       - (dev)
       - type

--- a/src/data/os/linux.cc
+++ b/src/data/os/linux.cc
@@ -1346,6 +1346,9 @@ static int open_sysfs_sensor(const char *dir, const char *dev, const char *type,
   if (strcmp(type, "in") == 0 || strcmp(type, "temp") == 0 ||
       strcmp(type, "tempf") == 0) {
     *divisor = 1;
+  } else if (strcmp(type, "power") == 0) {
+    /* power unit is microwatts */
+    *divisor = 1000000;
   } else {
     *divisor = 0;
   }
@@ -1430,7 +1433,7 @@ static double get_sysfs_info(int *fd, int divisor, char *devtype, char *type) {
     }
   } else {
     if (divisor > 1) {
-      return val / divisor;
+      return val / static_cast<double>(divisor);
     } else if (divisor) {
       return val / 1000.0;
     } else {
@@ -1492,7 +1495,8 @@ static void parse_sysfs_sensor(struct text_object *obj, const char *arg,
 static bool is_sysfs_sensor_type(const char *type) {
   return strcmp(type, "fan") == 0 || strcmp(type, "in") == 0 ||
          strcmp(type, "temp") == 0 || strcmp(type, "temp2") == 0 ||
-         strcmp(type, "tempf") == 0 || strcmp(type, "vol") == 0;
+         strcmp(type, "tempf") == 0 || strcmp(type, "vol") == 0 ||
+         strcmp(type, "power") == 0;
 }
 
 static const char *scan_sysfs_bar(struct text_object *obj, const char *arg) {
@@ -1535,6 +1539,10 @@ void print_sysfs_sensor(struct text_object *obj, char *p,
     temp_print(p, p_max_size, r, TEMP_CELSIUS, 0);
   } else if (!strncmp(sf->type, "temp", 4)) {
     temp_print(p, p_max_size, r, TEMP_CELSIUS, 1);
+  } else if (!strncmp(sf->type, "power", 5)) {
+    /* power values will always be treated as integers, since a CPU TDP, for
+     * example, can go over 100W */
+    snprintf(p, p_max_size, "%.0f", r);
   } else if (r >= 100.0 || r == 0) {
     snprintf(p, p_max_size, "%d", (int)r);
   } else {


### PR DESCRIPTION
## Description

New Linux kernels are starting to show more power entries inside /sys/class/hwmon, and on my computer for example, I can now see the CPU power consummation, which makes a nice target for an hwmon variable use.

"Unfortunately", the powerX_input unit is microwatts, which does not really fit a CPU (or GPU) TDP, and this PR addresses exactly this particular issue:
- Automatically convert microwatts to watts
- Always print power values as integer, since it can go above 100W on high-end hardware

I have successfully checked the modifications on my local machine, using both hwmon and hwmonbar (with a scale factor).